### PR TITLE
Codegen: fix SMT memoization.

### DIFF
--- a/src/main/resources/codegen/src/smt_solver.h
+++ b/src/main/resources/codegen/src/smt_solver.h
@@ -59,7 +59,8 @@ public:
 private:
     std::unique_ptr<SmtSolver> m_delegate;
 
-    static inline tbb::concurrent_unordered_map<std::set<term_ptr>, SmtResult, boost::hash<std::set<term_ptr>>> s_memo;
+    typedef std::tuple<std::set<term_ptr>, bool, int32_t> memo_key_t;
+    static inline tbb::concurrent_unordered_map<memo_key_t, SmtResult, boost::hash<memo_key_t>> s_memo;
 };
 
 class AbstractSmtSolver : public SmtSolver {


### PR DESCRIPTION
Previously, when the generated code memoized SMT calls, it didn't take into account whether a model was requested or what the timeout was. This could lead to a crash (if we try to extract a model from the memoized result of a query that was previously discharged without getting a model) and strange behavior (i.e., the client cannot try a previously made query with a higher timeout). This PR fixes this through using richer keys for the memoization table.