### PR TITLE
Codegen: Fix Z3 process leak

### DIFF
--- a/src/main/resources/codegen/src/main.cpp
+++ b/src/main/resources/codegen/src/main.cpp
@@ -194,6 +194,7 @@ int main(int argc, char **argv) {
     loadEdbs(vm["fact-dir"].as<vector<string>>(), parallelism);
     globals::program->setNumThreads(parallelism);
     globals::program->run();
+    flg::smt::SmtLibShim::terminate_all_children();
     boost::filesystem::path out_dir(vm["out-dir"].as<string>());
     boost::filesystem::create_directories(out_dir);
     ExternalIdbPrinter idbPrinter(out_dir, parallelism);

--- a/src/main/resources/codegen/src/smt_shim.cpp
+++ b/src/main/resources/codegen/src/smt_shim.cpp
@@ -102,7 +102,9 @@ void MyTypeInferer::unify(const Type &ty1, const Type &ty2) {
 }
 
 SmtLibShim::SmtLibShim(boost::process::child &&proc, boost::process::opstream &&in, boost::process::ipstream &&out)
-        : m_proc{std::move(proc)}, m_in{std::move(in)}, m_out{std::move(out)} {}
+        : m_proc{std::move(proc)}, m_in{std::move(in)}, m_out{std::move(out)} {
+            s_shims[this] = true;
+        }
 
 void SmtLibShim::declare_vars(term_ptr t) {
     if (is_solver_var(t)) {

--- a/src/main/resources/codegen/src/smt_shim.h
+++ b/src/main/resources/codegen/src/smt_shim.h
@@ -7,6 +7,7 @@
 
 #include <unordered_set>
 #include <boost/process.hpp>
+#include <tbb/concurrent_unordered_map.h>
 #include "Term.hpp"
 #include "Type.hpp"
 
@@ -59,7 +60,21 @@ public:
 
     Model get_model() override;
 
+    static void terminate_all_children() {
+        for (auto p : s_shims) {
+            if (p.second) {
+                p.first->m_proc.terminate();
+            }
+        }
+    }
+
+    ~SmtLibShim() override {
+        s_shims[this] = false;
+    }
+
 private:
+    inline static tbb::concurrent_unordered_map<SmtLibShim *, bool> s_shims;
+
     class Logger {
     public:
         explicit Logger(boost::process::opstream &&in) : m_in{std::move(in)} {}


### PR DESCRIPTION
The C++ code we generate creates Z3 child processes. Unfortunately, the main process can end without terminating these children, leading to a resource leak. The problem seems to be we depend on destructors to terminate the children, but the destructors of OpenMP `threadprivate` variables are not guaranteed to be called (see [here](https://stackoverflow.com/questions/32374778/omp-threadprivate-objects-not-being-destructed)). In this PR, we track and terminate the children explicitly.