### PR TITLE
Bump version returned by `-V` flag.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Main.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Main.java
@@ -50,7 +50,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.*;
 import picocli.CommandLine.Model;
 
-@Command(name = "formulog", mixinStandardHelpOptions = true, version = "Formulog 0.6.0", description = "Runs Formulog.")
+@Command(name = "formulog", mixinStandardHelpOptions = true, version = "Formulog 0.7.0", description = "Runs Formulog.")
 public final class Main implements Callable<Integer> {
 
     @Spec


### PR DESCRIPTION
The flag returns an out-of-date value; updated this from `0.6.0` to `0.7.0`.