### PR TITLE
Codegen: fix push-pop SMT solver.

### DIFF
--- a/src/main/resources/codegen/src/smt_solver.cpp
+++ b/src/main/resources/codegen/src/smt_solver.cpp
@@ -168,18 +168,15 @@ void PushPopSolver::initialize() {
 
 AbstractSmtSolver::term_vector_pair PushPopSolver::make_assertions(const std::vector<term_ptr> &assertions) {
     unsigned int pos = find_diff_pos(assertions);
-    shrink_cache(m_set.size() - pos);
-    assert(m_stack.size() == pos && m_set.size() == pos);
+    shrink_cache(m_stack.size() - pos);
+    assert(m_stack.size() == pos);
     assert(pos <= assertions.size());
     for (auto it = assertions.begin() + pos; it != assertions.end(); ++it) {
         auto elt = *it;
-        if (m_set.insert(elt).second) {
-            m_shim->push();
-            m_shim->make_assertion(elt);
-            m_stack.push_back(elt);
-        }
+        m_shim->push();
+        m_shim->make_assertion(elt);
+        m_stack.push_back(elt);
     }
-    assert(m_stack.size() == m_set.size());
     assert(m_stack.size() <= assertions.size());
     return {{},
             {}};
@@ -193,8 +190,7 @@ unsigned int PushPopSolver::find_diff_pos(const std::vector<term_ptr> &assertion
     unsigned int pos = 0;
     unsigned int end = std::min(m_stack.size(), assertions.size());
     while (pos < end) {
-        auto assertion = assertions[pos];
-        if (m_set.find(assertion) == m_set.end() && m_stack[pos] != assertion) {
+        if (m_stack[pos] != assertions[pos]) {
             break;
         }
         pos++;
@@ -205,7 +201,6 @@ unsigned int PushPopSolver::find_diff_pos(const std::vector<term_ptr> &assertion
 void PushPopSolver::shrink_cache(unsigned int num_to_pop) {
     m_shim->pop(num_to_pop);
     for (unsigned int i = 0; i < num_to_pop; ++i) {
-        m_set.erase(m_stack.back());
         m_stack.pop_back();
     }
 }

--- a/src/main/resources/codegen/src/smt_solver.h
+++ b/src/main/resources/codegen/src/smt_solver.h
@@ -125,7 +125,6 @@ public:
 
 private:
     std::vector<term_ptr> m_stack;
-    std::unordered_set<term_ptr> m_set;
 
     void initialize() override;
 


### PR DESCRIPTION
Fix a bug in codegen implementation of push-pop SMT solver, and make it act analogously to version in interpreter.