### PR TITLE
Delete codegen test directories

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -148,6 +148,7 @@ public final class Configuration {
             "stratification_graphs");
 
     public static final boolean testCodegen = propIsSet("testCodegen");
+    public static final boolean keepCodegenTestDirs = propIsSet("keepCodegenTestDirs");
     public static final String cxxCompiler = getStringProp("cxxCompiler", null);
 
     public static final String souffleInclude = System.getProperty("souffleInclude");


### PR DESCRIPTION
By default, delete directories created when running the codegen tests. These can use a bit of disk space (probably mainly a problem when running on Docker). They can be retained by using the system property `-DkeepCodegenTestDirs`.