### PR TITLE
Avoid push timing out

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
@@ -182,6 +182,8 @@ public class SmtLibShim {
 	}
 
 	public void push() throws EvaluationException {
+		// Avoid push timing out. See <https://github.com/Z3Prover/z3/issues/4713>
+		setTimeout(Integer.MAX_VALUE);
 		println("(push 1)");
 		checkSuccess();
 		symbolsByStackPos.addLast(new HashSet<>());
@@ -206,8 +208,7 @@ public class SmtLibShim {
 		return checkSatAssuming(Collections.emptyList(), Collections.emptyList(), timeout);
 	}
 
-	public SmtStatus checkSatAssuming(Collection<SolverVariable> onVars, Collection<SolverVariable> offVars,
-			int timeout) throws EvaluationException {
+	private void setTimeout(int timeout) throws EvaluationException {
 		if (timeout < 0) {
 			System.err.println("Warning: negative timeout provided to solver - ignored");
 			timeout = Integer.MAX_VALUE;
@@ -216,6 +217,11 @@ public class SmtLibShim {
 			println("(set-option :timeout " + timeout + ")");
 			checkSuccess();
 		}
+	}
+	
+	public SmtStatus checkSatAssuming(Collection<SolverVariable> onVars, Collection<SolverVariable> offVars,
+			int timeout) throws EvaluationException {
+		setTimeout(timeout);
 		if (onVars.isEmpty() && offVars.isEmpty()) {
 			println("(check-sat)");
 		} else {

--- a/src/main/resources/codegen/src/funcs.hpp
+++ b/src/main/resources/codegen/src/funcs.hpp
@@ -331,8 +331,8 @@ term_ptr is_valid(term_ptr t1) {
     __builtin_unreachable();
 }
 
-int _extract_timeout_from_option(term_ptr o) {
-    int timeout{numeric_limits<int>::max()};
+int32_t _extract_timeout_from_option(term_ptr o) {
+    int32_t timeout{numeric_limits<int32_t>::max()};
 #ifndef FLG_DEV
     if (o->sym == Symbol::some) {
         auto &x = o->as_complex();

--- a/src/main/resources/codegen/src/smt_shim.h
+++ b/src/main/resources/codegen/src/smt_shim.h
@@ -34,7 +34,7 @@ public:
     void pop() { pop(1); }
 
     virtual SmtStatus
-    check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int timeout) = 0;
+    check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int32_t timeout) = 0;
 
     virtual Model get_model() = 0;
 
@@ -56,7 +56,7 @@ public:
     void pop(unsigned int n) override;
 
     SmtStatus
-    check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int timeout) override;
+    check_sat_assuming(const std::vector<term_ptr> &onVars, const std::vector<term_ptr> &offVars, int32_t timeout) override;
 
     Model get_model() override;
 
@@ -113,6 +113,8 @@ private:
     std::vector<term_ptr> m_solver_vars_in_order;
     std::vector<unsigned int> m_stack_positions;
     std::deque<Type> m_annotations;
+
+    void set_timeout(int32_t timeout);
 
     Type next_annotation() {
         auto ty = m_annotations.front();

--- a/src/main/resources/codegen/src/smt_solver.h
+++ b/src/main/resources/codegen/src/smt_solver.h
@@ -27,7 +27,7 @@ public:
 
     SmtSolver() = default;
 
-    virtual SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int timeout) = 0;
+    virtual SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int32_t timeout) = 0;
 
     virtual ~SmtSolver() = default;
 };
@@ -38,7 +38,7 @@ public:
 
     TopLevelSmtSolver();
 
-    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int timeout) override;
+    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int32_t timeout) override;
 
     SmtResult check(term_ptr assertion);
 
@@ -54,7 +54,7 @@ public:
 
     explicit MemoizingSmtSolver(std::unique_ptr<SmtSolver> &&delegate);
 
-    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int timeout) override;
+    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int32_t timeout) override;
 
 private:
     std::unique_ptr<SmtSolver> m_delegate;
@@ -70,7 +70,7 @@ public:
 
     using term_vector_pair = std::pair<std::vector<term_ptr>, std::vector<term_ptr>>;
 
-    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int timeout) override;
+    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int32_t timeout) override;
 
 protected:
     virtual void initialize() = 0;
@@ -143,7 +143,7 @@ public:
     DoubleCheckingSolver(std::unique_ptr<SmtSolver> &&first, std::unique_ptr<SmtSolver> &&second) : m_first(
             std::move(first)), m_second(std::move(second)) {}
 
-    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int timeout) override;
+    SmtResult check(const std::vector<term_ptr> &assertions, bool get_model, int32_t timeout) override;
 
 private:
     std::unique_ptr<SmtSolver> m_first;


### PR DESCRIPTION
The SMT-LIB command `push` is subject to the same timeout as `check-sat`; however, if it times out, it leaves the solver in an unusable state. This PR resets the timeout to the max value before pushes. See <https://github.com/Z3Prover/z3/issues/4713>