### PR TITLE
Codegen: support model extraction

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -149,6 +149,7 @@ public final class Configuration {
 
     public static final boolean codeGen = propIsSet("codeGen");
     public static final boolean testCodeGen = propIsSet("testCodeGen");
+    public static final String cxxCompiler = getStringProp("cxxCompiler", null);
 
     public static final String souffleInclude = System.getProperty("souffleInclude");
     public static final String boostInclude = System.getProperty("boostInclude");

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGen.java
@@ -75,6 +75,8 @@ public class CodeGen {
         copySrc("smt_solver.cpp");
         copySrc("smt_shim.h");
         new SmtShimCpp(ctx).gen(outDir);
+        copySrc("smt_parser.hpp");
+        new SmtParserCpp(ctx).gen(outDir);
         copySrc("Type.hpp");
         new TypeCpp(ctx).gen(outDir);
         copySrc("Term.hpp");

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/FuncsHpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/FuncsHpp.java
@@ -272,6 +272,12 @@ public class FuncsHpp extends TemplateSrcFile {
                 case IS_VALID:
                     ctx.register(sym, "is_valid");
                     break;
+                case GET_MODEL:
+                    ctx.register(sym, "get_model");
+                    break;
+                case QUERY_MODEL:
+                    ctx.register(sym, "query_model");
+                    break;
                 case PRINT:
                     ctx.register(sym, "print");
                     break;

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
@@ -89,6 +89,11 @@ public class SmtParserCpp extends TemplateSrcFile {
             for (ConstructorSymbol sym : trackedSmtVars) {
                 genParseFunc(getSmtVarType(sym));
             }
+            // Forward-declare functions to account for mutually recursive data types.
+            for (String name : parseFuncDefs.keySet()) {
+                out.println("struct " + name + ";");
+            }
+            out.println();
             for (Map.Entry<String, CppStmt> e : parseFuncDefs.entrySet()) {
                 out.println("struct " + e.getKey() + " {");
                 out.println("  term_ptr operator()(SmtLibTokenizer &t) {");

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
@@ -1,0 +1,162 @@
+package edu.harvard.seas.pl.formulog.codegen;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppBinop;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppConst;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppDecl;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppExpr;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppExprFromString;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppFuncCall;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppIf;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppMethodCall;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppReturn;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppSeq;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppStmt;
+import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppVar;
+import edu.harvard.seas.pl.formulog.smt.SmtLibParser;
+import edu.harvard.seas.pl.formulog.smt.SmtLibParser.SmtLibParseException;
+import edu.harvard.seas.pl.formulog.symbols.ConstructorSymbol;
+import edu.harvard.seas.pl.formulog.symbols.parameterized.BuiltInConstructorSymbolBase;
+import edu.harvard.seas.pl.formulog.symbols.parameterized.ParameterizedConstructorSymbol;
+import edu.harvard.seas.pl.formulog.types.BuiltInTypes;
+import edu.harvard.seas.pl.formulog.types.Types.AlgebraicDataType;
+import edu.harvard.seas.pl.formulog.types.Types.AlgebraicDataType.ConstructorScheme;
+import edu.harvard.seas.pl.formulog.types.Types.Type;
+import edu.harvard.seas.pl.formulog.util.Pair;
+
+public class SmtParserCpp extends TemplateSrcFile {
+
+    public SmtParserCpp(CodeGenContext ctx) {
+        super("smt_parser.cpp", ctx);
+    }
+
+    @Override
+    void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException {
+        Worker w = new Worker(out);
+        CodeGenUtil.copyOver(br, out, 0);
+        w.outputShouldRecord();
+        CodeGenUtil.copyOver(br, out, 1);
+        w.outputParseFuncs();
+        CodeGenUtil.copyOver(br, out, 2);
+        w.outputParseTerm();
+        CodeGenUtil.copyOver(br, out, -1);
+    }
+
+    private class Worker {
+
+        private final PrintWriter out;
+        private final Set<ConstructorSymbol> trackedSmtVars = new HashSet<>();
+        private final Map<Type, String> parseFuncs = new HashMap<>();
+        private final Map<String, CppStmt> parseFuncDefs = new HashMap<>();
+
+        public Worker(PrintWriter out) {
+            this.out = out;
+            parseFuncs.put(BuiltInTypes.string, "parse_string");
+            parseFuncs.put(BuiltInTypes.i32, "parse_i32");
+            parseFuncs.put(BuiltInTypes.i64, "parse_i64");
+            parseFuncs.put(BuiltInTypes.fp32, "parse_fp32");
+            parseFuncs.put(BuiltInTypes.fp64, "parse_fp64");
+            parseFuncs.put(BuiltInTypes.bool, "parse_bool");
+
+        }
+
+        private void outputShouldRecord() throws CodeGenException {
+            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+                var ty = getSmtVarType(sym);
+                if (ty != null) {
+                    try {
+                        if (SmtLibParser.shouldRecord(ty)) {
+                            out.printf("    case %s: return true;\n", ctx.lookupRepr(sym));
+                            trackedSmtVars.add(sym);
+                        }
+                    } catch (SmtLibParseException e) {
+                        throw new CodeGenException(e);
+                    }
+                }
+            }
+        }
+
+        private void outputParseFuncs() {
+            for (ConstructorSymbol sym : trackedSmtVars) {
+                genParseFunc(getSmtVarType(sym));
+            }
+            for (Map.Entry<String, CppStmt> e : parseFuncDefs.entrySet()) {
+                out.println("struct " + e.getKey() + " {");
+                out.println("  term_ptr operator()(SmtLibTokenizer &t) {");
+                e.getValue().println(out, 2);
+                out.println("  }\n};\n");
+            }
+        }
+
+        private String genParseFunc(AlgebraicDataType ty) {
+            String name = parseFuncs.get(ty);
+            if (name != null) {
+                return name;
+            }
+            name = "parse_" + ctx.newId(CodeGenUtil.mkName(ty.getSymbol()));
+            var wrapped_name = "parse_adt<" + name + ">";
+            parseFuncs.put(ty, wrapped_name);
+
+            List<CppStmt> body = new ArrayList<>();
+            String scrutinee = "x";
+            body.add(CppDecl.mk(scrutinee, CppMethodCall.mk(CppVar.mk("t"), "next")));
+
+            List<Pair<CppExpr, CppStmt>> cases = new ArrayList<>();
+            for (var cs : ty.getConstructors()) {
+                cases.add(genConstructorCase(CppVar.mk(scrutinee), cs));
+            }
+            body.add(CppIf.mk(cases));
+
+            body.add(CppExprFromString.mk("abort()").toStmt());
+            parseFuncDefs.put(name, CppSeq.mk(body));
+            return wrapped_name;
+        }
+
+        private Pair<CppExpr, CppStmt> genConstructorCase(CppExpr scrutinee, ConstructorScheme cs) {
+            ConstructorSymbol sym = cs.getSymbol();
+            var check = CppBinop.mkEq(scrutinee, CppConst.mkString(sym.toString()));
+            List<CppExpr> args = new ArrayList<>();
+            List<CppStmt> stmts = new ArrayList<>();
+            int i = 0;
+            for (var ty : cs.getTypeArgs()) {
+                String arg = "a" + i;
+                CppStmt decl = CppDecl.mk(arg, CppFuncCall.mk(genParseFunc((AlgebraicDataType) ty), CppVar.mk("t")));
+                stmts.add(decl);
+                args.add(CppVar.mk(arg));
+                i++;
+            }
+            CppExpr term = CppFuncCall.mk("Term::make<" + ctx.lookupRepr(sym) + ">", args); 
+            stmts.add(CppReturn.mk(term));
+            return new Pair<>(check, CppSeq.mk(stmts));
+        }
+
+        private void outputParseTerm() {
+            for (ConstructorSymbol sym : trackedSmtVars) {
+                var ty = getSmtVarType(sym);
+                var func = parseFuncs.get(ty);
+                out.printf("    case %s: return %s(t);\n", ctx.lookupRepr(sym), func);
+            }
+        }
+
+        private AlgebraicDataType getSmtVarType(ConstructorSymbol sym) {
+            if (sym instanceof ParameterizedConstructorSymbol) {
+                var base = ((ParameterizedConstructorSymbol) sym).getBase();
+                if (base.equals(BuiltInConstructorSymbolBase.SMT_VAR)) {
+                    return SmtLibParser.stripSymType((AlgebraicDataType) sym.getCompileTimeType().getRetType());
+                }
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
@@ -108,7 +108,7 @@ public class SmtParserCpp extends TemplateSrcFile {
 
             List<CppStmt> body = new ArrayList<>();
             String scrutinee = "x";
-            body.add(CppDecl.mk(scrutinee, CppMethodCall.mk(CppVar.mk("t"), "next")));
+            body.add(CppDecl.mk(scrutinee, CppFuncCall.mk("parse_identifier", CppVar.mk("t"))));
 
             List<Pair<CppExpr, CppStmt>> cases = new ArrayList<>();
             for (var cs : ty.getConstructors()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtShimCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtShimCpp.java
@@ -330,6 +330,14 @@ public class SmtShimCpp extends TemplateSrcFile {
                 case SMT_PAT:
                 case SMT_WRAP_VAR:
                     return CppFuncCall.mk("abort").toStmt();
+                case BV_TO_INT:
+                    return genSerializeOp("bv2int");
+                case INT_TO_BV: {
+                    int width = index(sym, 0);
+                    String func = "serialize_int2bv<" + width + ">";
+                    return mkCall(func);
+                }
+                    
             }
             return null;
         }

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
@@ -112,7 +112,6 @@ public class SmtLibParser {
         SolverVariable x = variables.get(id);
         if (x != null) {
             FunctorType ft = (FunctorType) x.getSymbol().getCompileTimeType();
-            System.out.println(x.getSymbol() + " " + ft);
             AlgebraicDataType type = (AlgebraicDataType) ft.getRetType();
             type = stripSymType(type);
 
@@ -414,7 +413,6 @@ public class SmtLibParser {
             args = new Term[argTypes.size()];
             int i = 0;
             for (Type ty : argTypes) {
-                System.out.println("arg type " + ty);
                 Term arg = parseTerm(t, (AlgebraicDataType) ty);
                 args[i] = arg;
                 ++i;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
@@ -112,6 +112,7 @@ public class SmtLibParser {
         SolverVariable x = variables.get(id);
         if (x != null) {
             FunctorType ft = (FunctorType) x.getSymbol().getCompileTimeType();
+            System.out.println(x.getSymbol() + " " + ft);
             AlgebraicDataType type = (AlgebraicDataType) ft.getRetType();
             type = stripSymType(type);
 
@@ -126,12 +127,12 @@ public class SmtLibParser {
         BV32, BV64, FP32, FP64, STRING, ADT
     }
 
-    private AlgebraicDataType stripSymType(AlgebraicDataType symType) {
+    public static AlgebraicDataType stripSymType(AlgebraicDataType symType) {
         assert symType.getSymbol().equals(BuiltInTypeSymbol.SYM_TYPE);
         return (AlgebraicDataType) symType.getTypeArgs().get(0);
     }
 
-    private boolean shouldRecord(AlgebraicDataType type) throws SmtLibParseException {
+    public static boolean shouldRecord(AlgebraicDataType type) throws SmtLibParseException {
         Set<Symbol> seen = new HashSet<>();
         boolean ok = shouldRecord1(type, seen);
         for (Type arg : type.getTypeArgs()) {
@@ -146,7 +147,7 @@ public class SmtLibParser {
         throw new SmtLibParseException("INTERNAL ERROR: " + msg);
     }
 
-    private boolean shouldRecord1(AlgebraicDataType type, Set<Symbol> seen) throws SmtLibParseException {
+    private static boolean shouldRecord1(AlgebraicDataType type, Set<Symbol> seen) throws SmtLibParseException {
         TypeSymbol sym = type.getSymbol();
         if (!seen.add(sym)) {
             return true;
@@ -413,6 +414,7 @@ public class SmtLibParser {
             args = new Term[argTypes.size()];
             int i = 0;
             for (Type ty : argTypes) {
+                System.out.println("arg type " + ty);
                 Term arg = parseTerm(t, (AlgebraicDataType) ty);
                 args[i] = arg;
                 ++i;

--- a/src/main/resources/codegen/CMakeLists.txt
+++ b/src/main/resources/codegen/CMakeLists.txt
@@ -31,7 +31,7 @@ target_sources(flg PRIVATE
         src/smt_shim.cpp
         src/smt_shim.h
         src/smt_parser.cpp
-        src/smt_parser.h
+        src/smt_parser.hpp
         formulog.cpp
         )
 

--- a/src/main/resources/codegen/CMakeLists.txt
+++ b/src/main/resources/codegen/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(flg PRIVATE
         src/smt_solver.h
         src/smt_shim.cpp
         src/smt_shim.h
+        src/smt_parser.cpp
+        src/smt_parser.h
         formulog.cpp
         )
 

--- a/src/main/resources/codegen/src/Symbol.cpp
+++ b/src/main/resources/codegen/src/Symbol.cpp
@@ -10,6 +10,7 @@ ostream& operator<<(ostream& out, Symbol sym) {
     case Symbol::boxed_fp32: return out << "boxed_fp32";
     case Symbol::boxed_fp64: return out << "boxed_fp64";
     case Symbol::boxed_string: return out << "boxed_string";
+    case Symbol::model: return out << "model";
 /* INSERT 0 */
   }
   __builtin_unreachable();

--- a/src/main/resources/codegen/src/Symbol.hpp
+++ b/src/main/resources/codegen/src/Symbol.hpp
@@ -16,6 +16,7 @@ enum class Symbol {
     boxed_fp32,
     boxed_fp64,
     boxed_string,
+    model,
 #ifdef FLG_DEV
     nil,
     cons,

--- a/src/main/resources/codegen/src/Term.hpp
+++ b/src/main/resources/codegen/src/Term.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <vector>
 
+#include <boost/container_hash/hash.hpp>
 #include <souffle/SouffleInterface.h>
 #include <tbb/concurrent_unordered_map.h>
 
@@ -154,7 +155,7 @@ inline const term_ptr max_term =
 // Concurrency-safe cache for BaseTerm values
 template<typename T, Symbol S>
 class BaseTermCache {
-    typedef concurrent_unordered_map<T, term_ptr> map_t;
+    typedef concurrent_unordered_map<T, term_ptr, boost::hash<T>> map_t;
     inline static map_t cache;
 
 public:
@@ -217,6 +218,13 @@ inline term_ptr Term::make<double>(double val) {
 template<>
 inline term_ptr Term::make<string>(string val) {
     return BaseTermCache<string, Symbol::boxed_string>::get(val);
+}
+
+typedef std::map<term_ptr, term_ptr> Model;
+
+template<>
+inline term_ptr Term::make<Model>(Model val) {
+    return BaseTermCache<Model, Symbol::model>::get(val);
 }
 
 template<typename T>

--- a/src/main/resources/codegen/src/Type.cpp
+++ b/src/main/resources/codegen/src/Type.cpp
@@ -72,6 +72,7 @@ functor_type Type::i64 = make_prim("_ BitVec", {make_index("64")});
 functor_type Type::fp32 = make_prim("_ FloatingPoint", {make_index("8"), make_index("24")});
 functor_type Type::fp64 = make_prim("_ FloatingPoint", {make_index("11"), make_index("53")});
 functor_type Type::string_ = make_prim("String");
+functor_type Type::model = make_prim("Model");
 
 atomic_size_t Type::cnt;
 
@@ -93,6 +94,8 @@ functor_type Type::lookup(Symbol sym) {
             return fp64;
         case Symbol::boxed_string:
             return string_;
+        case Symbol::model:
+            return model;
 /* INSERT 0 */
     }
     __builtin_unreachable();

--- a/src/main/resources/codegen/src/Type.hpp
+++ b/src/main/resources/codegen/src/Type.hpp
@@ -29,6 +29,7 @@ struct Type {
     static functor_type fp64;
     static functor_type string_;
     static functor_type bool_;
+    static functor_type model;
 
 private:
     static functor_type make_prim(const std::string &name);

--- a/src/main/resources/codegen/src/funcs.hpp
+++ b/src/main/resources/codegen/src/funcs.hpp
@@ -329,6 +329,14 @@ term_ptr is_sat_opt(term_ptr t1, term_ptr t2) {
     __builtin_unreachable();
 }
 
+term_ptr get_model(term_ptr t1, term_ptr t2) {
+    return nullptr;
+}
+
+term_ptr query_model(term_ptr t1, term_ptr t2) {
+    return nullptr;
+}
+
 std::vector<souffle::RamDomain> make_int_key(std::vector<term_ptr> key) {
     unsigned arity = key.size();
     std::vector<souffle::RamDomain> intKey(arity);

--- a/src/main/resources/codegen/src/funcs.hpp
+++ b/src/main/resources/codegen/src/funcs.hpp
@@ -272,12 +272,12 @@ term_ptr __conv(term_ptr t1) {
 }
 
 term_ptr is_sat(term_ptr t1) {
-    switch (smt::smt_solver.check(t1)) {
-        case smt::SmtResult::sat:
+    switch (smt::smt_solver.check(t1).status) {
+        case smt::SmtStatus::sat:
             return Term::make<bool>(true);
-        case smt::SmtResult::unsat:
+        case smt::SmtStatus::unsat:
             return Term::make<bool>(false);
-        case smt::SmtResult::unknown:
+        case smt::SmtStatus::unknown:
             throw runtime_error("SMT returned `unknown`");
     }
     __builtin_unreachable();
@@ -292,12 +292,12 @@ term_ptr _make_smt_not(term_ptr t) {
 }
 
 term_ptr is_valid(term_ptr t1) {
-    switch (smt::smt_solver.check(_make_smt_not(t1))) {
-        case smt::SmtResult::sat:
+    switch (smt::smt_solver.check(_make_smt_not(t1)).status) {
+        case smt::SmtStatus::sat:
             return Term::make<bool>(false);
-        case smt::SmtResult::unsat:
+        case smt::SmtStatus::unsat:
             return Term::make<bool>(true);
-        case smt::SmtResult::unknown:
+        case smt::SmtStatus::unknown:
             abort();
     }
     __builtin_unreachable();
@@ -318,23 +318,39 @@ term_ptr is_sat_opt(term_ptr t1, term_ptr t2) {
     int timeout = _extract_timeout_from_option(t2);
     auto assertions = Term::vectorize_list_term(t1);
     std::reverse(assertions.begin(), assertions.end());
-    switch (smt::smt_solver.check(assertions, false, timeout)) {
-        case smt::SmtResult::sat:
+    switch (smt::smt_solver.check(assertions, false, timeout).status) {
+        case smt::SmtStatus::sat:
             return _make_some(Term::make<bool>(true));
-        case smt::SmtResult::unsat:
+        case smt::SmtStatus::unsat:
             return _make_some(Term::make<bool>(false));
-        case smt::SmtResult::unknown:
+        case smt::SmtStatus::unknown:
             return _make_none();
     }
     __builtin_unreachable();
 }
 
 term_ptr get_model(term_ptr t1, term_ptr t2) {
-    return nullptr;
+    int timeout = _extract_timeout_from_option(t2);
+    auto assertions = Term::vectorize_list_term(t1);
+    std::reverse(assertions.begin(), assertions.end());
+    auto res = smt::smt_solver.check(assertions, true, timeout);
+    switch (res.status) {
+        case smt::SmtStatus::sat:
+            return _make_some(Term::make<Model>(res.model.value()));
+        case smt::SmtStatus::unsat:
+        case smt::SmtStatus::unknown:
+            return _make_none();
+    }
+    __builtin_unreachable();
 }
 
 term_ptr query_model(term_ptr t1, term_ptr t2) {
-    return nullptr;
+    Model m = t2->as_base<Model>().val;
+    auto it = m.find(t1);
+    if (it != m.end()) {
+        return _make_some(it->second);
+    }
+    return _make_none();
 }
 
 std::vector<souffle::RamDomain> make_int_key(std::vector<term_ptr> key) {

--- a/src/main/resources/codegen/src/smt_parser.cpp
+++ b/src/main/resources/codegen/src/smt_parser.cpp
@@ -2,10 +2,10 @@
 // Created by Aaron Bembenek on 1/23/23.
 //
 
-#include "smt_parser.h"
+#include "smt_parser.hpp"
 #include <sstream>
 
-void SmtTokenizer::load(bool allow_eof) {
+void SmtLibTokenizer::load(bool allow_eof) {
     if (m_next.has_value()) {
         return;
     }
@@ -29,26 +29,26 @@ void SmtTokenizer::load(bool allow_eof) {
     m_next = std::move(s);
 }
 
-const std::string &SmtTokenizer::peek() {
+const std::string &SmtLibTokenizer::peek() {
     load(false);
     return *m_next;
 }
 
-std::string SmtTokenizer::next() {
+std::string SmtLibTokenizer::next() {
     load(false);
     std::string s = *std::move(m_next);
     m_next.reset();
     return s;
 }
 
-bool SmtTokenizer::has_next() {
+bool SmtLibTokenizer::has_next() {
     load(true);
     return m_next.has_value();
 }
 
-void SmtTokenizer::consume(const std::string &s) {
+void SmtLibTokenizer::consume(const std::string &s) {
     std::stringstream ss(s);
-    SmtTokenizer t(ss);
+    SmtLibTokenizer t(ss);
     while (t.has_next()) {
         std::string expected = t.next();
         std::string found = next();

--- a/src/main/resources/codegen/src/smt_parser.cpp
+++ b/src/main/resources/codegen/src/smt_parser.cpp
@@ -307,7 +307,7 @@ term_ptr parse_fp32(SmtLibTokenizer &t) {
 }
 
 term_ptr parse_fp64(SmtLibTokenizer &t) {
-    return parse_fp<float, 11, 53>(t);
+    return parse_fp<double, 11, 53>(t);
 }
 
 term_ptr parse_bool(SmtLibTokenizer &t) {

--- a/src/main/resources/codegen/src/smt_parser.cpp
+++ b/src/main/resources/codegen/src/smt_parser.cpp
@@ -5,12 +5,14 @@
 #include "smt_parser.hpp"
 #include <sstream>
 
+namespace flg {
+
 void SmtLibTokenizer::load(bool allow_eof) {
     if (m_next.has_value()) {
         return;
     }
     int ch;
-    while ((ch = m_is.get()) != std::char_traits<char>::eof() && m_ignore_whitespace && std::isspace(ch)) {
+    while (std::isspace(ch = m_is.get()) && m_ignore_whitespace) {
         // keep looping
     }
     if (ch == std::char_traits<char>::eof()) {
@@ -58,4 +60,154 @@ void SmtLibTokenizer::consume(const std::string &s) {
             throw std::runtime_error(msg.str());
         }
     }
+}
+
+SmtLibParser::Model SmtLibParser::get_model(std::istream &is) const {
+    SmtLibTokenizer t(is);
+    t.consume("(");
+    Model m;
+    while (true) {
+        const std::string &tok = t.peek();
+        if (tok == ")") {
+            break;
+        } else if (tok == ";") {
+            consume_comment(t);
+        } else {
+            parse_function_def(m, t);
+        }
+    }
+    t.consume(")");
+    t.ignore_whitespace(false);
+    // Remove EOL
+    t.next();
+    return m;
+}
+
+void SmtLibParser::consume_comment(SmtLibTokenizer &t) const {
+    t.consume(";;");
+    t.ignore_whitespace(false);
+    while (t.next() != "\n") {
+        // Keep cruising
+    }
+    t.ignore_whitespace(true);
+}
+
+void SmtLibParser::parse_function_def(Model &m, SmtLibTokenizer &t) const {
+    t.consume("(");
+    auto tok = t.peek();
+    if (tok == "forall" || tok == "declare") {
+        skip_rest_of_s_exp(t);
+        return;
+    }
+    t.consume("define-fun");
+    std::string id = parse_identifier(t);
+
+    // Ignore args
+    t.consume("(");
+    skip_rest_of_s_exp(t);
+
+    // Ignore type
+    parse_type(t);
+
+    auto it = m_vars.find(id);
+    if (it != m_vars.end()) {
+        term_ptr x = it->second;
+        if (should_record(x->sym)) {
+            m.emplace(x, parse_term(t, x->sym));
+        }
+    }
+    skip_rest_of_s_exp(t);
+}
+
+void SmtLibParser::skip_rest_of_s_exp(SmtLibTokenizer &t) const {
+    unsigned depth = 1;
+    while (depth > 0) {
+        const std::string &tok = t.peek();
+        if (tok == "(") {
+            t.consume(tok);
+            depth++;
+        } else if (tok == ")") {
+            t.consume(tok);
+            depth--;
+        } else if (tok == "\"") {
+            parse_string_raw(t);
+        } else if (tok == "|") {
+            parse_identifier(t);
+        }
+    }
+}
+
+std::string SmtLibParser::parse_string_raw(SmtLibTokenizer &t) const {
+    t.consume("\"");
+    t.ignore_whitespace(false);
+    std::string s;
+    while (true) {
+        std::string tok = t.next();
+        if (tok == "\"") {
+            // SMT-LIB uses "" to represent the character "
+            if (t.peek() != "\"") {
+                break;
+            }
+            t.consume(tok);
+        }
+        s += tok;
+    }
+    t.ignore_whitespace(true);
+    return s;
+}
+
+std::string SmtLibParser::parse_identifier(SmtLibTokenizer &t) const {
+    std::string s = t.next();
+    if (s == "|") {
+        t.ignore_whitespace(false);
+        while (t.peek() != "|") {
+            s += t.next();
+        }
+        t.ignore_whitespace(true);
+    } else {
+        while (true) {
+            const std::string &tok = t.peek();
+            if (is_ident_char(tok[0])) {
+                t.consume(tok);
+                s += tok;
+            } else {
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+bool SmtLibParser::is_ident_char(int ch) {
+    if (std::isalnum(ch)) {
+        return true;
+    }
+    switch (ch) {
+        case '~':
+        case '!':
+        case '@':
+        case '%':
+        case '^':
+        case '&':
+        case '*':
+        case '_':
+        case '-':
+        case '+':
+        case '=':
+        case '<':
+        case '>':
+        case '.':
+        case '?':
+        case '/':
+            return true;
+    }
+    return false;
+}
+
+void SmtLibParser::parse_type(SmtLibTokenizer &t) const {
+    if (t.next() == "(") {
+        skip_rest_of_s_exp(t);
+    }
+}
+
 }

--- a/src/main/resources/codegen/src/smt_parser.cpp
+++ b/src/main/resources/codegen/src/smt_parser.cpp
@@ -136,6 +136,16 @@ std::string parse_string_raw(SmtLibTokenizer &t) {
                 break;
             }
             t.consume(tok);
+        } else if (tok == "\\" && t.peek() == "u") {
+            // Handle unicode (in a hacky way). Not sure if we also need to account for the backslash being escaped.
+            t.consume("u");
+            t.consume("{");
+            std::string val;
+            while ((tok = t.next()) != "}") {
+                val += tok;
+            }
+            s.push_back((char) std::stoi(val, nullptr, 16));
+            continue;
         }
         s += tok;
     }

--- a/src/main/resources/codegen/src/smt_parser.cpp
+++ b/src/main/resources/codegen/src/smt_parser.cpp
@@ -1,0 +1,61 @@
+//
+// Created by Aaron Bembenek on 1/23/23.
+//
+
+#include "smt_parser.h"
+#include <sstream>
+
+void SmtTokenizer::load(bool allow_eof) {
+    if (m_next.has_value()) {
+        return;
+    }
+    int ch;
+    while ((ch = m_is.get()) != std::char_traits<char>::eof() && m_ignore_whitespace && std::isspace(ch)) {
+        // keep looping
+    }
+    if (ch == std::char_traits<char>::eof()) {
+        if (!allow_eof) {
+            throw std::runtime_error("SMT-LIB tokenization error: unexpected EOF");
+        }
+    }
+    std::string s;
+    s.push_back((char) ch);
+    if (is_word_char(ch)) {
+        while ((ch = m_is.peek()) != std::char_traits<char>::eof() && is_word_char(ch)) {
+            s.push_back((char) ch);
+            m_is.get();
+        }
+    }
+    m_next = std::move(s);
+}
+
+const std::string &SmtTokenizer::peek() {
+    load(false);
+    return *m_next;
+}
+
+std::string SmtTokenizer::next() {
+    load(false);
+    std::string s = *std::move(m_next);
+    m_next.reset();
+    return s;
+}
+
+bool SmtTokenizer::has_next() {
+    load(true);
+    return m_next.has_value();
+}
+
+void SmtTokenizer::consume(const std::string &s) {
+    std::stringstream ss(s);
+    SmtTokenizer t(ss);
+    while (t.has_next()) {
+        std::string expected = t.next();
+        std::string found = next();
+        if (expected != found) {
+            std::stringstream msg;
+            msg << "SMT-LIB tokenization error: tried to consume \"" << expected << "\" but found \"" << found << "\"";
+            throw std::runtime_error(msg.str());
+        }
+    }
+}

--- a/src/main/resources/codegen/src/smt_parser.h
+++ b/src/main/resources/codegen/src/smt_parser.h
@@ -1,0 +1,39 @@
+//
+// Created by Aaron Bembenek on 1/23/23.
+//
+
+#ifndef CODEGEN_SMT_PARSER_H
+#define CODEGEN_SMT_PARSER_H
+
+#include <istream>
+#include <optional>
+
+class SmtTokenizer {
+public:
+    explicit SmtTokenizer(std::istream &is) : m_is(is) {}
+
+    void ignore_whitespace(bool ignore) {
+        m_ignore_whitespace = ignore;
+    }
+
+    const std::string &peek();
+
+    std::string next();
+
+    bool has_next();
+
+    void consume(const std::string &s);
+
+private:
+    std::istream &m_is;
+    bool m_ignore_whitespace{true};
+    std::optional<std::string> m_next{};
+
+    void load(bool allow_eof);
+
+    static bool is_word_char(int ch) {
+        return ch == '_' || std::isalnum(ch);
+    }
+};
+
+#endif //CODEGEN_SMT_PARSER_H

--- a/src/main/resources/codegen/src/smt_parser.hpp
+++ b/src/main/resources/codegen/src/smt_parser.hpp
@@ -43,7 +43,6 @@ class SmtLibParser {
 public:
     explicit SmtLibParser(std::unordered_map<std::string, term_ptr> &vars) : m_vars(vars) {}
 
-    typedef std::unordered_map<term_ptr, term_ptr> Model;
     Model get_model(std::istream &is) const;
 
 private:

--- a/src/main/resources/codegen/src/smt_parser.hpp
+++ b/src/main/resources/codegen/src/smt_parser.hpp
@@ -53,15 +53,11 @@ private:
 
     void parse_function_def(Model &m, SmtLibTokenizer &t) const;
 
-    void skip_rest_of_s_exp(SmtLibTokenizer &t) const;
-
-    std::string parse_string_raw(SmtLibTokenizer &t) const;
-
-    std::string parse_identifier(SmtLibTokenizer &t) const;
-
     void parse_type(SmtLibTokenizer &t) const;
 
-    static bool is_ident_char(int ch);
+    bool should_record(Symbol sym) const;
+
+    term_ptr parse_term(SmtLibTokenizer &t, Symbol sym) const;
 };
 
 }

--- a/src/main/resources/codegen/src/smt_parser.hpp
+++ b/src/main/resources/codegen/src/smt_parser.hpp
@@ -19,6 +19,10 @@ public:
         m_ignore_whitespace = ignore;
     }
 
+    bool ignoring_whitespace() {
+        return m_ignore_whitespace;
+    }
+
     const std::string &peek();
 
     std::string next();

--- a/src/main/resources/codegen/src/smt_parser.hpp
+++ b/src/main/resources/codegen/src/smt_parser.hpp
@@ -2,15 +2,15 @@
 // Created by Aaron Bembenek on 1/23/23.
 //
 
-#ifndef CODEGEN_SMT_PARSER_H
-#define CODEGEN_SMT_PARSER_H
+#ifndef CODEGEN_SMT_PARSER_HPP
+#define CODEGEN_SMT_PARSER_HPP
 
 #include <istream>
 #include <optional>
 
-class SmtTokenizer {
+class SmtLibTokenizer {
 public:
-    explicit SmtTokenizer(std::istream &is) : m_is(is) {}
+    explicit SmtLibTokenizer(std::istream &is) : m_is(is) {}
 
     void ignore_whitespace(bool ignore) {
         m_ignore_whitespace = ignore;
@@ -36,4 +36,4 @@ private:
     }
 };
 
-#endif //CODEGEN_SMT_PARSER_H
+#endif //CODEGEN_SMT_PARSER_HPP

--- a/src/main/resources/codegen/src/smt_parser.hpp
+++ b/src/main/resources/codegen/src/smt_parser.hpp
@@ -7,6 +7,9 @@
 
 #include <istream>
 #include <optional>
+#include "Term.hpp"
+
+namespace flg {
 
 class SmtLibTokenizer {
 public:
@@ -35,5 +38,32 @@ private:
         return ch == '_' || std::isalnum(ch);
     }
 };
+
+class SmtLibParser {
+public:
+    explicit SmtLibParser(std::unordered_map<std::string, term_ptr> &vars) : m_vars(vars) {}
+
+    typedef std::unordered_map<term_ptr, term_ptr> Model;
+    Model get_model(std::istream &is) const;
+
+private:
+    const std::unordered_map<std::string, term_ptr> &m_vars;
+
+    void consume_comment(SmtLibTokenizer &t) const;
+
+    void parse_function_def(Model &m, SmtLibTokenizer &t) const;
+
+    void skip_rest_of_s_exp(SmtLibTokenizer &t) const;
+
+    std::string parse_string_raw(SmtLibTokenizer &t) const;
+
+    std::string parse_identifier(SmtLibTokenizer &t) const;
+
+    void parse_type(SmtLibTokenizer &t) const;
+
+    static bool is_ident_char(int ch);
+};
+
+}
 
 #endif //CODEGEN_SMT_PARSER_HPP

--- a/src/main/resources/codegen/src/smt_shim.cpp
+++ b/src/main/resources/codegen/src/smt_shim.cpp
@@ -351,6 +351,13 @@ void SmtLibShim::serialize_int(term_ptr t) {
     m_in << arg0(t)->as_base<T>().val;
 }
 
+template<size_t W>
+void SmtLibShim::serialize_int2bv(term_ptr t) {
+    m_in << "((_ int2bv " << W << ") ";
+    serialize(arg0(t));
+    m_in << ")";
+}
+
 template<bool Exists>
 void SmtLibShim::serialize_quantifier(term_ptr t) {
     auto &x = t->as_complex();

--- a/src/main/resources/codegen/src/smt_shim.cpp
+++ b/src/main/resources/codegen/src/smt_shim.cpp
@@ -6,6 +6,7 @@
 #include "smt_parser.hpp"
 #include <bitset>
 #include <boost/format.hpp>
+#include <regex>
 
 namespace flg::smt {
 
@@ -217,7 +218,7 @@ void SmtLibShim::serialize(term_ptr t) {
     switch (t->sym) {
         case Symbol::boxed_bool:
         case Symbol::boxed_string: {
-            m_in << *t;
+            m_in << "\"" << std::regex_replace(t->as_base<std::string>().val, std::regex("\""), "\"\"") << "\"";
             break;
         }
         case Symbol::boxed_i32: {

--- a/src/main/resources/codegen/src/smt_shim.cpp
+++ b/src/main/resources/codegen/src/smt_shim.cpp
@@ -216,7 +216,10 @@ Model SmtLibShim::get_model() {
 
 void SmtLibShim::serialize(term_ptr t) {
     switch (t->sym) {
-        case Symbol::boxed_bool:
+        case Symbol::boxed_bool: {
+            m_in << *t;
+            break;
+        }
         case Symbol::boxed_string: {
             m_in << "\"" << std::regex_replace(t->as_base<std::string>().val, std::regex("\""), "\"\"") << "\"";
             break;

--- a/src/main/resources/codegen/src/smt_shim.h
+++ b/src/main/resources/codegen/src/smt_shim.h
@@ -12,7 +12,7 @@
 
 namespace flg::smt {
 
-enum class SmtResult {
+enum class SmtStatus {
     sat, unsat, unknown
 };
 
@@ -32,8 +32,10 @@ public:
 
     void pop() { pop(1); }
 
-    virtual SmtResult
+    virtual SmtStatus
     check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int timeout) = 0;
+
+    virtual Model get_model() = 0;
 
     virtual ~SmtShim() = default;
 };
@@ -52,8 +54,10 @@ public:
 
     void pop(unsigned int n) override;
 
-    SmtResult
+    SmtStatus
     check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int timeout) override;
+
+    Model get_model() override;
 
 private:
     class Logger {
@@ -66,7 +70,7 @@ private:
             /*
             std::cerr << val;
             std::cerr.flush();
-             */
+            */
             return *this;
         }
 
@@ -74,7 +78,7 @@ private:
             m_in.flush();
             /*
             std::cerr.flush();
-             */
+            */
         }
 
     private:
@@ -86,6 +90,7 @@ private:
     boost::process::ipstream m_out;
 
     std::unordered_map<term_ptr, string> m_solver_vars;
+    std::unordered_map<string, term_ptr> m_solver_var_lookup;
     std::vector<term_ptr> m_solver_vars_in_order;
     std::vector<unsigned int> m_stack_positions;
     unsigned int m_cnt{0};

--- a/src/main/resources/codegen/src/smt_shim.h
+++ b/src/main/resources/codegen/src/smt_shim.h
@@ -152,6 +152,8 @@ private:
 
     std::string serialize_tester(Symbol sym);
 
+    template<size_t W>
+    void serialize_int2bv(term_ptr t);
 };
 
 }

--- a/src/main/resources/codegen/src/smt_solver.h
+++ b/src/main/resources/codegen/src/smt_solver.h
@@ -16,6 +16,11 @@ enum class SmtSolverMode {
     push_pop_naive, push_pop, check_sat_assuming
 };
 
+struct SmtResult {
+    SmtStatus status;
+    std::optional<Model> model;
+};
+
 class SmtSolver {
 public:
     NO_COPY_OR_ASSIGN(SmtSolver);

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
@@ -37,7 +37,7 @@ public class CompiledSemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNa
 	public CompiledSemiNaiveEvaluationTest() {
 		super(Configuration.testCodeGen ? new CompiledSemiNaiveTester() : new NopTester<>());
 	}
-	
+
 	@Override
 	public void test061() {
 		// Ignoring test (substitute)
@@ -54,113 +54,8 @@ public class CompiledSemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNa
 	}
 
 	@Override
-	public void test099() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test100() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test102() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test103() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test104() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test105() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test106() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test107() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test108() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test109() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test110() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test111() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test112() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test113() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test114() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test115() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test116() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
 	public void test128() {
 		// Ignoring test (is_free)
-	}
-	
-	@Override
-	public void test135() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test137() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test190() {
-		// Ignoring test (get_model)
-	}
-	
-	@Override
-	public void test254() {
-		// Ignoring test (get_model)
 	}
 	
 	@Override

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
@@ -107,5 +107,25 @@ public class CompiledSemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNa
 	public void test305() {
 		// Ignoring test (is_sats)
 	}
+	
+	@Override
+	public void test326() {
+		// Ignoring test (opaque_set_empty)
+	}
+	
+	@Override
+	public void test328() {
+		// Ignoring test (opaque_set_from_list)
+	}
+	
+	@Override
+	public void test336() {
+		// Ignoring test (i32_shl)
+	}
+	
+	@Override
+	public void test337() {
+		// Ignoring test (i64_urem)
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveTester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveTester.java
@@ -26,9 +26,11 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import edu.harvard.seas.pl.formulog.Configuration;
 import edu.harvard.seas.pl.formulog.Main;
 import edu.harvard.seas.pl.formulog.ast.BasicProgram;
 import edu.harvard.seas.pl.formulog.eval.Tester;
@@ -87,10 +89,12 @@ public class CompiledSemiNaiveTester implements Tester {
         Path buildPath = topPath.resolve("build");
         CodeGen cg = new CodeGen(prog, topPath.toFile());
         cg.go();
-        Process cmake = Runtime.getRuntime().exec(new String[]{"cmake", "-B", buildPath.toString(),
-                "-S", topPath.toString(), "-DCMAKE_BUILD_TYPE=Debug",
-                "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"});
-        //"-DCMAKE_CXX_COMPILER=/usr/local/opt/gcc@11/bin/g++-11"
+        var cmakeCmds = new ArrayList<>(Arrays.asList("cmake", "-B", buildPath.toString(), "-S", topPath.toString(),
+                "-DCMAKE_BUILD_TYPE=Debug"));
+        if (Configuration.cxxCompiler != null) {
+            cmakeCmds.add("-DCMAKE_CXX_COMPILER=" + Configuration.cxxCompiler);
+        }
+        Process cmake = Runtime.getRuntime().exec(cmakeCmds.toArray(new String[0]));
         if (cmake.waitFor() != 0) {
             System.err.println("Could not cmake test");
             printToStdErr(cmake.getErrorStream());


### PR DESCRIPTION
- Add Souffle/C++ codegen support for `get_model` and `query_model` via a C++ version of SMT-LIB parser
- Slightly fix up Java version of SMT-LIB parser