### PR TITLE
Codegen: sync process creation

### DIFF
--- a/src/main/resources/codegen/src/smt_shim.h
+++ b/src/main/resources/codegen/src/smt_shim.h
@@ -63,7 +63,6 @@ public:
     static void terminate_all_children() {
         for (auto p : s_shims) {
             if (p.second) {
-                p.first->m_in.close();
                 p.first->m_proc.terminate();
             }
         }

--- a/src/main/resources/codegen/src/smt_solver.cpp
+++ b/src/main/resources/codegen/src/smt_solver.cpp
@@ -30,9 +30,12 @@ TopLevelSmtSolver::TopLevelSmtSolver() {
 }
 
 std::unique_ptr<SmtShim> TopLevelSmtSolver::make_shim() {
+    namespace bp = boost::process;
+    // Force synchronization here to avoid some issues that come up with the
+    // `bp::child` constructor and pipes in a multithreaded setting. See
+    // <https://github.com/HarvardPL/formulog/issues/30>
     static std::mutex mtx;
     std::lock_guard<std::mutex> guard(mtx);
-    namespace bp = boost::process;
     bp::ipstream out;
     bp::opstream in;
     bp::child proc("z3 -in", bp::std_in < in, (bp::std_out & bp::std_err) > out);

--- a/src/main/resources/codegen/src/smt_solver.cpp
+++ b/src/main/resources/codegen/src/smt_solver.cpp
@@ -5,6 +5,8 @@
 #include "globals.h"
 #include "smt_solver.h"
 
+#include <mutex>
+
 namespace flg::smt {
 
 TopLevelSmtSolver::TopLevelSmtSolver() {
@@ -28,6 +30,8 @@ TopLevelSmtSolver::TopLevelSmtSolver() {
 }
 
 std::unique_ptr<SmtShim> TopLevelSmtSolver::make_shim() {
+    static std::mutex mtx;
+    std::lock_guard<std::mutex> guard(mtx);
     namespace bp = boost::process;
     bp::ipstream out;
     bp::opstream in;


### PR DESCRIPTION
Fixes #30 by explicitly synchronizing around `boost::process:child` creation.