### PR TITLE
Codegen: emit query plans.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenContext.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenContext.java
@@ -46,6 +46,7 @@ public class CodeGenContext {
     private final Map<String, Pair<Integer, SRuleMode>> customRelations = new HashMap<>();
     private final Map<Term, String> exprFunctorNames = new HashMap<>();
     private final Map<ConstructorSymbol, String> dtorFunctorNames = new HashMap<>();
+    private final Map<String, RelationSymbol> reprToRelSym = new HashMap<>();
 
     private final BasicProgram prog;
 
@@ -83,7 +84,13 @@ public class CodeGenContext {
     }
 
     public synchronized String lookupRepr(RelationSymbol sym) {
-        return sym.toString().replace(":", "__") + "_";
+        var repr = sym.toString().replace(":", "__") + "_";
+        reprToRelSym.put(repr, sym);
+        return repr;
+    }
+
+    public synchronized RelationSymbol lookupRel(String repr) {
+        return reprToRelSym.get(repr);
     }
 
     public synchronized void register(FunctionSymbol sym, String repr) {
@@ -124,7 +131,8 @@ public class CodeGenContext {
     }
 
     public Set<Pair<String, Pair<Integer, SRuleMode>>> getCustomRelations() {
-        return customRelations.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue())).collect(Collectors.toSet());
+        return customRelations.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue()))
+                .collect(Collectors.toSet());
     }
 
     public void registerCustomRelation(String name, Integer arity, SRuleMode mode) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/DeltaFirstQueryPlanner.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/DeltaFirstQueryPlanner.java
@@ -1,0 +1,85 @@
+package edu.harvard.seas.pl.formulog.codegen;
+
+/*-
+ * #%L
+ * Formulog
+ * %%
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import edu.harvard.seas.pl.formulog.codegen.ast.souffle.SAtom;
+import edu.harvard.seas.pl.formulog.codegen.ast.souffle.SRule;
+import edu.harvard.seas.pl.formulog.util.Pair;
+import edu.harvard.seas.pl.formulog.validating.Stratum;
+
+public class DeltaFirstQueryPlanner implements QueryPlanner {
+
+	private final CodeGenContext ctx;
+
+	public DeltaFirstQueryPlanner(CodeGenContext ctx) {
+		this.ctx = ctx;
+	}
+
+	@Override
+	public List<Pair<Integer, int[]>> genPlan(SRule r, Stratum stratum) {
+		List<Pair<Integer, int[]>> l = new ArrayList<>();
+		var p = findDeltas(r, stratum);
+		var numAtoms = p.fst();
+		int i = 0;
+		for (var deltaPos : p.snd()) {
+			l.add(new Pair<>(i++, genPlanForDelta(deltaPos, numAtoms)));
+		}
+		return l;
+	}
+
+	private Pair<Integer, List<Integer>> findDeltas(SRule r, Stratum stratum) {
+		List<Integer> l = new ArrayList<>();
+		var body = r.getBody();
+		var preds = stratum.getPredicateSyms();
+		int numAtoms = 0;
+		for (int i = 0; i < body.size(); ++i) {
+			var lit = body.get(i);
+			if (lit instanceof SAtom) {
+			    numAtoms++;
+				var pred = ((SAtom) lit).getSymbol();
+				var rel = ctx.lookupRel(pred);
+				if (rel != null && preds.contains(rel)) {
+					l.add(i + 1);
+				}
+			}
+		}
+		return new Pair<>(numAtoms, l);
+	}
+	
+	private int[] genPlanForDelta(int delta, int numAtoms) {
+		int[] arr = new int[numAtoms];
+		Arrays.setAll(arr, (i) -> {
+			if (i == 0) {
+				return delta;
+			} else if (i < delta) {
+				return i;
+			} else {
+				return i + 1;
+			}
+		});
+		return arr;
+	}
+
+}

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/NopQueryPlanner.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/NopQueryPlanner.java
@@ -1,0 +1,36 @@
+package edu.harvard.seas.pl.formulog.codegen;
+
+/*-
+ * #%L
+ * Formulog
+ * %%
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+import edu.harvard.seas.pl.formulog.codegen.ast.souffle.SRule;
+import edu.harvard.seas.pl.formulog.util.Pair;
+import edu.harvard.seas.pl.formulog.validating.Stratum;
+
+public class NopQueryPlanner implements QueryPlanner {
+
+	@Override
+	public List<Pair<Integer, int[]>> genPlan(SRule r, Stratum stratum) {
+		return null;
+	}
+
+}

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/QueryPlanner.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/QueryPlanner.java
@@ -1,0 +1,31 @@
+package edu.harvard.seas.pl.formulog.codegen;
+
+/*-
+ * #%L
+ * Formulog
+ * %%
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+import edu.harvard.seas.pl.formulog.codegen.ast.souffle.SRule;
+import edu.harvard.seas.pl.formulog.util.Pair;
+import edu.harvard.seas.pl.formulog.validating.Stratum;
+
+public interface QueryPlanner {
+	List<Pair<Integer, int[]>> genPlan(SRule r, Stratum stratum);
+}

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
@@ -28,10 +28,14 @@ public class SAtom implements SLit {
     private final List<STerm> args;
     private final boolean isNegated;
 
-    public SAtom(String symbol_, List<STerm> args_, boolean isNegated_) {
-        pred = symbol_;
-        args = args_;
-        isNegated = isNegated_;
+    public SAtom(String symbol, List<STerm> args, boolean isNegated) {
+        pred = symbol;
+        this.args = args;
+        this.isNegated = isNegated;
+    }
+
+    public String getSymbol() {
+        return pred;
     }
 
     @Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRule.java
@@ -21,12 +21,16 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class SRule {
 
     private final SLit head;
     private final List<SLit> body;
+    private List<Pair<Integer, int[]>> queryPlan;
 
     public SRule(SLit head, List<SLit> body) {
         this.head = head;
@@ -35,6 +39,14 @@ public class SRule {
 
     public SRule(SLit head, SLit... body) {
         this(head, Arrays.asList(body));
+    }
+
+    public List<SLit> getBody() {
+        return Collections.unmodifiableList(body);
+    }
+
+    public void setQueryPlan(List<Pair<Integer, int[]>> queryPlan) {
+        this.queryPlan = queryPlan;
     }
 
     @Override
@@ -56,6 +68,27 @@ public class SRule {
             }
         }
         sb.append(".");
+        if (queryPlan != null) {
+            sb.append("\n");
+            for (int i = 0; i < queryPlan.size(); ++i) {
+                if (i == 0) {
+                    sb.append(".plan ");
+                } else {
+                    sb.append(", ");
+                }
+                var p = queryPlan.get(i);
+                sb.append(p.fst());
+                sb.append(": (");
+                var plan = p.snd();
+                for (int j = 0; j < plan.length; ++j) {
+                    sb.append(plan[j]);
+                    if (j < plan.length - 1) {
+                        sb.append(",");
+                    }
+                }
+                sb.append(")");
+            }
+        }
         return sb.toString();
     }
 


### PR DESCRIPTION
Codegen can now emit "delta-first" query plans using Souffle's `.plan` directive.