### PR TITLE
Reformat codebase using Eclipse style.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -41,505 +41,505 @@ import java.util.stream.Collectors;
 
 public final class Configuration {
 
-    private Configuration() {
-        throw new AssertionError("impossible");
-    }
-
-    public static final boolean runTests = propIsSet("runTests");
-    public static final String testFile = System.getProperty("testFile");
-
-    public static final boolean recordFuncDiagnostics = propIsSet("timeFuncs");
-    private static final Map<FunctionSymbol, AtomicLong> funcTimes = new ConcurrentHashMap<>();
-
-    public static final boolean recordRuleDiagnostics = propIsSet("timeRules");
-    private static final Map<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> ruleTimes = new ConcurrentHashMap<>();
-
-    public static final boolean debugSmt = propIsSet("debugSmt");
-    public static final String debugSmtOutDir = getStringProp("debugSmtOutDir", "solver_logs");
-
-    public static final boolean timeSmt = propIsSet("timeSmt");
-    public static final boolean smtMemoize = propIsSet("smtMemoize", true);
-    private static final Map<SmtLibSolver, Dataset> perProcessSmtEvalStats = new ConcurrentHashMap<>();
-    private static final Dataset smtEvalStats = new Dataset();
-    private static final AtomicLong smtDeclGlobalsTime = new AtomicLong();
-    private static final AtomicLong smtEncodeTime = new AtomicLong();
-    private static final AtomicLong smtDeclTime = new AtomicLong();
-    private static final AtomicLong smtInferTime = new AtomicLong();
-    private static final AtomicLong smtSerialTime = new AtomicLong();
-    private static final AtomicLong smtWaitTime = new AtomicLong();
-    private static final AtomicInteger smtNumCallsSat = new AtomicInteger();
-    private static final AtomicInteger smtNumCallsUnsat = new AtomicInteger();
-    private static final AtomicInteger smtNumCallsUnknown = new AtomicInteger();
-    private static final AtomicInteger smtNumCallsDoubleCheck = new AtomicInteger();
-    private static final AtomicInteger smtNumCallsFalseUnknown = new AtomicInteger();
-
-    // XXX I don't think this is being used any more
-    private static final AtomicLong smtTotalTime = new AtomicLong();
-
-    public static void recordSmtTime(long delta) {
-        smtTotalTime.addAndGet(delta);
-    }
-
-    public static long getSmtTotalTime() {
-        return smtTotalTime.get();
-    }
-
-    public static final boolean printRelSizes = propIsSet("printRelSizes");
-    public static final boolean printFinalRules = propIsSet("printFinalRules");
-    public static final boolean simplifyFormulaVars = propIsSet("simplifyFormulaVars", true);
-    public static final boolean debugRounds = propIsSet("debugRounds");
-    public static final boolean debugParallelism = propIsSet("debugParallelism");
-
-    public static final int optimizationSetting = getIntProp("optimize", 0);
-
-    public static final int taskSize = getIntProp("taskSize", 128);
-
-    public static final int smtTaskSize = getIntProp("smtTaskSize", 8);
-    public static final int smtCacheSize = getIntProp("smtCacheSize", 100);
-    public static final String smtSolver;
-
-    static {
-        smtSolver = getStringProp("smtSolver", "z3");
-        switch (smtSolver) {
-            case "z3":
-            case "cvc4":
-            case "yices":
-            case "boolector":
-                break;
-            default:
-                throw new IllegalArgumentException("Unrecognized solver: " + smtSolver);
-        }
-    }
-
-    public static final String smtLogic = getStringProp("smtLogic", "ALL");
-    public static final boolean smtDeclareAdts = propIsSet("smtDeclareAdts", true);
-    public static final boolean smtCacheHardResets = propIsSet("smtCacheHardResets", false);
-    public static final boolean smtUseNegativeLiterals = propIsSet("smtUseNegativeLiterals", false);
-    public static final boolean smtDoubleCheckUnknowns = propIsSet("smtDoubleCheckUnknowns", true);
-    public static final boolean smtUseSingleShotSolver = propIsSet("smtUseSingleShotSolver", false)
-            || smtSolver.equals("boolector");
-    public static final boolean smtCheckSuccess = propIsSet("smtCheckSuccess", false);
-
-    private static final Dataset pushPopStackSize = new Dataset();
-    private static final Dataset pushPopStackReuse = new Dataset();
-    private static final Dataset pushPopStackPushes = new Dataset();
-    private static final Dataset pushPopStackPops = new Dataset();
-    private static final Dataset pushPopStackDelta = new Dataset();
-    private static final Dataset csaCacheHitRate = new Dataset();
-    private static final Dataset csaCacheUseRate = new Dataset();
-    private static final Dataset csaCacheSize = new Dataset();
-    private static final Dataset csaCacheHits = new Dataset();
-    private static final Dataset csaCacheMisses = new Dataset();
-    private static final AtomicInteger csaCacheClears = new AtomicInteger();
-    private static final Dataset csaEvalStats = new Dataset();
-    private static final Dataset pushPopEvalStats = new Dataset();
-    private static final Dataset otherSolverEvalStats = new Dataset();
-
-    public static final boolean oneRuleAtATime = propIsSet("oneRuleAtATime");
-
-    public static final boolean useDemandTransformation = propIsSet("useDemandTransformation", true);
-    public static final boolean restoreStratification = propIsSet("restoreStratification", true);
-
-    public static final List<String> trackedRelations = getListProp("trackedRelations");
-
-    public static final boolean debugMst = propIsSet("debugMst");
-    public static final boolean debugStratification = propIsSet("debugStratification");
-    public static final String debugStratificationOutDir = getStringProp("debugStratificationOutDir",
-            "stratification_graphs");
-
-    public static final boolean testCodegen = propIsSet("testCodegen");
-    public static final boolean keepCodegenTestDirs = propIsSet("keepCodegenTestDirs");
-    public static final String cxxCompiler = getStringProp("cxxCompiler", null);
-
-    public static final String souffleInclude = System.getProperty("souffleInclude");
-    public static final String boostInclude = System.getProperty("boostInclude");
-    public static final String boostLib = System.getProperty("boostLib");
-    public static final String tbbInclude = System.getProperty("tbbInclude");
-    public static final String tbbLib = System.getProperty("tbbLib");
-    public static final String outputExec = System.getProperty("outputExec");
-
-    public static final int memoizeThreshold() {
-        return getIntProp("memoizeThreshold", 0);
-    }
-
-    public static final boolean genComparators = propIsSet("genComparators", true);
-    public static final boolean minIndex = propIsSet("minIndex", true);
-
-    public static final boolean inlineInRules = propIsSet("inlineInRules", true);
-
-    public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
-    
-    public static final boolean recordWork = propIsSet("recordWork");
-    public static final AtomicLong work = new AtomicLong();
-    
-    public static final AtomicLong smtCalls = new AtomicLong();
-    public static final AtomicLong smtTime = new AtomicLong();
-
-    static {
-        if (recordFuncDiagnostics) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-
-                @Override
-                public void run() {
-                    printFuncDiagnostics(System.err);
-                }
-
-            });
-        }
-        if (recordRuleDiagnostics) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-
-                @Override
-                public void run() {
-                    printRuleDiagnostics(System.err);
-                }
-
-            });
-        }
-        if (timeSmt) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-
-                @Override
-                public void run() {
-                    printSmtDiagnostics(System.err);
-                }
-
-            });
-        }
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-
-            @Override
-            public void run() {
-                printConfiguration(System.err);
-            }
-
-        });
-    }
-
-    public static synchronized void printConfiguration(PrintStream out) {
-        // out.println("[CONFIG] noResults=" + noResults);
-        // out.println("[CONFIG] timeRules=" + recordRuleDiagnostics);
-        // out.println("[CONFIG] timeFuncs=" + recordFuncDiagnostics);
-        // out.println("[CONFIG] timeSmt=" + timeSmt);
-        // out.println("[CONFIG] optimize=" + optimizationSetting);
-        // out.println("[CONFIG] taskSize=" + taskSize);
-        // out.println("[CONFIG] smtTaskSize=" + smtTaskSize);
-        // out.println("[CONFIG] memoizeThreshold=" + memoizeThreshold());
-        // out.println("[CONFIG] noModel=" + noModel());
-    }
-
-    public static void recordSmtDeclTime(long time) {
-        smtDeclTime.addAndGet(time);
-    }
-
-    public static void recordSmtInferTime(long time) {
-        smtInferTime.addAndGet(time);
-    }
-
-    public static void recordSmtSerialTime(long time) {
-        smtSerialTime.addAndGet(time);
-    }
-
-    public static void recordSmtEvalTime(SmtLibSolver solver, long encodeTime, long evalTime, SmtStatus result) {
-        smtEncodeTime.addAndGet(encodeTime);
-        smtEvalStats.addDataPoint(evalTime);
-        if (solver instanceof CheckSatAssumingSolver) {
-            csaEvalStats.addDataPoint(evalTime);
-        } else if (solver instanceof PushPopSolver) {
-            pushPopEvalStats.addDataPoint(evalTime);
-        } else {
-            otherSolverEvalStats.addDataPoint(evalTime);
-        }
-        Util.lookupOrCreate(perProcessSmtEvalStats, solver, () -> new Dataset()).addDataPoint(evalTime);
-        switch (result) {
-            case SATISFIABLE:
-                smtNumCallsSat.incrementAndGet();
-                break;
-            case UNKNOWN:
-                smtNumCallsUnknown.incrementAndGet();
-                break;
-            case UNSATISFIABLE:
-                smtNumCallsUnsat.incrementAndGet();
-                break;
-        }
-    }
-
-    public static void recordSmtWaitTime(long time) {
-        smtWaitTime.addAndGet(time);
-    }
-
-    public static void recordSmtDeclGlobalsTime(long time) {
-        smtDeclGlobalsTime.addAndGet(time);
-    }
-
-    public static synchronized void printSmtDiagnostics(PrintStream out) {
-        Dataset callsPerSolver = new Dataset();
-        Dataset timePerSolver = new Dataset();
-        for (Dataset ds : perProcessSmtEvalStats.values()) {
-            callsPerSolver.addDataPoint(ds.size());
-            timePerSolver.addDataPoint(ds.computeSum());
-        }
-        out.println("[SMT WAIT TIME] " + smtWaitTime.get() / 1e6 + "ms");
-        out.println("[SMT DECL GLOBALS TIME] " + smtDeclGlobalsTime.get() / 1e6 + "ms");
-        out.println("[SMT ENCODE TIME - TOTAL] " + smtEncodeTime.get() / 1e6 + "ms");
-        out.println("[SMT ENCODE TIME - DECL] " + smtDeclTime.get() / 1e6 + "ms");
-        out.println("[SMT ENCODE TIME - INFER] " + smtInferTime.get() / 1e6 + "ms");
-        out.println("[SMT ENCODE TIME - SERIAL] " + smtSerialTime.get() / 1e6 + "ms");
-        out.printf("[SMT EVAL TIME] %1.1fms%n", smtEvalStats.computeSum() / 1e6);
-        out.println("[SMT EVAL TIME PER CALL (ms)] " + smtEvalStats.getStatsString(1e-6));
-        out.println("[SMT EVAL TIME PER SOLVER (ms)] " + timePerSolver.getStatsString(1e-6));
-        out.println("[SMT NUM CALLS PER SOLVER] " + callsPerSolver.getStatsString());
-        out.println("[SMT NUM CALLS - SAT] " + smtNumCallsSat);
-        out.println("[SMT NUM CALLS - UNSAT] " + smtNumCallsUnsat);
-        out.println("[SMT NUM CALLS - UNKNOWN] " + smtNumCallsUnknown);
-        out.println("[SMT NUM CALLS - DOUBLE CHECK] " + smtNumCallsDoubleCheck);
-        out.println("[SMT NUM CALLS - FALSE UNKNOWN] " + smtNumCallsFalseUnknown);
-        if (csaEvalStats.size() > 0) {
-            out.println("--- CSA ---");
-            out.printf("[CSA EVAL TIME] %1.1fms%n", csaEvalStats.computeSum() / 1e6);
-            out.println("[CSA EVAL TIME PER CALL (ms)] " + csaEvalStats.getStatsString(1e-6));
-            out.println("[CSA CACHE LIMIT] " + smtCacheSize);
-            out.println("[CSA CACHE BASE SIZE] " + csaCacheSize.getStatsString());
-            out.println("[CSA CACHE HITS] " + csaCacheHits.getStatsString());
-            out.println("[CSA CACHE MISSES] " + csaCacheMisses.getStatsString());
-            out.println("[CSA CACHE HIT RATE] " + csaCacheHitRate.getStatsString());
-            out.println("[CSA CACHE USE RATE] " + csaCacheUseRate.getStatsString());
-            out.println("[CSA CACHE CLEARS] " + csaCacheClears.get());
-        }
-        if (pushPopEvalStats.size() > 0) {
-            out.println("--- PUSH POP ---");
-            out.printf("[PUSH POP EVAL TIME] %1.1fms%n", pushPopEvalStats.computeSum() / 1e6);
-            out.println("[PUSH POP EVAL TIME PER CALL (ms)] " + pushPopEvalStats.getStatsString(1e-6));
-            out.println("[PUSH POP STACK BASE SIZE] " + pushPopStackSize.getStatsString());
-            out.println("[PUSH POP STACK PUSHES] " + pushPopStackPushes.getStatsString());
-            out.println("[PUSH POP STACK POPS] " + pushPopStackPops.getStatsString());
-            out.println("[PUSH POP STACK DELTA] " + pushPopStackDelta.getStatsString());
-            out.println("[PUSH POP STACK REUSE] " + pushPopStackReuse.getStatsString());
-        }
-        if (otherSolverEvalStats.size() > 0) {
-            out.println("--- OTHER ---");
-            out.printf("[OTHER EVAL TIME] %1.1fms%n", otherSolverEvalStats.computeSum() / 1e6);
-            out.println("[OTHER EVAL TIME PER CALL (ms)] " + otherSolverEvalStats.getStatsString(1e-6));
-        }
-    }
-
-    public static void recordPushPopSolverStats(int solverId, int stackStartSize, int pops, int pushes) {
-        pushPopStackSize.addDataPoint(stackStartSize);
-        pushPopStackReuse.addDataPoint(stackStartSize - pops);
-        pushPopStackPops.addDataPoint(pops);
-        pushPopStackPushes.addDataPoint(pushes);
-        pushPopStackDelta.addDataPoint(pushes - pops);
-    }
-
-    public static void recordCsaCacheStats(int solverId, int hits, int misses, int oldSize) {
-        int numAsserts = hits + misses;
-        csaCacheHits.addDataPoint(hits);
-        csaCacheMisses.addDataPoint(misses);
-        csaCacheHitRate.addDataPoint(numAsserts == 0 ? 1 : (double) hits / numAsserts);
-        csaCacheUseRate.addDataPoint(oldSize == 0 ? 1 : (double) hits / oldSize);
-        csaCacheSize.addDataPoint(oldSize);
-    }
-
-    public static void recordSmtDoubleCheck(boolean falseUnknown) {
-        smtNumCallsDoubleCheck.incrementAndGet();
-        if (falseUnknown) {
-            smtNumCallsFalseUnknown.incrementAndGet();
-        }
-    }
-
-    public static void recordCsaCacheClear(int solverId) {
-        csaCacheClears.incrementAndGet();
-    }
-
-    public static void recordFuncTime(FunctionSymbol func, long time) {
-        AtomicLong l = Util.lookupOrCreate(funcTimes, func, () -> new AtomicLong());
-        l.addAndGet(time);
-    }
-
-    public static Map<FunctionSymbol, AtomicLong> getFuncDiagnostics() {
-        return Collections.unmodifiableMap(funcTimes);
-    }
-
-    public static synchronized void printFuncDiagnostics(PrintStream out) {
-        Map<FunctionSymbol, AtomicLong> times = Configuration.getFuncDiagnostics();
-        List<Map.Entry<FunctionSymbol, AtomicLong>> sorted = times.entrySet().stream().sorted(sortTimes)
-                .collect(Collectors.toList());
-        Iterator<Map.Entry<FunctionSymbol, AtomicLong>> it = sorted.iterator();
-        int end = Math.min(times.size(), 10);
-        for (int i = 0; i < end; ++i) {
-            Map.Entry<FunctionSymbol, AtomicLong> e = it.next();
-            out.println("[FUNC DIAGNOSTICS] " + e.getValue().get() + "ms: " + e.getKey());
-        }
-    }
-
-    private static final Comparator<Map.Entry<?, AtomicLong>> sortTimes = new Comparator<Map.Entry<?, AtomicLong>>() {
-
-        @Override
-        public int compare(Entry<?, AtomicLong> e1, Entry<?, AtomicLong> e2) {
-            return -Long.compare(e1.getValue().get(), e2.getValue().get());
-        }
-
-    };
-
-    private static final Comparator<Map.Entry<?, Pair<AtomicLong, AtomicLong>>> sortPairedTimes = new Comparator<Map.Entry<?, Pair<AtomicLong, AtomicLong>>>() {
-
-        @Override
-        public int compare(Entry<?, Pair<AtomicLong, AtomicLong>> e1, Entry<?, Pair<AtomicLong, AtomicLong>> e2) {
-            return -Long.compare(getTotal(e1), getTotal(e2));
-        }
-
-        private long getTotal(Entry<?, Pair<AtomicLong, AtomicLong>> e) {
-            Pair<AtomicLong, AtomicLong> p = e.getValue();
-            return p.fst().get() + p.snd().get();
-        }
-
-    };
-
-    public static void recordRulePrefixTime(Rule<?, ?> rule, long time) {
-        Pair<AtomicLong, AtomicLong> p = Util.lookupOrCreate(ruleTimes, rule,
-                () -> new Pair<>(new AtomicLong(), new AtomicLong()));
-        p.fst().addAndGet(time);
-    }
-
-    public static void recordRuleSuffixTime(Rule<?, ?> rule, long time) {
-        Pair<AtomicLong, AtomicLong> p = Util.lookupOrCreate(ruleTimes, rule,
-                () -> new Pair<>(new AtomicLong(), new AtomicLong()));
-        p.snd().addAndGet(time);
-    }
-
-    public static synchronized void printRuleDiagnostics(PrintStream out) {
-        Map<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> times = ruleTimes;
-        List<Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>>> sorted = times.entrySet().stream()
-                .sorted(sortPairedTimes).collect(Collectors.toList());
-        Iterator<Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>>> it = sorted.iterator();
-        int end = Math.min(times.size(), 10);
-        for (int i = 0; i < end; ++i) {
-            Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> e = it.next();
-            Pair<AtomicLong, AtomicLong> p = e.getValue();
-            long pre = p.fst().get();
-            long suf = p.snd().get();
-            long total = pre + suf;
-            out.println("[RULE DIAGNOSTICS] " + total + " (" + pre + " + " + suf + ") ms:\n" + e.getKey());
-        }
-    }
-
-    public static synchronized void printRelSizes(PrintStream out, String header, IndexedFactDb db,
-                                                  boolean printEmpty) {
-        for (RelationSymbol sym : db.getSymbols()) {
-            if (printEmpty || !db.isEmpty(sym)) {
-                out.println("[" + header + "] " + sym + ": " + db.countDistinct(sym) + " / " + db.numIndices(sym)
-                        + " / " + db.countDuplicates(sym));
-            }
-        }
-    }
-
-    private static boolean propIsSet(String prop, boolean defaultValue) {
-        String val = System.getProperty(prop);
-        if (val == null) {
-            return defaultValue;
-        }
-        if (val.equals("true") || val.equals("")) {
-            return true;
-        }
-        if (val.equals("false")) {
-            return false;
-        }
-        throw new IllegalArgumentException("Unexpected argument for property " + prop + ": " + val);
-    }
-
-    private static boolean propIsSet(String prop) {
-        return propIsSet(prop, false);
-    }
-
-    static int getIntProp(String prop, int def) {
-        String val = System.getProperty(prop);
-        if (val == null) {
-            return def;
-        }
-        try {
-            return Integer.parseInt(val);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Property " + prop + " expects an integer argument");
-        }
-    }
-
-    private static String getStringProp(String prop, String def) {
-        String val = System.getProperty(prop);
-        if (val == null) {
-            return def;
-        }
-        return val;
-    }
-
-    static List<String> getListProp(String prop) {
-        String val = System.getProperty(prop);
-        if (val == null || val.equals("")) {
-            return Collections.emptyList();
-        }
-        List<String> l = new ArrayList<>();
-        breakIntoCollection(val, l);
-        return Collections.unmodifiableList(l);
-    }
-
-    private static void breakIntoCollection(String s, Collection<String> acc) {
-        int split;
-        while ((split = s.indexOf(',')) != -1) {
-            String sub = s.substring(0, split);
-            acc.add(sub);
-            if (split == s.length()) {
-                return;
-            }
-            s = s.substring(split + 1);
-        }
-        acc.add(s);
-    }
-
-    static SmtStrategy getSmtStrategy() {
-        String val = System.getProperty("smtStrategy");
-        if (val == null) {
-            val = "queue-1";
-        }
-
-        switch (val) {
-            case "naive":
-                return new SmtStrategy(SmtStrategy.Tag.NAIVE, null);
-            case "pushPop":
-                return new SmtStrategy(SmtStrategy.Tag.PUSH_POP, null);
-            case "pushPopNaive":
-                return new SmtStrategy(SmtStrategy.Tag.PUSH_POP_NAIVE, null);
-            case "perThreadNaive":
-                return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_NAIVE, null);
-            case "perThreadPushPop":
-                return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP, null);
-            case "perThreadPushPopNaive":
-                return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP_NAIVE, null);
-        }
-
-        Pattern p = Pattern.compile("queue-(\\d+)");
-        Matcher m = p.matcher(val);
-        if (m.matches()) {
-            int size = Integer.parseInt(m.group(1));
-            return new SmtStrategy(SmtStrategy.Tag.QUEUE, size);
-        }
-        p = Pattern.compile("bestMatch-(\\d+)");
-        m = p.matcher(val);
-        if (m.matches()) {
-            int size = Integer.parseInt(m.group(1));
-            return new SmtStrategy(SmtStrategy.Tag.BEST_MATCH, size);
-        }
-        p = Pattern.compile("perThreadQueue-(\\d+)");
-        m = p.matcher(val);
-        if (m.matches()) {
-            int size = Integer.parseInt(m.group(1));
-            return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_QUEUE, size);
-        }
-        p = Pattern.compile("perThreadBestMatch-(\\d+)");
-        m = p.matcher(val);
-        if (m.matches()) {
-            int size = Integer.parseInt(m.group(1));
-            return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_BEST_MATCH, size);
-        }
-        throw new IllegalArgumentException("Unrecognized SMT strategy: " + val);
-    }
+	private Configuration() {
+		throw new AssertionError("impossible");
+	}
+
+	public static final boolean runTests = propIsSet("runTests");
+	public static final String testFile = System.getProperty("testFile");
+
+	public static final boolean recordFuncDiagnostics = propIsSet("timeFuncs");
+	private static final Map<FunctionSymbol, AtomicLong> funcTimes = new ConcurrentHashMap<>();
+
+	public static final boolean recordRuleDiagnostics = propIsSet("timeRules");
+	private static final Map<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> ruleTimes = new ConcurrentHashMap<>();
+
+	public static final boolean debugSmt = propIsSet("debugSmt");
+	public static final String debugSmtOutDir = getStringProp("debugSmtOutDir", "solver_logs");
+
+	public static final boolean timeSmt = propIsSet("timeSmt");
+	public static final boolean smtMemoize = propIsSet("smtMemoize", true);
+	private static final Map<SmtLibSolver, Dataset> perProcessSmtEvalStats = new ConcurrentHashMap<>();
+	private static final Dataset smtEvalStats = new Dataset();
+	private static final AtomicLong smtDeclGlobalsTime = new AtomicLong();
+	private static final AtomicLong smtEncodeTime = new AtomicLong();
+	private static final AtomicLong smtDeclTime = new AtomicLong();
+	private static final AtomicLong smtInferTime = new AtomicLong();
+	private static final AtomicLong smtSerialTime = new AtomicLong();
+	private static final AtomicLong smtWaitTime = new AtomicLong();
+	private static final AtomicInteger smtNumCallsSat = new AtomicInteger();
+	private static final AtomicInteger smtNumCallsUnsat = new AtomicInteger();
+	private static final AtomicInteger smtNumCallsUnknown = new AtomicInteger();
+	private static final AtomicInteger smtNumCallsDoubleCheck = new AtomicInteger();
+	private static final AtomicInteger smtNumCallsFalseUnknown = new AtomicInteger();
+
+	// XXX I don't think this is being used any more
+	private static final AtomicLong smtTotalTime = new AtomicLong();
+
+	public static void recordSmtTime(long delta) {
+		smtTotalTime.addAndGet(delta);
+	}
+
+	public static long getSmtTotalTime() {
+		return smtTotalTime.get();
+	}
+
+	public static final boolean printRelSizes = propIsSet("printRelSizes");
+	public static final boolean printFinalRules = propIsSet("printFinalRules");
+	public static final boolean simplifyFormulaVars = propIsSet("simplifyFormulaVars", true);
+	public static final boolean debugRounds = propIsSet("debugRounds");
+	public static final boolean debugParallelism = propIsSet("debugParallelism");
+
+	public static final int optimizationSetting = getIntProp("optimize", 0);
+
+	public static final int taskSize = getIntProp("taskSize", 128);
+
+	public static final int smtTaskSize = getIntProp("smtTaskSize", 8);
+	public static final int smtCacheSize = getIntProp("smtCacheSize", 100);
+	public static final String smtSolver;
+
+	static {
+		smtSolver = getStringProp("smtSolver", "z3");
+		switch (smtSolver) {
+		case "z3":
+		case "cvc4":
+		case "yices":
+		case "boolector":
+			break;
+		default:
+			throw new IllegalArgumentException("Unrecognized solver: " + smtSolver);
+		}
+	}
+
+	public static final String smtLogic = getStringProp("smtLogic", "ALL");
+	public static final boolean smtDeclareAdts = propIsSet("smtDeclareAdts", true);
+	public static final boolean smtCacheHardResets = propIsSet("smtCacheHardResets", false);
+	public static final boolean smtUseNegativeLiterals = propIsSet("smtUseNegativeLiterals", false);
+	public static final boolean smtDoubleCheckUnknowns = propIsSet("smtDoubleCheckUnknowns", true);
+	public static final boolean smtUseSingleShotSolver = propIsSet("smtUseSingleShotSolver", false)
+			|| smtSolver.equals("boolector");
+	public static final boolean smtCheckSuccess = propIsSet("smtCheckSuccess", false);
+
+	private static final Dataset pushPopStackSize = new Dataset();
+	private static final Dataset pushPopStackReuse = new Dataset();
+	private static final Dataset pushPopStackPushes = new Dataset();
+	private static final Dataset pushPopStackPops = new Dataset();
+	private static final Dataset pushPopStackDelta = new Dataset();
+	private static final Dataset csaCacheHitRate = new Dataset();
+	private static final Dataset csaCacheUseRate = new Dataset();
+	private static final Dataset csaCacheSize = new Dataset();
+	private static final Dataset csaCacheHits = new Dataset();
+	private static final Dataset csaCacheMisses = new Dataset();
+	private static final AtomicInteger csaCacheClears = new AtomicInteger();
+	private static final Dataset csaEvalStats = new Dataset();
+	private static final Dataset pushPopEvalStats = new Dataset();
+	private static final Dataset otherSolverEvalStats = new Dataset();
+
+	public static final boolean oneRuleAtATime = propIsSet("oneRuleAtATime");
+
+	public static final boolean useDemandTransformation = propIsSet("useDemandTransformation", true);
+	public static final boolean restoreStratification = propIsSet("restoreStratification", true);
+
+	public static final List<String> trackedRelations = getListProp("trackedRelations");
+
+	public static final boolean debugMst = propIsSet("debugMst");
+	public static final boolean debugStratification = propIsSet("debugStratification");
+	public static final String debugStratificationOutDir = getStringProp("debugStratificationOutDir",
+			"stratification_graphs");
+
+	public static final boolean testCodegen = propIsSet("testCodegen");
+	public static final boolean keepCodegenTestDirs = propIsSet("keepCodegenTestDirs");
+	public static final String cxxCompiler = getStringProp("cxxCompiler", null);
+
+	public static final String souffleInclude = System.getProperty("souffleInclude");
+	public static final String boostInclude = System.getProperty("boostInclude");
+	public static final String boostLib = System.getProperty("boostLib");
+	public static final String tbbInclude = System.getProperty("tbbInclude");
+	public static final String tbbLib = System.getProperty("tbbLib");
+	public static final String outputExec = System.getProperty("outputExec");
+
+	public static final int memoizeThreshold() {
+		return getIntProp("memoizeThreshold", 0);
+	}
+
+	public static final boolean genComparators = propIsSet("genComparators", true);
+	public static final boolean minIndex = propIsSet("minIndex", true);
+
+	public static final boolean inlineInRules = propIsSet("inlineInRules", true);
+
+	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
+
+	public static final boolean recordWork = propIsSet("recordWork");
+	public static final AtomicLong work = new AtomicLong();
+
+	public static final AtomicLong smtCalls = new AtomicLong();
+	public static final AtomicLong smtTime = new AtomicLong();
+
+	static {
+		if (recordFuncDiagnostics) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+
+				@Override
+				public void run() {
+					printFuncDiagnostics(System.err);
+				}
+
+			});
+		}
+		if (recordRuleDiagnostics) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+
+				@Override
+				public void run() {
+					printRuleDiagnostics(System.err);
+				}
+
+			});
+		}
+		if (timeSmt) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+
+				@Override
+				public void run() {
+					printSmtDiagnostics(System.err);
+				}
+
+			});
+		}
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+
+			@Override
+			public void run() {
+				printConfiguration(System.err);
+			}
+
+		});
+	}
+
+	public static synchronized void printConfiguration(PrintStream out) {
+		// out.println("[CONFIG] noResults=" + noResults);
+		// out.println("[CONFIG] timeRules=" + recordRuleDiagnostics);
+		// out.println("[CONFIG] timeFuncs=" + recordFuncDiagnostics);
+		// out.println("[CONFIG] timeSmt=" + timeSmt);
+		// out.println("[CONFIG] optimize=" + optimizationSetting);
+		// out.println("[CONFIG] taskSize=" + taskSize);
+		// out.println("[CONFIG] smtTaskSize=" + smtTaskSize);
+		// out.println("[CONFIG] memoizeThreshold=" + memoizeThreshold());
+		// out.println("[CONFIG] noModel=" + noModel());
+	}
+
+	public static void recordSmtDeclTime(long time) {
+		smtDeclTime.addAndGet(time);
+	}
+
+	public static void recordSmtInferTime(long time) {
+		smtInferTime.addAndGet(time);
+	}
+
+	public static void recordSmtSerialTime(long time) {
+		smtSerialTime.addAndGet(time);
+	}
+
+	public static void recordSmtEvalTime(SmtLibSolver solver, long encodeTime, long evalTime, SmtStatus result) {
+		smtEncodeTime.addAndGet(encodeTime);
+		smtEvalStats.addDataPoint(evalTime);
+		if (solver instanceof CheckSatAssumingSolver) {
+			csaEvalStats.addDataPoint(evalTime);
+		} else if (solver instanceof PushPopSolver) {
+			pushPopEvalStats.addDataPoint(evalTime);
+		} else {
+			otherSolverEvalStats.addDataPoint(evalTime);
+		}
+		Util.lookupOrCreate(perProcessSmtEvalStats, solver, () -> new Dataset()).addDataPoint(evalTime);
+		switch (result) {
+		case SATISFIABLE:
+			smtNumCallsSat.incrementAndGet();
+			break;
+		case UNKNOWN:
+			smtNumCallsUnknown.incrementAndGet();
+			break;
+		case UNSATISFIABLE:
+			smtNumCallsUnsat.incrementAndGet();
+			break;
+		}
+	}
+
+	public static void recordSmtWaitTime(long time) {
+		smtWaitTime.addAndGet(time);
+	}
+
+	public static void recordSmtDeclGlobalsTime(long time) {
+		smtDeclGlobalsTime.addAndGet(time);
+	}
+
+	public static synchronized void printSmtDiagnostics(PrintStream out) {
+		Dataset callsPerSolver = new Dataset();
+		Dataset timePerSolver = new Dataset();
+		for (Dataset ds : perProcessSmtEvalStats.values()) {
+			callsPerSolver.addDataPoint(ds.size());
+			timePerSolver.addDataPoint(ds.computeSum());
+		}
+		out.println("[SMT WAIT TIME] " + smtWaitTime.get() / 1e6 + "ms");
+		out.println("[SMT DECL GLOBALS TIME] " + smtDeclGlobalsTime.get() / 1e6 + "ms");
+		out.println("[SMT ENCODE TIME - TOTAL] " + smtEncodeTime.get() / 1e6 + "ms");
+		out.println("[SMT ENCODE TIME - DECL] " + smtDeclTime.get() / 1e6 + "ms");
+		out.println("[SMT ENCODE TIME - INFER] " + smtInferTime.get() / 1e6 + "ms");
+		out.println("[SMT ENCODE TIME - SERIAL] " + smtSerialTime.get() / 1e6 + "ms");
+		out.printf("[SMT EVAL TIME] %1.1fms%n", smtEvalStats.computeSum() / 1e6);
+		out.println("[SMT EVAL TIME PER CALL (ms)] " + smtEvalStats.getStatsString(1e-6));
+		out.println("[SMT EVAL TIME PER SOLVER (ms)] " + timePerSolver.getStatsString(1e-6));
+		out.println("[SMT NUM CALLS PER SOLVER] " + callsPerSolver.getStatsString());
+		out.println("[SMT NUM CALLS - SAT] " + smtNumCallsSat);
+		out.println("[SMT NUM CALLS - UNSAT] " + smtNumCallsUnsat);
+		out.println("[SMT NUM CALLS - UNKNOWN] " + smtNumCallsUnknown);
+		out.println("[SMT NUM CALLS - DOUBLE CHECK] " + smtNumCallsDoubleCheck);
+		out.println("[SMT NUM CALLS - FALSE UNKNOWN] " + smtNumCallsFalseUnknown);
+		if (csaEvalStats.size() > 0) {
+			out.println("--- CSA ---");
+			out.printf("[CSA EVAL TIME] %1.1fms%n", csaEvalStats.computeSum() / 1e6);
+			out.println("[CSA EVAL TIME PER CALL (ms)] " + csaEvalStats.getStatsString(1e-6));
+			out.println("[CSA CACHE LIMIT] " + smtCacheSize);
+			out.println("[CSA CACHE BASE SIZE] " + csaCacheSize.getStatsString());
+			out.println("[CSA CACHE HITS] " + csaCacheHits.getStatsString());
+			out.println("[CSA CACHE MISSES] " + csaCacheMisses.getStatsString());
+			out.println("[CSA CACHE HIT RATE] " + csaCacheHitRate.getStatsString());
+			out.println("[CSA CACHE USE RATE] " + csaCacheUseRate.getStatsString());
+			out.println("[CSA CACHE CLEARS] " + csaCacheClears.get());
+		}
+		if (pushPopEvalStats.size() > 0) {
+			out.println("--- PUSH POP ---");
+			out.printf("[PUSH POP EVAL TIME] %1.1fms%n", pushPopEvalStats.computeSum() / 1e6);
+			out.println("[PUSH POP EVAL TIME PER CALL (ms)] " + pushPopEvalStats.getStatsString(1e-6));
+			out.println("[PUSH POP STACK BASE SIZE] " + pushPopStackSize.getStatsString());
+			out.println("[PUSH POP STACK PUSHES] " + pushPopStackPushes.getStatsString());
+			out.println("[PUSH POP STACK POPS] " + pushPopStackPops.getStatsString());
+			out.println("[PUSH POP STACK DELTA] " + pushPopStackDelta.getStatsString());
+			out.println("[PUSH POP STACK REUSE] " + pushPopStackReuse.getStatsString());
+		}
+		if (otherSolverEvalStats.size() > 0) {
+			out.println("--- OTHER ---");
+			out.printf("[OTHER EVAL TIME] %1.1fms%n", otherSolverEvalStats.computeSum() / 1e6);
+			out.println("[OTHER EVAL TIME PER CALL (ms)] " + otherSolverEvalStats.getStatsString(1e-6));
+		}
+	}
+
+	public static void recordPushPopSolverStats(int solverId, int stackStartSize, int pops, int pushes) {
+		pushPopStackSize.addDataPoint(stackStartSize);
+		pushPopStackReuse.addDataPoint(stackStartSize - pops);
+		pushPopStackPops.addDataPoint(pops);
+		pushPopStackPushes.addDataPoint(pushes);
+		pushPopStackDelta.addDataPoint(pushes - pops);
+	}
+
+	public static void recordCsaCacheStats(int solverId, int hits, int misses, int oldSize) {
+		int numAsserts = hits + misses;
+		csaCacheHits.addDataPoint(hits);
+		csaCacheMisses.addDataPoint(misses);
+		csaCacheHitRate.addDataPoint(numAsserts == 0 ? 1 : (double) hits / numAsserts);
+		csaCacheUseRate.addDataPoint(oldSize == 0 ? 1 : (double) hits / oldSize);
+		csaCacheSize.addDataPoint(oldSize);
+	}
+
+	public static void recordSmtDoubleCheck(boolean falseUnknown) {
+		smtNumCallsDoubleCheck.incrementAndGet();
+		if (falseUnknown) {
+			smtNumCallsFalseUnknown.incrementAndGet();
+		}
+	}
+
+	public static void recordCsaCacheClear(int solverId) {
+		csaCacheClears.incrementAndGet();
+	}
+
+	public static void recordFuncTime(FunctionSymbol func, long time) {
+		AtomicLong l = Util.lookupOrCreate(funcTimes, func, () -> new AtomicLong());
+		l.addAndGet(time);
+	}
+
+	public static Map<FunctionSymbol, AtomicLong> getFuncDiagnostics() {
+		return Collections.unmodifiableMap(funcTimes);
+	}
+
+	public static synchronized void printFuncDiagnostics(PrintStream out) {
+		Map<FunctionSymbol, AtomicLong> times = Configuration.getFuncDiagnostics();
+		List<Map.Entry<FunctionSymbol, AtomicLong>> sorted = times.entrySet().stream().sorted(sortTimes)
+				.collect(Collectors.toList());
+		Iterator<Map.Entry<FunctionSymbol, AtomicLong>> it = sorted.iterator();
+		int end = Math.min(times.size(), 10);
+		for (int i = 0; i < end; ++i) {
+			Map.Entry<FunctionSymbol, AtomicLong> e = it.next();
+			out.println("[FUNC DIAGNOSTICS] " + e.getValue().get() + "ms: " + e.getKey());
+		}
+	}
+
+	private static final Comparator<Map.Entry<?, AtomicLong>> sortTimes = new Comparator<Map.Entry<?, AtomicLong>>() {
+
+		@Override
+		public int compare(Entry<?, AtomicLong> e1, Entry<?, AtomicLong> e2) {
+			return -Long.compare(e1.getValue().get(), e2.getValue().get());
+		}
+
+	};
+
+	private static final Comparator<Map.Entry<?, Pair<AtomicLong, AtomicLong>>> sortPairedTimes = new Comparator<Map.Entry<?, Pair<AtomicLong, AtomicLong>>>() {
+
+		@Override
+		public int compare(Entry<?, Pair<AtomicLong, AtomicLong>> e1, Entry<?, Pair<AtomicLong, AtomicLong>> e2) {
+			return -Long.compare(getTotal(e1), getTotal(e2));
+		}
+
+		private long getTotal(Entry<?, Pair<AtomicLong, AtomicLong>> e) {
+			Pair<AtomicLong, AtomicLong> p = e.getValue();
+			return p.fst().get() + p.snd().get();
+		}
+
+	};
+
+	public static void recordRulePrefixTime(Rule<?, ?> rule, long time) {
+		Pair<AtomicLong, AtomicLong> p = Util.lookupOrCreate(ruleTimes, rule,
+				() -> new Pair<>(new AtomicLong(), new AtomicLong()));
+		p.fst().addAndGet(time);
+	}
+
+	public static void recordRuleSuffixTime(Rule<?, ?> rule, long time) {
+		Pair<AtomicLong, AtomicLong> p = Util.lookupOrCreate(ruleTimes, rule,
+				() -> new Pair<>(new AtomicLong(), new AtomicLong()));
+		p.snd().addAndGet(time);
+	}
+
+	public static synchronized void printRuleDiagnostics(PrintStream out) {
+		Map<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> times = ruleTimes;
+		List<Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>>> sorted = times.entrySet().stream()
+				.sorted(sortPairedTimes).collect(Collectors.toList());
+		Iterator<Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>>> it = sorted.iterator();
+		int end = Math.min(times.size(), 10);
+		for (int i = 0; i < end; ++i) {
+			Map.Entry<Rule<?, ?>, Pair<AtomicLong, AtomicLong>> e = it.next();
+			Pair<AtomicLong, AtomicLong> p = e.getValue();
+			long pre = p.fst().get();
+			long suf = p.snd().get();
+			long total = pre + suf;
+			out.println("[RULE DIAGNOSTICS] " + total + " (" + pre + " + " + suf + ") ms:\n" + e.getKey());
+		}
+	}
+
+	public static synchronized void printRelSizes(PrintStream out, String header, IndexedFactDb db,
+			boolean printEmpty) {
+		for (RelationSymbol sym : db.getSymbols()) {
+			if (printEmpty || !db.isEmpty(sym)) {
+				out.println("[" + header + "] " + sym + ": " + db.countDistinct(sym) + " / " + db.numIndices(sym)
+						+ " / " + db.countDuplicates(sym));
+			}
+		}
+	}
+
+	private static boolean propIsSet(String prop, boolean defaultValue) {
+		String val = System.getProperty(prop);
+		if (val == null) {
+			return defaultValue;
+		}
+		if (val.equals("true") || val.equals("")) {
+			return true;
+		}
+		if (val.equals("false")) {
+			return false;
+		}
+		throw new IllegalArgumentException("Unexpected argument for property " + prop + ": " + val);
+	}
+
+	private static boolean propIsSet(String prop) {
+		return propIsSet(prop, false);
+	}
+
+	static int getIntProp(String prop, int def) {
+		String val = System.getProperty(prop);
+		if (val == null) {
+			return def;
+		}
+		try {
+			return Integer.parseInt(val);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Property " + prop + " expects an integer argument");
+		}
+	}
+
+	private static String getStringProp(String prop, String def) {
+		String val = System.getProperty(prop);
+		if (val == null) {
+			return def;
+		}
+		return val;
+	}
+
+	static List<String> getListProp(String prop) {
+		String val = System.getProperty(prop);
+		if (val == null || val.equals("")) {
+			return Collections.emptyList();
+		}
+		List<String> l = new ArrayList<>();
+		breakIntoCollection(val, l);
+		return Collections.unmodifiableList(l);
+	}
+
+	private static void breakIntoCollection(String s, Collection<String> acc) {
+		int split;
+		while ((split = s.indexOf(',')) != -1) {
+			String sub = s.substring(0, split);
+			acc.add(sub);
+			if (split == s.length()) {
+				return;
+			}
+			s = s.substring(split + 1);
+		}
+		acc.add(s);
+	}
+
+	static SmtStrategy getSmtStrategy() {
+		String val = System.getProperty("smtStrategy");
+		if (val == null) {
+			val = "queue-1";
+		}
+
+		switch (val) {
+		case "naive":
+			return new SmtStrategy(SmtStrategy.Tag.NAIVE, null);
+		case "pushPop":
+			return new SmtStrategy(SmtStrategy.Tag.PUSH_POP, null);
+		case "pushPopNaive":
+			return new SmtStrategy(SmtStrategy.Tag.PUSH_POP_NAIVE, null);
+		case "perThreadNaive":
+			return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_NAIVE, null);
+		case "perThreadPushPop":
+			return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP, null);
+		case "perThreadPushPopNaive":
+			return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP_NAIVE, null);
+		}
+
+		Pattern p = Pattern.compile("queue-(\\d+)");
+		Matcher m = p.matcher(val);
+		if (m.matches()) {
+			int size = Integer.parseInt(m.group(1));
+			return new SmtStrategy(SmtStrategy.Tag.QUEUE, size);
+		}
+		p = Pattern.compile("bestMatch-(\\d+)");
+		m = p.matcher(val);
+		if (m.matches()) {
+			int size = Integer.parseInt(m.group(1));
+			return new SmtStrategy(SmtStrategy.Tag.BEST_MATCH, size);
+		}
+		p = Pattern.compile("perThreadQueue-(\\d+)");
+		m = p.matcher(val);
+		if (m.matches()) {
+			int size = Integer.parseInt(m.group(1));
+			return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_QUEUE, size);
+		}
+		p = Pattern.compile("perThreadBestMatch-(\\d+)");
+		m = p.matcher(val);
+		if (m.matches()) {
+			int size = Integer.parseInt(m.group(1));
+			return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_BEST_MATCH, size);
+		}
+		throw new IllegalArgumentException("Unrecognized SMT strategy: " + val);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/FormulogTester.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/FormulogTester.java
@@ -63,259 +63,260 @@ import edu.harvard.seas.pl.formulog.validating.InvalidProgramException;
 
 public class FormulogTester {
 
-    private boolean initialized;
-    private final List<FormulogTest> tests = new ArrayList<>();
-    private WellTypedProgram prog;
+	private boolean initialized;
+	private final List<FormulogTest> tests = new ArrayList<>();
+	private WellTypedProgram prog;
 
-    public synchronized void setup(Reader program, File testFile) throws ParseException, TypeException, IOException {
-        Parser parser = new Parser();
-        prog = new TypeChecker(parser.parse(program)).typeCheck();
-        loadTests(testFile, parser);
-        initialized = true;
-    }
+	public synchronized void setup(Reader program, File testFile) throws ParseException, TypeException, IOException {
+		Parser parser = new Parser();
+		prog = new TypeChecker(parser.parse(program)).typeCheck();
+		loadTests(testFile, parser);
+		initialized = true;
+	}
 
-    private void loadTests(File testFile, Parser parser) throws IOException, ParseException {
-        tests.clear();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode topLevel = objectMapper.readValue(testFile, JsonNode.class);
-        Path rootTestDir = testFile.getParentFile().toPath();
-        for (JsonNode test : topLevel) {
-            tests.add(loadTest(test, rootTestDir, parser));
-        }
-    }
+	private void loadTests(File testFile, Parser parser) throws IOException, ParseException {
+		tests.clear();
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode topLevel = objectMapper.readValue(testFile, JsonNode.class);
+		Path rootTestDir = testFile.getParentFile().toPath();
+		for (JsonNode test : topLevel) {
+			tests.add(loadTest(test, rootTestDir, parser));
+		}
+	}
 
-    private FormulogTest loadTest(JsonNode test, Path rootTestDir, Parser parser)
-            throws ParseException, FileNotFoundException {
-        String name = test.get("name").asText();
-        Path dir = rootTestDir.resolve(name);
-        Map<RelationSymbol, Set<Term[]>> m = new HashMap<>();
-        for (RelationSymbol sym : prog.getFactSymbols()) {
-            if (sym.isEdbSymbol()) {
-                FileReader fr = new FileReader(dir.resolve(sym + ".tsv").toFile());
-                Set<Term[]> s = parser.parseFacts(sym, fr);
-                m.put(sym, s);
-            }
-        }
-        try {
-            Function<EvaluationResult, List<String>> logic = parseBoolLogic(test.get("spec").asText());
-            return new FormulogTest(name, m, logic);
-        } catch (ParseException e) {
-            throw new ParseException(-1, "Trouble parsing spec for test " + name + ": " + e.getMessage());
-        }
-    }
+	private FormulogTest loadTest(JsonNode test, Path rootTestDir, Parser parser)
+			throws ParseException, FileNotFoundException {
+		String name = test.get("name").asText();
+		Path dir = rootTestDir.resolve(name);
+		Map<RelationSymbol, Set<Term[]>> m = new HashMap<>();
+		for (RelationSymbol sym : prog.getFactSymbols()) {
+			if (sym.isEdbSymbol()) {
+				FileReader fr = new FileReader(dir.resolve(sym + ".tsv").toFile());
+				Set<Term[]> s = parser.parseFacts(sym, fr);
+				m.put(sym, s);
+			}
+		}
+		try {
+			Function<EvaluationResult, List<String>> logic = parseBoolLogic(test.get("spec").asText());
+			return new FormulogTest(name, m, logic);
+		} catch (ParseException e) {
+			throw new ParseException(-1, "Trouble parsing spec for test " + name + ": " + e.getMessage());
+		}
+	}
 
-    private Function<EvaluationResult, List<String>> parseBoolLogic(String s) throws ParseException {
-        Reader r = new StringReader(s);
-        SExpParser p = new SExpParser(r);
-        SExp sexp;
-        try {
-            sexp = p.parse();
-        } catch (SExpException e) {
-            throw new ParseException(-1, e.getMessage());
-        }
-        return parseBoolLogic(sexp);
-    }
+	private Function<EvaluationResult, List<String>> parseBoolLogic(String s) throws ParseException {
+		Reader r = new StringReader(s);
+		SExpParser p = new SExpParser(r);
+		SExp sexp;
+		try {
+			sexp = p.parse();
+		} catch (SExpException e) {
+			throw new ParseException(-1, e.getMessage());
+		}
+		return parseBoolLogic(sexp);
+	}
 
-    private Function<EvaluationResult, List<String>> parseBoolLogic(SExp sexp) throws ParseException {
-        if (sexp.isAtom()) {
-            return parseBoolAtom(sexp.asAtom());
-        } else {
-            return parseBoolList(sexp.asList());
-        }
-    }
+	private Function<EvaluationResult, List<String>> parseBoolLogic(SExp sexp) throws ParseException {
+		if (sexp.isAtom()) {
+			return parseBoolAtom(sexp.asAtom());
+		} else {
+			return parseBoolList(sexp.asList());
+		}
+	}
 
-    private Function<EvaluationResult, List<String>> parseBoolAtom(String atom) throws ParseException {
-        switch (atom) {
-            case "true":
-                return r -> Collections.emptyList();
-            default:
-                throw new ParseException(-1, "Unrecognized boolean constant: " + atom);
-        }
-    }
+	private Function<EvaluationResult, List<String>> parseBoolAtom(String atom) throws ParseException {
+		switch (atom) {
+		case "true":
+			return r -> Collections.emptyList();
+		default:
+			throw new ParseException(-1, "Unrecognized boolean constant: " + atom);
+		}
+	}
 
-    private Function<EvaluationResult, List<String>> parseBoolList(List<SExp> l) throws ParseException {
-        if (l.isEmpty()) {
-            throw new ParseException(-1, "Unexpected empty list");
-        }
-        SExp head = l.get(0);
-        if (head.isList()) {
-            throw new ParseException(-1, "Expected an operator, but got a list: " + head);
-        }
-        String cmd = head.asAtom();
-        switch (cmd) {
-            case "=": {
-                if (l.size() != 3) {
-                    throw new ParseException(-1, "Wrong number of arguments for = operator: " + l.size());
-                }
-                SExp sexp1 = l.get(1);
-                SExp sexp2 = l.get(2);
-                Function<EvaluationResult, Integer> f1 = parseIntLogic(sexp1);
-                Function<EvaluationResult, Integer> f2 = parseIntLogic(sexp2);
-                return r -> {
-                    int v1 = f1.apply(r);
-                    int v2 = f2.apply(r);
-                    if (v1 == v2) {
-                        return Collections.emptyList();
-                    } else {
-                        return Collections.singletonList(
-                                "Failed equality: (= " + sexp1 + " " + sexp2 + ") reduces to (= " + v1 + " " + v2 + ")");
-                    }
-                };
-            }
-            case "and": {
-                List<Function<EvaluationResult, List<String>>> fs = new ArrayList<>();
-                for (Iterator<SExp> it = l.listIterator(1); it.hasNext(); ) {
-                    fs.add(parseBoolLogic(it.next()));
-                }
-                return r -> {
-                    List<String> errors = new ArrayList<>();
-                    for (Function<EvaluationResult, List<String>> f : fs) {
-                        errors.addAll(f.apply(r));
-                    }
-                    return errors;
-                };
-            }
-            default:
-                throw new ParseException(-1, "Unrecognized boolean operator: " + cmd);
-        }
-    }
+	private Function<EvaluationResult, List<String>> parseBoolList(List<SExp> l) throws ParseException {
+		if (l.isEmpty()) {
+			throw new ParseException(-1, "Unexpected empty list");
+		}
+		SExp head = l.get(0);
+		if (head.isList()) {
+			throw new ParseException(-1, "Expected an operator, but got a list: " + head);
+		}
+		String cmd = head.asAtom();
+		switch (cmd) {
+		case "=": {
+			if (l.size() != 3) {
+				throw new ParseException(-1, "Wrong number of arguments for = operator: " + l.size());
+			}
+			SExp sexp1 = l.get(1);
+			SExp sexp2 = l.get(2);
+			Function<EvaluationResult, Integer> f1 = parseIntLogic(sexp1);
+			Function<EvaluationResult, Integer> f2 = parseIntLogic(sexp2);
+			return r -> {
+				int v1 = f1.apply(r);
+				int v2 = f2.apply(r);
+				if (v1 == v2) {
+					return Collections.emptyList();
+				} else {
+					return Collections.singletonList(
+							"Failed equality: (= " + sexp1 + " " + sexp2 + ") reduces to (= " + v1 + " " + v2 + ")");
+				}
+			};
+		}
+		case "and": {
+			List<Function<EvaluationResult, List<String>>> fs = new ArrayList<>();
+			for (Iterator<SExp> it = l.listIterator(1); it.hasNext();) {
+				fs.add(parseBoolLogic(it.next()));
+			}
+			return r -> {
+				List<String> errors = new ArrayList<>();
+				for (Function<EvaluationResult, List<String>> f : fs) {
+					errors.addAll(f.apply(r));
+				}
+				return errors;
+			};
+		}
+		default:
+			throw new ParseException(-1, "Unrecognized boolean operator: " + cmd);
+		}
+	}
 
-    private Function<EvaluationResult, Integer> parseIntLogic(SExp sexp) throws ParseException {
-        if (sexp.isAtom()) {
-            return parseIntAtom(sexp.asAtom());
-        } else {
-            return parseIntList(sexp.asList());
-        }
-    }
+	private Function<EvaluationResult, Integer> parseIntLogic(SExp sexp) throws ParseException {
+		if (sexp.isAtom()) {
+			return parseIntAtom(sexp.asAtom());
+		} else {
+			return parseIntList(sexp.asList());
+		}
+	}
 
-    private Function<EvaluationResult, Integer> parseIntAtom(String s) throws ParseException {
-        try {
-            int n = Integer.parseInt(s);
-            return r -> n;
-        } catch (NumberFormatException e) {
-            throw new ParseException(-1, "Expected an integer constant but got " + s);
-        }
-    }
+	private Function<EvaluationResult, Integer> parseIntAtom(String s) throws ParseException {
+		try {
+			int n = Integer.parseInt(s);
+			return r -> n;
+		} catch (NumberFormatException e) {
+			throw new ParseException(-1, "Expected an integer constant but got " + s);
+		}
+	}
 
-    private Function<EvaluationResult, Integer> parseIntList(List<SExp> l) throws ParseException {
-        if (l.isEmpty()) {
-            throw new ParseException(-1, "Unexpected empty list");
-        }
-        SExp head = l.get(0);
-        if (head.isList()) {
-            throw new ParseException(-1, "Expected an operator, but got a list: " + head);
-        }
-        String cmd = head.asAtom();
-        switch (cmd) {
-            case "size":
-                if (l.size() != 2) {
-                    throw new ParseException(-1, "Wrong number of arguments for size operator: " + l.size());
-                }
-                SExp sexp1 = l.get(1);
-                if (sexp1.isList()) {
-                    throw new ParseException(-1, "size operator expects a relation symbol, but got a list: " + sexp1);
-                }
-                String name = sexp1.asAtom();
-                SymbolManager sm = prog.getSymbolManager();
-                if (!sm.hasName(name)) {
-                    throw new ParseException(-1, "unrecognized relation used in size operator: " + name);
-                }
-                Symbol sym = sm.lookupSymbol(name);
-                if (!(sym instanceof RelationSymbol)) {
-                    throw new ParseException(-1, "non-relation symbol used in size operator: " + name);
-                }
-                RelationSymbol rel = (RelationSymbol) sym;
-                return r -> r.getCount(rel);
-            default:
-                throw new ParseException(-1, "Unrecognized integer operator: " + cmd);
-        }
-    }
+	private Function<EvaluationResult, Integer> parseIntList(List<SExp> l) throws ParseException {
+		if (l.isEmpty()) {
+			throw new ParseException(-1, "Unexpected empty list");
+		}
+		SExp head = l.get(0);
+		if (head.isList()) {
+			throw new ParseException(-1, "Expected an operator, but got a list: " + head);
+		}
+		String cmd = head.asAtom();
+		switch (cmd) {
+		case "size":
+			if (l.size() != 2) {
+				throw new ParseException(-1, "Wrong number of arguments for size operator: " + l.size());
+			}
+			SExp sexp1 = l.get(1);
+			if (sexp1.isList()) {
+				throw new ParseException(-1, "size operator expects a relation symbol, but got a list: " + sexp1);
+			}
+			String name = sexp1.asAtom();
+			SymbolManager sm = prog.getSymbolManager();
+			if (!sm.hasName(name)) {
+				throw new ParseException(-1, "unrecognized relation used in size operator: " + name);
+			}
+			Symbol sym = sm.lookupSymbol(name);
+			if (!(sym instanceof RelationSymbol)) {
+				throw new ParseException(-1, "non-relation symbol used in size operator: " + name);
+			}
+			RelationSymbol rel = (RelationSymbol) sym;
+			return r -> r.getCount(rel);
+		default:
+			throw new ParseException(-1, "Unrecognized integer operator: " + cmd);
+		}
+	}
 
-    synchronized boolean runTests() throws InvalidProgramException, EvaluationException {
-        if (!initialized) {
-            throw new IllegalStateException("Need to set up tests first.");
-        }
-        // Need to get the EDBs that are hard-coded into the program.
-        Map<RelationSymbol, Set<Term[]>> hardCodedFacts = new HashMap<>();
-        for (RelationSymbol sym : prog.getFactSymbols()) {
-            hardCodedFacts.put(sym, new HashSet<>(prog.getFacts(sym)));
-        }
-        boolean ok = true;
-        for (FormulogTest test : tests) {
-            ok &= runTest(test, hardCodedFacts);
-        }
-        return ok;
-    }
+	synchronized boolean runTests() throws InvalidProgramException, EvaluationException {
+		if (!initialized) {
+			throw new IllegalStateException("Need to set up tests first.");
+		}
+		// Need to get the EDBs that are hard-coded into the program.
+		Map<RelationSymbol, Set<Term[]>> hardCodedFacts = new HashMap<>();
+		for (RelationSymbol sym : prog.getFactSymbols()) {
+			hardCodedFacts.put(sym, new HashSet<>(prog.getFacts(sym)));
+		}
+		boolean ok = true;
+		for (FormulogTest test : tests) {
+			ok &= runTest(test, hardCodedFacts);
+		}
+		return ok;
+	}
 
-    private void clearCachedState() {
-        // Need to clear memoized function calls
-        prog.getFunctionCallFactory().clearMemoCache();
-        // Need to reset predicate functions
-        for (FunctionSymbol sym : prog.getFunctionSymbols()) {
-            FunctionDef def = prog.getDef(sym);
-            if (def instanceof DummyFunctionDef) {
-                ((DummyFunctionDef) def).setDef(null);
-            }
-        }
-    }
+	private void clearCachedState() {
+		// Need to clear memoized function calls
+		prog.getFunctionCallFactory().clearMemoCache();
+		// Need to reset predicate functions
+		for (FunctionSymbol sym : prog.getFunctionSymbols()) {
+			FunctionDef def = prog.getDef(sym);
+			if (def instanceof DummyFunctionDef) {
+				((DummyFunctionDef) def).setDef(null);
+			}
+		}
+	}
 
-    private boolean runTest(FormulogTest test, Map<RelationSymbol, Set<Term[]>> hardCodedFacts) throws InvalidProgramException, EvaluationException {
-        for (RelationSymbol sym : prog.getFactSymbols()) {
-            if (sym.isEdbSymbol()) {
-                Set<Term[]> s = prog.getFacts(sym);
-                s.clear();
-                s.addAll(hardCodedFacts.get(sym));
-                s.addAll(test.testInputs.get(sym));
-            }
-        }
-        clearCachedState();
-        // This would be better if we could set up the program, and then load
-        // the external facts, so we do not need to do the setup each time.
-        Evaluation e = SemiNaiveEvaluation.setup(prog, 1, false);
-        System.out.print(test.name + "... ");
-        e.run();
-        List<String> errors = test.testLogic.apply(e.getResult());
-        if (errors.isEmpty()) {
-            System.out.println("PASSED");
-            return true;
-        } else {
-            System.out.println("FAILED");
-            for (String error : errors) {
-                System.out.println(">>> " + error);
-            }
-            return false;
-        }
-    }
+	private boolean runTest(FormulogTest test, Map<RelationSymbol, Set<Term[]>> hardCodedFacts)
+			throws InvalidProgramException, EvaluationException {
+		for (RelationSymbol sym : prog.getFactSymbols()) {
+			if (sym.isEdbSymbol()) {
+				Set<Term[]> s = prog.getFacts(sym);
+				s.clear();
+				s.addAll(hardCodedFacts.get(sym));
+				s.addAll(test.testInputs.get(sym));
+			}
+		}
+		clearCachedState();
+		// This would be better if we could set up the program, and then load
+		// the external facts, so we do not need to do the setup each time.
+		Evaluation e = SemiNaiveEvaluation.setup(prog, 1, false);
+		System.out.print(test.name + "... ");
+		e.run();
+		List<String> errors = test.testLogic.apply(e.getResult());
+		if (errors.isEmpty()) {
+			System.out.println("PASSED");
+			return true;
+		} else {
+			System.out.println("FAILED");
+			for (String error : errors) {
+				System.out.println(">>> " + error);
+			}
+			return false;
+		}
+	}
 
-    private static class FormulogTest {
-        public final String name;
-        public final Map<RelationSymbol, Set<Term[]>> testInputs;
-        public final Function<EvaluationResult, List<String>> testLogic;
+	private static class FormulogTest {
+		public final String name;
+		public final Map<RelationSymbol, Set<Term[]>> testInputs;
+		public final Function<EvaluationResult, List<String>> testLogic;
 
-        public FormulogTest(String name, Map<RelationSymbol, Set<Term[]>> testInputs,
-                            Function<EvaluationResult, List<String>> testLogic) {
-            this.name = name;
-            this.testInputs = testInputs;
-            this.testLogic = testLogic;
-        }
-    }
+		public FormulogTest(String name, Map<RelationSymbol, Set<Term[]>> testInputs,
+				Function<EvaluationResult, List<String>> testLogic) {
+			this.name = name;
+			this.testInputs = testInputs;
+			this.testLogic = testLogic;
+		}
+	}
 
-    public static void main(String[] args) throws Exception {
-        if (args.length != 1) {
-            System.out.println("Expected a single Formulog file as an input.");
-            System.exit(1);
-        }
-        if (Configuration.testFile == null) {
-            System.out.println("Must specify a JSON test file.");
-            System.exit(1);
-        }
-        main(new File(args[0]), new File(Configuration.testFile));
-    }
+	public static void main(String[] args) throws Exception {
+		if (args.length != 1) {
+			System.out.println("Expected a single Formulog file as an input.");
+			System.exit(1);
+		}
+		if (Configuration.testFile == null) {
+			System.out.println("Must specify a JSON test file.");
+			System.exit(1);
+		}
+		main(new File(args[0]), new File(Configuration.testFile));
+	}
 
-    public static void main(File file, File json) throws Exception {
-        FormulogTester tester = new FormulogTester();
-        tester.setup(new FileReader(file), json);
-        System.exit(tester.runTests() ? 0 : 1);
-    }
+	public static void main(File file, File json) throws Exception {
+		FormulogTester tester = new FormulogTester();
+		tester.setup(new FileReader(file), json);
+		System.exit(tester.runTests() ? 0 : 1);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/Main.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Main.java
@@ -53,299 +53,303 @@ import picocli.CommandLine.Model;
 @Command(name = "formulog", mixinStandardHelpOptions = true, version = "Formulog 0.7.0", description = "Runs Formulog.")
 public final class Main implements Callable<Integer> {
 
-    @Spec
-    private static Model.CommandSpec spec;
+	@Spec
+	private static Model.CommandSpec spec;
 
-    @Option(names = "--smt-solver-mode", description = "Strategy to use when interacting with external SMT solvers" +
-            "('naive', 'push-pop', or 'check-sat-assuming').", converter = SmtModeConverter.class)
-    public static SmtStrategy smtStrategy = Configuration.getSmtStrategy();
+	@Option(names = "--smt-solver-mode", description = "Strategy to use when interacting with external SMT solvers"
+			+ "('naive', 'push-pop', or 'check-sat-assuming').", converter = SmtModeConverter.class)
+	public static SmtStrategy smtStrategy = Configuration.getSmtStrategy();
 
-    @Option(names = {"-F", "--fact-dir"}, description = "Directory to look for fact .tsv files (default: '.').")
-    private List<String> factDirs = Configuration.getListProp("factDirs");
+	@Option(names = { "-F", "--fact-dir" }, description = "Directory to look for fact .tsv files (default: '.').")
+	private List<String> factDirs = Configuration.getListProp("factDirs");
 
-    @Option(names = {"-D", "--output-dir"}, description = "Directory for .tsv output files (default: '.').")
-    private File outDir = new File(".");
+	@Option(names = { "-D", "--output-dir" }, description = "Directory for .tsv output files (default: '.').")
+	private File outDir = new File(".");
 
-    @Option(names = {"-j", "--parallelism"}, description = "Number of threads to use.")
-    public static int parallelism = Configuration.getIntProp("parallelism", 4);
+	@Option(names = { "-j", "--parallelism" }, description = "Number of threads to use.")
+	public static int parallelism = Configuration.getIntProp("parallelism", 4);
 
-    @Option(names = "--dump-all", description = "Print all relations.")
-    private boolean dumpAll;
+	@Option(names = "--dump-all", description = "Print all relations.")
+	private boolean dumpAll;
 
-    @Option(names = "--dump-idb", description = "Print all IDB relations.")
-    private boolean dumpIdb;
+	@Option(names = "--dump-idb", description = "Print all IDB relations.")
+	private boolean dumpIdb;
 
-    @Option(names = "--dump", description = "Print selected relations.")
-    private Set<String> relationsToPrint = Collections.emptySet();
+	@Option(names = "--dump", description = "Print selected relations.")
+	private Set<String> relationsToPrint = Collections.emptySet();
 
-    @Option(names = "--dump-query", description = "Print query result.")
-    private boolean dumpQuery;
+	@Option(names = "--dump-query", description = "Print query result.")
+	private boolean dumpQuery;
 
-    @Option(names = "--dump-sizes", description = "Print relation sizes.")
-    private boolean dumpSizes;
-    
-    @Option(names = {"-c", "--codegen"}, description = "Compile the Formulog program.")
-    private boolean codegen;
-    
-    @Option(names = {"--codegen-dir"}, description = "Directory for generated code (default: './codegen').")
-    private File codegenDir = new File("codegen");
-    
-    @Option(names = {"--smt-stats"}, description = "Report basic statistics related to SMT solver usage.")
-    public static boolean smtStats = false;
+	@Option(names = "--dump-sizes", description = "Print relation sizes.")
+	private boolean dumpSizes;
 
-    @Parameters(index = "0", description = "Formulog program file.")
-    private File file;
+	@Option(names = { "-c", "--codegen" }, description = "Compile the Formulog program.")
+	private boolean codegen;
 
-    private final StopWatch clock = new StopWatch();
-    private volatile boolean interrupted = true;
+	@Option(names = { "--codegen-dir" }, description = "Directory for generated code (default: './codegen').")
+	private File codegenDir = new File("codegen");
 
-    private static final boolean exnStackTrace = System.getProperty("exnStackTrace") != null;
+	@Option(names = { "--smt-stats" }, description = "Report basic statistics related to SMT solver usage.")
+	public static boolean smtStats = false;
 
-    private void go() {
-        if (!outDir.mkdirs() && !outDir.exists() || !outDir.isDirectory()) {
-            System.out.println("Unable to create output directory: " + outDir);
-            System.exit(1);
-        }
-        BasicProgram prog = parse();
-        WellTypedProgram typedProg = typeCheck(prog);
-        Evaluation eval = setup(typedProg);
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                    if (interrupted) {
-                        dumpResults(eval.getResult());
-                    }
-                })
+	@Parameters(index = "0", description = "Formulog program file.")
+	private File file;
 
-        );
-        evaluate(eval);
-        interrupted = false;
-        var res = eval.getResult();
-        dumpResults(res);
-        dumpResultsToDisk(res);
-    }
+	private final StopWatch clock = new StopWatch();
+	private volatile boolean interrupted = true;
 
-    private BasicProgram parse() {
-        System.out.println("Parsing...");
-        clock.start();
-        try {
-            List<Path> factPaths = factDirs.stream().map(Paths::get).collect(Collectors.toList());
-            if (factPaths.isEmpty()) {
-                factPaths = Collections.singletonList(Paths.get(""));
-            }
-            FileReader reader = new FileReader(file);
-            BasicProgram prog = new Parser().parse(reader, factPaths);
-            clock.stop();
-            System.out.println("Finished parsing (" + clock.getTime() / 1000.0 + "s)");
-            return prog;
-        } catch (FileNotFoundException e) {
-            handleException("Error while parsing!", e);
-        } catch (ParseException e) {
-            String msg = "Error while parsing ";
-            if (e.getFileName() != null) {
-                msg += e.getFileName() + ", ";
-            }
-            msg += "line " + e.getLineNo() + ":";
-            handleException(msg, e);
-        }
-        throw new AssertionError("impossible");
-    }
+	private static final boolean exnStackTrace = System.getProperty("exnStackTrace") != null;
 
-    private WellTypedProgram typeCheck(Program<UserPredicate, BasicRule> prog) {
-        System.out.println("Type checking...");
-        clock.reset();
-        clock.start();
-        try {
-            WellTypedProgram prog2 = new TypeChecker(prog).typeCheck();
-            clock.stop();
-            System.out.println("Finished type checking (" + clock.getTime() / 1000.0 + "s)");
-            return prog2;
-        } catch (TypeException e) {
-            handleException("Error while typechecking the program!", e);
-            throw new AssertionError("impossible");
-        }
-    }
+	private void go() {
+		if (!outDir.mkdirs() && !outDir.exists() || !outDir.isDirectory()) {
+			System.out.println("Unable to create output directory: " + outDir);
+			System.exit(1);
+		}
+		BasicProgram prog = parse();
+		WellTypedProgram typedProg = typeCheck(prog);
+		Evaluation eval = setup(typedProg);
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			if (interrupted) {
+				dumpResults(eval.getResult());
+			}
+		})
 
-    private Evaluation setup(WellTypedProgram prog) {
-        System.out.println("Rewriting and validating...");
-        clock.reset();
-        clock.start();
-        try {
-            Evaluation eval = SemiNaiveEvaluation.setup(prog, parallelism, Configuration.eagerSemiNaive);
-            clock.stop();
-            System.out.println("Finished rewriting and validating (" + clock.getTime() / 1000.0 + "s)");
-            return eval;
-        } catch (InvalidProgramException e) {
-            handleException("Error while rewriting/validation!", e);
-            throw new AssertionError("impossible");
-        }
-    }
+		);
+		evaluate(eval);
+		interrupted = false;
+		var res = eval.getResult();
+		dumpResults(res);
+		dumpResultsToDisk(res);
+	}
 
-    private void evaluate(Evaluation eval) {
-        System.out.println("Evaluating...");
-        clock.reset();
-        clock.start();
-        try {
-            eval.run();
-            clock.stop();
-            System.out.println("Finished evaluating (" + clock.getTime() / 1000.0 + "s)");
-        } catch (EvaluationException e) {
-            handleException("Error while evaluating the program!", e);
-        }
-    }
+	private BasicProgram parse() {
+		System.out.println("Parsing...");
+		clock.start();
+		try {
+			List<Path> factPaths = factDirs.stream().map(Paths::get).collect(Collectors.toList());
+			if (factPaths.isEmpty()) {
+				factPaths = Collections.singletonList(Paths.get(""));
+			}
+			FileReader reader = new FileReader(file);
+			BasicProgram prog = new Parser().parse(reader, factPaths);
+			clock.stop();
+			System.out.println("Finished parsing (" + clock.getTime() / 1000.0 + "s)");
+			return prog;
+		} catch (FileNotFoundException e) {
+			handleException("Error while parsing!", e);
+		} catch (ParseException e) {
+			String msg = "Error while parsing ";
+			if (e.getFileName() != null) {
+				msg += e.getFileName() + ", ";
+			}
+			msg += "line " + e.getLineNo() + ":";
+			handleException(msg, e);
+		}
+		throw new AssertionError("impossible");
+	}
 
-    private String getBanner(String heading) {
-        return "==================== " + heading + " ====================";
-    }
+	private WellTypedProgram typeCheck(Program<UserPredicate, BasicRule> prog) {
+		System.out.println("Type checking...");
+		clock.reset();
+		clock.start();
+		try {
+			WellTypedProgram prog2 = new TypeChecker(prog).typeCheck();
+			clock.stop();
+			System.out.println("Finished type checking (" + clock.getTime() / 1000.0 + "s)");
+			return prog2;
+		} catch (TypeException e) {
+			handleException("Error while typechecking the program!", e);
+			throw new AssertionError("impossible");
+		}
+	}
 
-    private String getSmallBanner(String heading) {
-        return "---------- " + heading + " ----------";
-    }
+	private Evaluation setup(WellTypedProgram prog) {
+		System.out.println("Rewriting and validating...");
+		clock.reset();
+		clock.start();
+		try {
+			Evaluation eval = SemiNaiveEvaluation.setup(prog, parallelism, Configuration.eagerSemiNaive);
+			clock.stop();
+			System.out.println("Finished rewriting and validating (" + clock.getTime() / 1000.0 + "s)");
+			return eval;
+		} catch (InvalidProgramException e) {
+			handleException("Error while rewriting/validation!", e);
+			throw new AssertionError("impossible");
+		}
+	}
 
-    private static class FactFileDumper implements Runnable {
+	private void evaluate(Evaluation eval) {
+		System.out.println("Evaluating...");
+		clock.reset();
+		clock.start();
+		try {
+			eval.run();
+			clock.stop();
+			System.out.println("Finished evaluating (" + clock.getTime() / 1000.0 + "s)");
+		} catch (EvaluationException e) {
+			handleException("Error while evaluating the program!", e);
+		}
+	}
 
-        private final Iterable<UserPredicate> facts;
-        private final PrintStream out;
+	private String getBanner(String heading) {
+		return "==================== " + heading + " ====================";
+	}
 
-        public FactFileDumper(Iterable<UserPredicate> facts, PrintStream out) {
-            this.facts = facts;
-            this.out = out;
-        }
+	private String getSmallBanner(String heading) {
+		return "---------- " + heading + " ----------";
+	}
 
-        @Override
-        public void run() {
-            for (var fact : facts) {
-                Term[] args = fact.getArgs();
-                for (int i = 0; i < args.length; ++i) {
-                    out.print(args[i]);
-                    if (i < args.length - 1) {
-                        out.print("\t");
-                    }
-                }
-                out.println();
-            }
-            out.close();
-        }
+	private static class FactFileDumper implements Runnable {
 
-    }
+		private final Iterable<UserPredicate> facts;
+		private final PrintStream out;
 
-    private void dumpResultsToDisk(EvaluationResult res) {
-        var pool = Executors.newFixedThreadPool(parallelism);
-        try {
-            for (RelationSymbol sym : res.getSymbols()) {
-                if (sym.isIdbSymbol() && sym.isDisk()) {
-                    File outFile = outDir.toPath().resolve(sym + ".tsv").toFile();
-                    boolean ok = outFile.createNewFile();
-                    if (!ok && !outFile.exists()) {
-                        throw new IOException("Cannot create output file " + outFile.getName());
-                    }
-                    pool.submit(new FactFileDumper(res.getAll(sym), new PrintStream(outFile)));
-                }
-            }
-            pool.shutdown();
-            while (!pool.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS)) {
-                // do nothing
-            }
-        } catch (Exception e) {
-            handleException("Problem writing output to disk", e);
-        }
-    }
+		public FactFileDumper(Iterable<UserPredicate> facts, PrintStream out) {
+			this.facts = facts;
+			this.out = out;
+		}
 
-    private void dumpResults(EvaluationResult res) {
-        PrintStream out = System.out;
-        if (smtStats) {
-            out.println();
-            out.println(getBanner("SMT STATS"));
-            out.println("SMT calls: " + Configuration.smtCalls);
-            out.println("SMT time (ms): " + Configuration.smtTime);
-        }
-        List<RelationSymbol> allSymbols = res.getSymbols().stream().sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
-        Set<String> stringReprs = allSymbols.stream().map(RelationSymbol::toString).collect(Collectors.toSet());
-        for (String sym : relationsToPrint) {
-            if (!stringReprs.contains(sym)) {
-                out.println("\nWARNING: ignoring unrecognized relation " + sym);
-            }
-        }
-        if (dumpSizes) {
-            out.println();
-            out.println(getBanner("RELATION SIZES"));
-            for (RelationSymbol sym : allSymbols) {
-                out.println(sym + ": " + res.getCount(sym));
-            }
-        }
-        if (dumpAll || dumpQuery) {
-            var queryRes = res.getQueryAnswer();
-            if (queryRes != null) {
-                List<UserPredicate> l = new ArrayList<>();
-                queryRes.forEach(l::add);
-                out.println();
-                out.println(getBanner("QUERY RESULTS (" + l.size() + ")"));
-                Util.printSortedFacts(l, out);
-            }
-        }
-        List<RelationSymbol> edbSymbols = allSymbols.stream().
-                filter(sym -> sym.isEdbSymbol() && (dumpAll || relationsToPrint.contains(sym.toString()))).collect(Collectors.toList());
-        dumpRelations("SELECTED EDB RELATIONS", edbSymbols, res, out);
-        List<RelationSymbol> idbSymbols = allSymbols.stream().
-                filter(sym -> sym.isIdbSymbol() && (dumpAll || dumpIdb || relationsToPrint.contains(sym.toString()))).collect(Collectors.toList());
-        dumpRelations("SELECTED IDB RELATIONS", idbSymbols, res, out);
-    }
+		@Override
+		public void run() {
+			for (var fact : facts) {
+				Term[] args = fact.getArgs();
+				for (int i = 0; i < args.length; ++i) {
+					out.print(args[i]);
+					if (i < args.length - 1) {
+						out.print("\t");
+					}
+				}
+				out.println();
+			}
+			out.close();
+		}
 
-    private void dumpRelations(String heading, Collection<RelationSymbol> symbols, EvaluationResult res, PrintStream out) {
-        if (symbols.isEmpty()) {
-            return;
-        }
-        out.println();
-        out.println(getBanner(heading));
-        for (RelationSymbol sym : symbols) {
-            out.println();
-            out.println(getSmallBanner(sym + " (" + res.getCount(sym) + ")"));
-            if (res.getCount(sym) < 1000) {
-                Util.printSortedFacts(res.getAll(sym), out);
-            } else {
-                for (var tup : res.getAll(sym)) {
-                    out.println(tup);
-                }
-            }
-        }
-    }
+	}
 
-    public static class SmtModeConverter implements ITypeConverter<SmtStrategy> {
+	private void dumpResultsToDisk(EvaluationResult res) {
+		var pool = Executors.newFixedThreadPool(parallelism);
+		try {
+			for (RelationSymbol sym : res.getSymbols()) {
+				if (sym.isIdbSymbol() && sym.isDisk()) {
+					File outFile = outDir.toPath().resolve(sym + ".tsv").toFile();
+					boolean ok = outFile.createNewFile();
+					if (!ok && !outFile.exists()) {
+						throw new IOException("Cannot create output file " + outFile.getName());
+					}
+					pool.submit(new FactFileDumper(res.getAll(sym), new PrintStream(outFile)));
+				}
+			}
+			pool.shutdown();
+			while (!pool.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS)) {
+				// do nothing
+			}
+		} catch (Exception e) {
+			handleException("Problem writing output to disk", e);
+		}
+	}
 
-        @Override
-        public SmtStrategy convert(String s) throws Exception {
-            switch (s) {
-                case "push-pop":
-                    return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP, null);
-                case "naive":
-                    return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP_NAIVE, null);
-                case "check-sat-assuming":
-                    return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_QUEUE, 1);
-            }
-            throw new ParameterException(Main.spec.commandLine(), "Unexpected value for SMT solver mode: " + s +
-                    " (must be one of 'naive', 'push-pop', or 'check-sat-assuming')");
-        }
-    }
+	private void dumpResults(EvaluationResult res) {
+		PrintStream out = System.out;
+		if (smtStats) {
+			out.println();
+			out.println(getBanner("SMT STATS"));
+			out.println("SMT calls: " + Configuration.smtCalls);
+			out.println("SMT time (ms): " + Configuration.smtTime);
+		}
+		List<RelationSymbol> allSymbols = res.getSymbols().stream().sorted(Comparator.comparing(Object::toString))
+				.collect(Collectors.toList());
+		Set<String> stringReprs = allSymbols.stream().map(RelationSymbol::toString).collect(Collectors.toSet());
+		for (String sym : relationsToPrint) {
+			if (!stringReprs.contains(sym)) {
+				out.println("\nWARNING: ignoring unrecognized relation " + sym);
+			}
+		}
+		if (dumpSizes) {
+			out.println();
+			out.println(getBanner("RELATION SIZES"));
+			for (RelationSymbol sym : allSymbols) {
+				out.println(sym + ": " + res.getCount(sym));
+			}
+		}
+		if (dumpAll || dumpQuery) {
+			var queryRes = res.getQueryAnswer();
+			if (queryRes != null) {
+				List<UserPredicate> l = new ArrayList<>();
+				queryRes.forEach(l::add);
+				out.println();
+				out.println(getBanner("QUERY RESULTS (" + l.size() + ")"));
+				Util.printSortedFacts(l, out);
+			}
+		}
+		List<RelationSymbol> edbSymbols = allSymbols.stream()
+				.filter(sym -> sym.isEdbSymbol() && (dumpAll || relationsToPrint.contains(sym.toString())))
+				.collect(Collectors.toList());
+		dumpRelations("SELECTED EDB RELATIONS", edbSymbols, res, out);
+		List<RelationSymbol> idbSymbols = allSymbols.stream()
+				.filter(sym -> sym.isIdbSymbol() && (dumpAll || dumpIdb || relationsToPrint.contains(sym.toString())))
+				.collect(Collectors.toList());
+		dumpRelations("SELECTED IDB RELATIONS", idbSymbols, res, out);
+	}
 
-    public static void main(String[] args) throws Exception {
-        int exitCode = new CommandLine(new Main()).execute(args);
-        System.exit(exitCode);
-    }
+	private void dumpRelations(String heading, Collection<RelationSymbol> symbols, EvaluationResult res,
+			PrintStream out) {
+		if (symbols.isEmpty()) {
+			return;
+		}
+		out.println();
+		out.println(getBanner(heading));
+		for (RelationSymbol sym : symbols) {
+			out.println();
+			out.println(getSmallBanner(sym + " (" + res.getCount(sym) + ")"));
+			if (res.getCount(sym) < 1000) {
+				Util.printSortedFacts(res.getAll(sym), out);
+			} else {
+				for (var tup : res.getAll(sym)) {
+					out.println(tup);
+				}
+			}
+		}
+	}
 
-    private static void handleException(String msg, Exception e) {
-        System.out.println(msg);
-        System.out.println(e.getMessage());
-        if (exnStackTrace) {
-            e.printStackTrace(System.out);
-        }
-        System.exit(1);
-    }
+	public static class SmtModeConverter implements ITypeConverter<SmtStrategy> {
 
-    @Override
-    public Integer call() throws Exception {
-        if (codegen) {
-            CodeGen.main(file, codegenDir);
-        } else {
-            go();
-        }
-        return 0;
-    }
+		@Override
+		public SmtStrategy convert(String s) throws Exception {
+			switch (s) {
+			case "push-pop":
+				return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP, null);
+			case "naive":
+				return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_PUSH_POP_NAIVE, null);
+			case "check-sat-assuming":
+				return new SmtStrategy(SmtStrategy.Tag.PER_THREAD_QUEUE, 1);
+			}
+			throw new ParameterException(Main.spec.commandLine(), "Unexpected value for SMT solver mode: " + s
+					+ " (must be one of 'naive', 'push-pop', or 'check-sat-assuming')");
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		int exitCode = new CommandLine(new Main()).execute(args);
+		System.exit(exitCode);
+	}
+
+	private static void handleException(String msg, Exception e) {
+		System.out.println(msg);
+		System.out.println(e.getMessage());
+		if (exnStackTrace) {
+			e.printStackTrace(System.out);
+		}
+		System.exit(1);
+	}
+
+	@Override
+	public Integer call() throws Exception {
+		if (codegen) {
+			CodeGen.main(file, codegenDir);
+		} else {
+			go();
+		}
+		return 0;
+	}
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/PrintPreference.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/PrintPreference.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog;
  * #L%
  */
 
-
 public enum PrintPreference {
 	EDB, IDB, NONE, ALL, QUERY, SOME
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/AbstractRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/AbstractRule.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Iterator;
 import java.util.List;
 
@@ -28,12 +27,12 @@ public abstract class AbstractRule<H extends Literal, B extends Literal> impleme
 
 	private final H head;
 	private final List<B> body;
-	
+
 	protected AbstractRule(H head, List<B> body) {
 		this.head = head;
 		this.body = body;
 	}
-	
+
 	@Override
 	public Iterator<B> iterator() {
 		return body.iterator();
@@ -104,5 +103,5 @@ public abstract class AbstractRule<H extends Literal, B extends Literal> impleme
 			return false;
 		return true;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/AbstractTerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/AbstractTerm.java
@@ -20,11 +20,10 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 public abstract class AbstractTerm implements Term {
 
 	private final int id;
-	
+
 	public AbstractTerm() {
 		this.id = Terms.nextId();
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/BasicProgram.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/BasicProgram.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 public interface BasicProgram extends Program<UserPredicate, BasicRule> {
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/BasicRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/BasicRule.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/BindingType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/BindingType.java
@@ -20,15 +20,14 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 public enum BindingType {
-	
+
 	BOUND, FREE, IGNORED;
-	
+
 	public boolean isBound() {
 		return this.equals(BOUND);
 	}
-	
+
 	public boolean isFree() {
 		return this.equals(FREE);
 	}
@@ -36,5 +35,5 @@ public enum BindingType {
 	public boolean isIgnored() {
 		return this.equals(IGNORED);
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/BoolTerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/BoolTerm.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.Set;
 
@@ -36,19 +35,19 @@ public class BoolTerm extends AbstractTerm implements Primitive<Boolean>, SmtLib
 	private final boolean val;
 	private static final BoolTerm true_ = new BoolTerm(true);
 	private static final BoolTerm false_ = new BoolTerm(false);
-	
+
 	private BoolTerm(boolean val) {
 		this.val = val;
 	}
-	
+
 	public static BoolTerm mk(boolean val) {
 		return val ? true_ : false_;
 	}
-	
+
 	public static BoolTerm mkTrue() {
 		return true_;
 	}
-	
+
 	public static BoolTerm mkFalse() {
 		return false_;
 	}
@@ -77,7 +76,7 @@ public class BoolTerm extends AbstractTerm implements Primitive<Boolean>, SmtLib
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();
 	}
-	
+
 	@Override
 	public String toString() {
 		return Boolean.toString(val);

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/ComplexLiteral.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/ComplexLiteral.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.ast;
 import java.util.HashSet;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralExnVisitor;
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralVisitor;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
@@ -31,7 +30,7 @@ import edu.harvard.seas.pl.formulog.unification.Substitution;
 public interface ComplexLiteral extends Literal {
 
 	Term[] getArgs();
-	
+
 	ComplexLiteral applySubstitution(Substitution subst);
 
 	boolean isNegated();
@@ -43,9 +42,9 @@ public interface ComplexLiteral extends Literal {
 		}
 		return vars;
 	}
-	
+
 	<I, O> O accept(ComplexLiteralVisitor<I, O> visitor, I input);
-	
+
 	<I, O, E extends Throwable> O accept(ComplexLiteralExnVisitor<I, O, E> visitor, I input) throws E;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/ComplexLiterals.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/ComplexLiterals.java
@@ -20,35 +20,34 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 public final class ComplexLiterals {
 
 	private ComplexLiterals() {
 		throw new AssertionError("impossible");
 	}
-	
+
 	public static UnificationPredicate unifyWithBool(Term t, boolean bool) {
 		return UnificationPredicate.make(t, bool ? BoolTerm.mkTrue() : BoolTerm.mkFalse(), false);
 	}
-	
+
 	public static UnificationPredicate trueAtom() {
 		return unifyWithBool(BoolTerm.mkTrue(), true);
 	}
-	
+
 	public static interface ComplexLiteralVisitor<I, O> {
 
 		O visit(UnificationPredicate unificationPredicate, I input);
 
 		O visit(UserPredicate userPredicate, I input);
-		
+
 	}
-	
+
 	public static interface ComplexLiteralExnVisitor<I, O, E extends Throwable> {
 
 		O visit(UnificationPredicate unificationPredicate, I input) throws E;
 
 		O visit(UserPredicate userPredicate, I input) throws E;
-		
+
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Constructor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Constructor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitor;
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitorExn;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -54,7 +53,7 @@ public interface Constructor extends Functor<ConstructorSymbol>, SmtLibTerm {
 
 	@Override
 	Term copyWithNewArgs(Term[] newArgs);
-	
+
 	@Override
 	default Term normalize(Substitution s) throws EvaluationException {
 		if (isGround() && !containsUnevaluatedTerm()) {
@@ -67,5 +66,5 @@ public interface Constructor extends Functor<ConstructorSymbol>, SmtLibTerm {
 		}
 		return copyWithNewArgs(newArgs);
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Constructors.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Constructors.java
@@ -99,13 +99,13 @@ public final class Constructors {
 	public static Constructor nil() {
 		return nil;
 	}
-	
+
 	public static Constructor cons(Term hd, Term tl) {
-		return make(BuiltInConstructorSymbol.CONS, new Term[] { hd, tl } );
+		return make(BuiltInConstructorSymbol.CONS, new Term[] { hd, tl });
 	}
 
 	private static final Constructor none = makeZeroAry(BuiltInConstructorSymbol.NONE);
-	
+
 	public static final Term none() {
 		return none;
 	}
@@ -113,12 +113,10 @@ public final class Constructors {
 	public static Term some(Term arg) {
 		return make(BuiltInConstructorSymbol.SOME, Terms.singletonArray(arg));
 	}
-	
+
 	public static Term tuple(Term... args) {
 		return make(GlobalSymbolManager.lookupTupleSymbol(args.length), args);
 	}
-	
-	
 
 	private static Constructor lookupOrCreateBuiltInConstructor(BuiltInConstructorSymbol sym, Term[] args) {
 		Function<String, Constructor> makeSolverOp = op -> memo.lookupOrCreate(sym, args,
@@ -645,7 +643,7 @@ public final class Constructors {
 			}
 		});
 	}
-	
+
 	private static Constructor makeBvExtract(ParameterizedConstructorSymbol sym, Term[] args) {
 		return memo.lookupOrCreate(sym, args, () -> new AbstractConstructor<ParameterizedConstructorSymbol>(sym, args) {
 			@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Expr.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Expr.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Exprs.ExprVisitor;
 import edu.harvard.seas.pl.formulog.ast.Exprs.ExprVisitorExn;
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitor;
@@ -36,12 +35,12 @@ public interface Expr extends Term {
 	default <I, O> O accept(TermVisitor<I, O> visitor, I in) {
 		return visitor.visit(this, in);
 	}
-	
+
 	@Override
 	default <I, O, E extends Throwable> O accept(TermVisitorExn<I, O, E> visitor, I in) throws E {
 		return visitor.visit(this, in);
 	}
-	
+
 	@Override
 	default boolean containsUnevaluatedTerm() {
 		return true;

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Exprs.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Exprs.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.FunctionCallFactory.FunctionCall;
 
 public final class Exprs {
@@ -32,9 +31,9 @@ public final class Exprs {
 	public static interface ExprVisitor<I, O> {
 
 		O visit(MatchExpr matchExpr, I in);
-		
+
 		O visit(FunctionCall funcCall, I in);
-		
+
 		O visit(LetFunExpr funcDefs, I in);
 
 		O visit(Fold fold, I in);
@@ -44,13 +43,13 @@ public final class Exprs {
 	public static interface ExprVisitorExn<I, O, E extends Throwable> {
 
 		O visit(MatchExpr matchExpr, I in) throws E;
-		
+
 		O visit(FunctionCall funcCall, I in) throws E;
-		
+
 		O visit(LetFunExpr funcDefs, I in) throws E;
-		
+
 		O visit(Fold fold, I in) throws E;
 
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/FP32.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/FP32.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Collections;
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,7 +42,7 @@ public class FP32 extends AbstractTerm implements Primitive<Float>, SmtLibTerm {
 	private FP32(float val) {
 		this.val = val;
 	}
-	
+
 	public static FP32 make(float val) {
 		return Util.lookupOrCreate(memo, val, () -> new FP32(val));
 	}
@@ -52,7 +51,7 @@ public class FP32 extends AbstractTerm implements Primitive<Float>, SmtLibTerm {
 	public Float getVal() {
 		return val;
 	}
-	
+
 	@Override
 	public String toString() {
 		if (Float.isNaN(val)) {
@@ -71,7 +70,7 @@ public class FP32 extends AbstractTerm implements Primitive<Float>, SmtLibTerm {
 	public SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst) {
 		return this;
 	}
-	
+
 	@Override
 	public void toSmtLib(SmtLibShim shim) {
 		if (Float.isNaN(val)) {
@@ -89,7 +88,7 @@ public class FP32 extends AbstractTerm implements Primitive<Float>, SmtLibTerm {
 	public Type getType() {
 		return BuiltInTypes.fp32;
 	}
-	
+
 	@Override
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/FP64.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/FP64.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Collections;
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,16 +42,16 @@ public class FP64 extends AbstractTerm implements Primitive<Double>, SmtLibTerm 
 	private FP64(double val) {
 		this.val = val;
 	}
-	
+
 	public static FP64 make(double val) {
 		return Util.lookupOrCreate(memo, val, () -> new FP64(val));
 	}
-	
+
 	@Override
 	public Double getVal() {
 		return val;
 	}
-	
+
 	@Override
 	public String toString() {
 		if (Double.isNaN(val)) {
@@ -66,7 +65,6 @@ public class FP64 extends AbstractTerm implements Primitive<Double>, SmtLibTerm 
 		}
 		return Double.toString(val);
 	}
-	
 
 	@Override
 	public SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst) {
@@ -90,7 +88,7 @@ public class FP64 extends AbstractTerm implements Primitive<Double>, SmtLibTerm 
 	public Type getType() {
 		return BuiltInTypes.fp64;
 	}
-	
+
 	@Override
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Fold.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Fold.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -50,19 +49,19 @@ public class Fold implements Expr {
 					+ f.getArity() + " arguments, but got the arguments " + Arrays.toString(args) + ").");
 		}
 	}
-	
+
 	public static Fold mk(FunctionSymbol f, Term[] args, FunctionCallFactory funCalls) {
 		return new Fold(f, args, funCalls);
 	}
-	
+
 	public Term[] getArgs() {
 		return args;
 	}
-	
+
 	public FunctionSymbol getFunction() {
 		return f;
 	}
-	
+
 	public FunctionCall getShamCall() {
 		return funCalls.make(f, args);
 	}
@@ -90,7 +89,7 @@ public class Fold implements Expr {
 		}
 		return new Fold(f, newArgs, funCalls);
 	}
-	
+
 	@Override
 	public Term normalize(Substitution s) throws EvaluationException {
 		Term[] newArgs = new Term[args.length];
@@ -139,13 +138,13 @@ public class Fold implements Expr {
 	public <I, O, E extends Throwable> O accept(ExprVisitorExn<I, O, E> visitor, I in) throws E {
 		return visitor.visit(this, in);
 	}
-	
+
 	@Override
 	public String toString() {
 		String s = "fold[" + f + "](";
 		for (int i = 0; i < args.length; ++i) {
 			s += args[i];
-			if (i < args.length -1) {
+			if (i < args.length - 1) {
 				s += ", ";
 			}
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/FunctionCallFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/FunctionCallFactory.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ public final class FunctionCallFactory {
 	public FunctionDefManager getDefManager() {
 		return defManager;
 	}
-	
+
 	public void clearMemoCache() {
 		callMemo.clear();
 	}
@@ -165,7 +164,7 @@ public final class FunctionCallFactory {
 			}
 			return r;
 		}
-		
+
 		private boolean hasSideEffects() {
 			// XXX This is rough, since it doesn't take into account the call
 			// graph (i.e., A could call B which is side effecting, but this
@@ -203,7 +202,7 @@ public final class FunctionCallFactory {
 			}
 			return r;
 		}
-		
+
 		public FunctionCallFactory getFactory() {
 			return FunctionCallFactory.this;
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Functor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Functor.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.ast;
 import java.util.Map;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.symbols.Symbol;
 
 public interface Functor<S extends Symbol> extends Term {
@@ -42,7 +41,7 @@ public interface Functor<S extends Symbol> extends Term {
 			}
 		}
 	}
-	
+
 	@Override
 	default void updateVarCounts(Map<Var, Integer> counts) {
 		for (Term arg : getArgs()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/I32.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/I32.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Collections;
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,11 +38,11 @@ public class I32 extends AbstractTerm implements Primitive<Integer>, SmtLibTerm 
 
 	private static final Map<Integer, I32> memo = new ConcurrentHashMap<>();
 	private final int val;
-	
+
 	private I32(int val) {
 		this.val = val;
 	}
-	
+
 	public static I32 make(int val) {
 		return Util.lookupOrCreate(memo, val, () -> new I32(val));
 	}
@@ -52,7 +51,7 @@ public class I32 extends AbstractTerm implements Primitive<Integer>, SmtLibTerm 
 	public Integer getVal() {
 		return val;
 	}
-	
+
 	@Override
 	public String toString() {
 		return Integer.toString(val);
@@ -62,7 +61,7 @@ public class I32 extends AbstractTerm implements Primitive<Integer>, SmtLibTerm 
 	public SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst) {
 		return this;
 	}
-	
+
 	@Override
 	public void toSmtLib(SmtLibShim shim) {
 		shim.print("#x" + String.format("%08x", val));
@@ -72,11 +71,10 @@ public class I32 extends AbstractTerm implements Primitive<Integer>, SmtLibTerm 
 	public Type getType() {
 		return BuiltInTypes.i32;
 	}
-	
+
 	@Override
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();
 	}
 
 }
-

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/I64.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/I64.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Collections;
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,11 +38,11 @@ public class I64 extends AbstractTerm implements Primitive<Long>, SmtLibTerm {
 
 	private static final Map<Long, I64> memo = new ConcurrentHashMap<>();
 	private final long val;
-	
+
 	private I64(long val) {
 		this.val = val;
 	}
-	
+
 	public static I64 make(long val) {
 		return Util.lookupOrCreate(memo, val, () -> new I64(val));
 	}
@@ -52,7 +51,7 @@ public class I64 extends AbstractTerm implements Primitive<Long>, SmtLibTerm {
 	public Long getVal() {
 		return val;
 	}
-	
+
 	@Override
 	public String toString() {
 		return Long.toString(val) + "L";
@@ -62,7 +61,7 @@ public class I64 extends AbstractTerm implements Primitive<Long>, SmtLibTerm {
 	public SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst) {
 		return this;
 	}
-	
+
 	@Override
 	public void toSmtLib(SmtLibShim shim) {
 		shim.print("#x" + String.format("%016x", val));
@@ -72,7 +71,7 @@ public class I64 extends AbstractTerm implements Primitive<Long>, SmtLibTerm {
 	public Type getType() {
 		return BuiltInTypes.i64;
 	}
-	
+
 	@Override
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/LetFunExpr.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/LetFunExpr.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -33,10 +32,10 @@ import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
 
 public class LetFunExpr implements Expr {
-	
+
 	private final Set<NestedFunctionDef> defs;
 	private final Term letBody;
-	
+
 	private LetFunExpr(Set<NestedFunctionDef> defs, Term letBody) {
 		Set<NestedFunctionDef> freshDefs = new HashSet<>();
 		for (NestedFunctionDef def : defs) {
@@ -45,15 +44,15 @@ public class LetFunExpr implements Expr {
 		this.defs = Collections.unmodifiableSet(freshDefs);
 		this.letBody = letBody;
 	}
-	
+
 	public static LetFunExpr make(Set<NestedFunctionDef> defs, Term letBody) {
 		return new LetFunExpr(defs, letBody);
 	}
-	
+
 	public Set<NestedFunctionDef> getDefs() {
 		return defs;
 	}
-	
+
 	public Term getLetBody() {
 		return letBody;
 	}
@@ -141,7 +140,7 @@ public class LetFunExpr implements Expr {
 			return false;
 		return true;
 	}
-	
+
 	@Override
 	public String toString() {
 		String s = "let fun ";

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Literal.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Literal.java
@@ -20,9 +20,8 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 public interface Literal {
-	
+
 	Term[] getArgs();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/MatchClause.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/MatchClause.java
@@ -30,12 +30,11 @@ import edu.harvard.seas.pl.formulog.unification.SimpleSubstitution;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
 import edu.harvard.seas.pl.formulog.util.Pair;
 
-
 public class MatchClause {
 
 	private final Term lhs;
 	private final Term rhs;
-	
+
 	public static MatchClause make(Term lhs, Term rhs) {
 		if (!checkForRepeatVariables(lhs)) {
 			throw new IllegalArgumentException("Cannot repeat variables in patterns: " + lhs);
@@ -53,7 +52,7 @@ public class MatchClause {
 	private static boolean checkForRepeatVariables(Term pat) {
 		return pat.accept(varsDistinct, new HashSet<>());
 	}
-	
+
 	private static TermVisitor<Set<String>, Boolean> varsDistinct = new TermVisitor<Set<String>, Boolean>() {
 
 		@Override
@@ -82,9 +81,9 @@ public class MatchClause {
 		public Boolean visit(Expr e, Set<String> in) {
 			throw new AssertionError("Shouldn't be expressions in patterns");
 		}
-		
+
 	};
-	
+
 	MatchClause(Term lhs, Term rhs) {
 		this.lhs = lhs;
 		this.rhs = rhs;
@@ -119,7 +118,7 @@ public class MatchClause {
 		}
 		return true;
 	}
-	
+
 	public Term getLhs() {
 		return lhs;
 	}
@@ -158,5 +157,5 @@ public class MatchClause {
 			return false;
 		return true;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Model.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Model.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +32,7 @@ import edu.harvard.seas.pl.formulog.util.Util;
 public class Model extends AbstractTerm implements Primitive<Map<SolverVariable, Term>> {
 
 	private static final Map<Map<SolverVariable, Term>, Model> memo = new ConcurrentHashMap<>();
-	
+
 	private final Map<SolverVariable, Term> m;
 
 	private Model(Map<SolverVariable, Term> m) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/NestedFunctionDef.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/NestedFunctionDef.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.ArrayList;
 
-
 import java.util.Collections;
 import java.util.List;
 
@@ -45,11 +44,11 @@ public class NestedFunctionDef {
 					"Mismatch between arity and number of given parameters in nested function definition: " + sym);
 		}
 	}
-	
+
 	public static NestedFunctionDef make(FunctionSymbol sym, List<Var> params, Term body) {
 		return new NestedFunctionDef(sym, params, body);
 	}
-	
+
 	public NestedFunctionDef applySubstitution(Substitution s) {
 		Substitution s2 = new SimpleSubstitution();
 		for (Var x : s.iterateKeys()) {
@@ -59,7 +58,7 @@ public class NestedFunctionDef {
 		}
 		return make(sym, params, body.applySubstitution(s2));
 	}
-	
+
 	public NestedFunctionDef freshen() {
 		List<Var> newParams = new ArrayList<>();
 		Substitution s = new SimpleSubstitution();
@@ -70,15 +69,15 @@ public class NestedFunctionDef {
 		}
 		return make(sym, newParams, body.applySubstitution(s));
 	}
-	
+
 	public FunctionSymbol getSymbol() {
 		return sym;
 	}
-	
+
 	public List<Var> getParams() {
 		return params;
 	}
-	
+
 	public Term getBody() {
 		return body;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/OpaqueSet.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/OpaqueSet.java
@@ -39,28 +39,28 @@ import edu.harvard.seas.pl.formulog.util.Util;
 public class OpaqueSet extends AbstractTerm implements Primitive<Set<Term>> {
 
 	private final PSet<Term> s;
-	
+
 	private OpaqueSet(PSet<Term> s) {
 		this.s = s;
 	}
 
 	private static final OpaqueSet empty;
-	
+
 	private static final Map<PSet<Term>, OpaqueSet> memo = new ConcurrentHashMap<>();
-	
+
 	static {
 		PSet<Term> mt = MapPSet.from(HashPMap.empty(IntTreePMap.empty()));
 		empty = make(mt);
 	}
-	
+
 	public static OpaqueSet empty() {
 		return empty;
 	}
-	
+
 	public static OpaqueSet singleton(Term t) {
 		return empty.plus(t);
 	}
-	
+
 	public static OpaqueSet fromCollection(Collection<Term> c) {
 		PSet<Term> s = MapPSet.from(HashPMap.empty(IntTreePMap.empty()));
 		for (Term t : c) {
@@ -68,43 +68,43 @@ public class OpaqueSet extends AbstractTerm implements Primitive<Set<Term>> {
 		}
 		return make(s);
 	}
-	
+
 	private static OpaqueSet make(PSet<Term> s) {
 		return Util.lookupOrCreate(memo, s, () -> new OpaqueSet(s));
 	}
-	
+
 	public Collection<Term> getCollection() {
 		return s;
 	}
-	
+
 	public boolean member(Term t) {
 		return s.contains(t);
 	}
-	
+
 	public OpaqueSet plus(Term t) {
 		return make(s.plus(t));
 	}
-	
+
 	public OpaqueSet minus(Term t) {
 		return make(s.minus(t));
 	}
-	
+
 	public OpaqueSet union(OpaqueSet other) {
 		return make(s.plusAll(other.s));
 	}
-	
+
 	public OpaqueSet diff(OpaqueSet other) {
 		return make(s.minusAll(other.s));
 	}
-	
+
 	public int size() {
 		return s.size();
 	}
-	
+
 	public boolean isEmpty() {
 		return s.isEmpty();
 	}
-	
+
 	public Pair<Term, OpaqueSet> choose() {
 		if (isEmpty()) {
 			return null;
@@ -112,7 +112,7 @@ public class OpaqueSet extends AbstractTerm implements Primitive<Set<Term>> {
 		Term t = s.iterator().next();
 		return new Pair<>(t, make(s.minus(t)));
 	}
-	
+
 	public boolean containsAll(OpaqueSet other) {
 		return s.containsAll(other.s);
 	}
@@ -126,7 +126,7 @@ public class OpaqueSet extends AbstractTerm implements Primitive<Set<Term>> {
 	public Type getType() {
 		return BuiltInTypes.opaqueSet(BuiltInTypes.a);
 	}
-	
+
 	@Override
 	public String toString() {
 		String str = s.toString();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Primitive.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Primitive.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.ast;
 import java.util.Map;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitor;
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitorExn;
 import edu.harvard.seas.pl.formulog.types.Types.Type;
@@ -32,7 +31,7 @@ import edu.harvard.seas.pl.formulog.unification.Substitution;
 public interface Primitive<T> extends Term {
 
 	T getVal();
-	
+
 	@Override
 	default <I, O> O accept(TermVisitor<I, O> v, I in) {
 		return v.visit(this, in);
@@ -52,27 +51,27 @@ public interface Primitive<T> extends Term {
 	public default Term applySubstitution(Substitution s) {
 		return this;
 	}
-	
+
 	@Override
 	public default Term normalize(Substitution s) {
 		return this;
 	}
-	
+
 	@Override
 	public default boolean isGround() {
 		return true;
 	}
-	
+
 	Type getType();
-	
+
 	@Override
 	public default void varSet(Set<Var> acc) {
 		// do nothing
 	}
-	
+
 	@Override
 	public default void updateVarCounts(Map<Var, Integer> counts) {
 		// do nothing
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Program.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Program.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.functions.FunctionDef;
@@ -33,27 +32,27 @@ import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 public interface Program<Q extends Literal, R extends Rule<Q, ?>> {
 
 	Set<FunctionSymbol> getFunctionSymbols();
-	
+
 	Set<RelationSymbol> getFactSymbols();
-	
+
 	Set<RelationSymbol> getRuleSymbols();
-	
+
 	FunctionDef getDef(FunctionSymbol sym);
-	
+
 	Set<Term[]> getFacts(RelationSymbol sym);
 
 	Set<R> getRules(RelationSymbol sym);
-	
+
 	SymbolManager getSymbolManager();
-	
+
 	boolean hasQuery();
-	
+
 	Q getQuery();
-	
+
 	FunctionCallFactory getFunctionCallFactory();
-	
+
 	Set<ConstructorSymbol> getUninterpretedFunctionSymbols();
-	
+
 	Set<TypeSymbol> getTypeSymbols();
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Rule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Rule.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public interface Rule<H extends Literal, B extends Literal> extends Iterable<B> {
 
 	H getHead();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/SmtLibTerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/SmtLibTerm.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Set;
 
-
 import org.pcollections.PMap;
 
 import edu.harvard.seas.pl.formulog.ast.Constructors.SolverVariable;
@@ -31,9 +30,9 @@ import edu.harvard.seas.pl.formulog.smt.SmtLibShim;
 public interface SmtLibTerm extends Term {
 
 	void toSmtLib(SmtLibShim shim);
-	
+
 	SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst);
-	
+
 	Set<SolverVariable> freeVars();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/StringTerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/StringTerm.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Collections;
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,11 +38,11 @@ public class StringTerm extends AbstractTerm implements Primitive<String>, SmtLi
 
 	private static final Map<String, StringTerm> memo = new ConcurrentHashMap<>();
 	private final String val;
-	
+
 	private StringTerm(String val) {
 		this.val = val;
 	}
-	
+
 	public static StringTerm make(String val) {
 		return Util.lookupOrCreate(memo, val, () -> new StringTerm(val));
 	}
@@ -52,7 +51,7 @@ public class StringTerm extends AbstractTerm implements Primitive<String>, SmtLi
 	public String getVal() {
 		return val;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "\"" + val + "\"";
@@ -62,7 +61,7 @@ public class StringTerm extends AbstractTerm implements Primitive<String>, SmtLi
 	public SmtLibTerm substSolverTerms(PMap<SolverVariable, SmtLibTerm> subst) {
 		return this;
 	}
-	
+
 	@Override
 	public void toSmtLib(SmtLibShim shim) {
 		String s = val.replace("\"", "\"\"");
@@ -73,7 +72,7 @@ public class StringTerm extends AbstractTerm implements Primitive<String>, SmtLi
 	public Type getType() {
 		return BuiltInTypes.string;
 	}
-	
+
 	@Override
 	public Set<SolverVariable> freeVars() {
 		return Collections.emptySet();

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Term.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Term.java
@@ -24,36 +24,35 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitor;
 import edu.harvard.seas.pl.formulog.ast.Terms.TermVisitorExn;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
 
 public interface Term {
-	
+
 	<I, O> O accept(TermVisitor<I, O> v, I in);
-	
+
 	<I, O, E extends Throwable> O accept(TermVisitorExn<I, O, E> v, I in) throws E;
-	
+
 	boolean isGround();
 
 	boolean containsUnevaluatedTerm();
 
 	Term applySubstitution(Substitution s);
-	
+
 	Term normalize(Substitution s) throws EvaluationException;
-	
+
 	void varSet(Set<Var> acc);
-	
+
 	default Set<Var> varSet() {
 		Set<Var> vars = new HashSet<>();
 		varSet(vars);
 		return vars;
 	}
-	
+
 	void updateVarCounts(Map<Var, Integer> counts);
-	
+
 	int getId();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/UnificationPredicate.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/UnificationPredicate.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.ast;
 
 import java.util.Arrays;
 
-
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralExnVisitor;
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralVisitor;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
@@ -35,19 +34,19 @@ public class UnificationPredicate implements ComplexLiteral {
 	public static UnificationPredicate make(Term lhs, Term rhs, boolean negated) {
 		return new UnificationPredicate(new Term[] { lhs, rhs }, negated);
 	}
-	
+
 	private UnificationPredicate(Term[] args, boolean negated) {
 		this.args = args;
 		this.negated = negated;
 	}
-	
+
 	@Override
 	public Term[] getArgs() {
 		return args;
 	}
-	
+
 	public Term getLhs() {
-		return args[0] ;
+		return args[0];
 	}
 
 	public Term getRhs() {
@@ -105,5 +104,5 @@ public class UnificationPredicate implements ComplexLiteral {
 			return false;
 		return true;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/UserPredicate.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/UserPredicate.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Arrays;
 
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralExnVisitor;
@@ -33,11 +32,11 @@ public class UserPredicate implements ComplexLiteral {
 	private final RelationSymbol symbol;
 	private final Term[] args;
 	private final boolean negated;
-	
+
 	public static UserPredicate make(RelationSymbol symbol, Term[] args, boolean negated) {
 		return new UserPredicate(symbol, args, negated);
 	}
-	
+
 	private UserPredicate(RelationSymbol symbol, Term[] args, boolean negated) {
 		this.symbol = symbol;
 		this.args = args;
@@ -52,7 +51,7 @@ public class UserPredicate implements ComplexLiteral {
 	public Term[] getArgs() {
 		return args;
 	}
-	
+
 	@Override
 	public boolean isNegated() {
 		return negated;
@@ -128,5 +127,5 @@ public class UserPredicate implements ComplexLiteral {
 	public <I, O, E extends Throwable> O accept(ComplexLiteralExnVisitor<I, O, E> visitor, I input) throws E {
 		return visitor.visit(this, input);
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/ast/Var.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/ast/Var.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.ast;
  * #L%
  */
 
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,29 +33,29 @@ import edu.harvard.seas.pl.formulog.util.Util;
 public class Var extends AbstractTerm implements Term {
 
 	static final AtomicInteger cnt = new AtomicInteger();
-	
+
 	private final String name;
-	
+
 	protected Var(String name) {
 		this.name = name;
 	}
-	
+
 	public static Var fresh(String name) {
 		return new Var(name);
 	}
-	
+
 	public static Var fresh() {
 		return new Var("$" + cnt.getAndIncrement());
 	}
-	
+
 	public boolean isUnderscore() {
 		return name.equals("_");
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-	
+
 	@Override
 	public String toString() {
 		return name;
@@ -110,9 +109,9 @@ public class Var extends AbstractTerm implements Term {
 	}
 
 	private static final Var hole = new Var("??");
-	
+
 	public static Var makeHole() {
 		return hole;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/BTreeRelationStruct.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/BTreeRelationStruct.java
@@ -38,464 +38,464 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 public class BTreeRelationStruct implements RelationStruct {
 
-    private static AtomicInteger cnt = new AtomicInteger();
-    private AtomicInteger patCnt = new AtomicInteger();
-
-    private final int arity;
-    private final int masterIndex;
-    private final Map<Integer, IndexInfo> indexInfo;
-    private final String name;
-    private final Map<List<BindingType>, Integer> pats = new ConcurrentHashMap<>();
-
-    public BTreeRelationStruct(int arity, int masterIndex, Map<Integer, IndexInfo> indexInfo) {
-        this.arity = arity;
-        this.masterIndex = masterIndex;
-        this.indexInfo = indexInfo;
-        name = "btree_relation_" + cnt.getAndIncrement() + "_t";
-    }
-
-    @Override
-    public String getName() {
-        return "rels::" + name;
-    }
-
-    @Override
-    public void declare(PrintWriter out) {
-        out.print("struct ");
-        out.print(name);
-        out.println(" {");
-        declareArity(out);
-        declareIndices(out);
-        declareContextStruct(out);
-        declareCreateContext(out);
-        declareContains(out);
-        declareInsert(out);
-        declareInsertAll(out);
-        declareLookup(out);
-        declareEmpty(out);
-        declarePurge(out);
-        declarePrint(out);
-        declarePartition(out);
-        declareBegin(out);
-        declareEnd(out);
-        declareSize(out);
-        out.println("};");
-    }
-
-    private void declareArity(PrintWriter out) {
-        out.println("  enum { arity = " + arity + " };");
-    }
-
-    private void declareIndices(PrintWriter out) {
-        for (Map.Entry<Integer, IndexInfo> e : indexInfo.entrySet()) {
-            int index = e.getKey();
-            String type = mkIndexType(index);
-            out.print("  using " + type + " = souffle::btree_set<");
-            String cmp = mkComparator(e.getValue().getComparatorOrder());
-            out.println(mkTupleType() + ", " + cmp + ">;");
-            out.println("  " + type + " " + mkIndexName(index) + ";");
-            index++;
-        }
-        out.println("  using iterator = " + mkIndexType(masterIndex) + "::iterator;");
-    }
-
-    private void declareContextStruct(PrintWriter out) {
-        out.println("  struct context {");
-        for (int index : indexInfo.keySet()) {
-            out.println("    " + mkIndexType(index) + "::operation_hints " + mkHintName(index) + ";");
-        }
-        out.println("  };");
-    }
-
-    private void declareCreateContext(PrintWriter out) {
-        out.println("  inline context create_context() const { return context(); }");
-    }
-
-    private String mkHintName(int index) {
-        return mkIndexName(index) + "_hints";
-    }
-
-    private void declarePrint(PrintWriter out) {
-        out.println("  inline void print(const string& name, bool sorted = true) const {");
-        CppVar m = CppVar.mk(mkIndexName(masterIndex));
-        CppFuncCall.mk("print_relation", CppVar.mk("name"), CppVar.mk("sorted"), m).toStmt().println(out, 2);
-        out.println("  }");
-    }
-
-    private void declarePurge(PrintWriter out) {
-        out.println("  inline void purge() {");
-        for (int i = 0; i < indexInfo.size(); ++i) {
-            CppMethodCall.mk(CppVar.mk(mkIndexName(i)), "clear").toStmt().println(out, 2);
-        }
-        out.println("  }");
-    }
-
-    private void declareContains(PrintWriter out) {
-        for (int i = 0; i < indexInfo.size(); ++i) {
-            declareContains(out, i);
-        }
-    }
-
-    private void declareContains(PrintWriter out, int idx) {
-        declareContainsHint(out, idx);
-        declareContainsNoHint(out, idx);
-    }
-
-    private CppExpr mkHint(int idx) {
-        return CppAccess.mk(CppVar.mk("h"), mkHintName(idx));
-    }
-
-    private void declareContainsHint(PrintWriter out, int idx) {
-        out.println("  inline bool " + mkContainsName(idx) + "(const " + mkTupleType() + "& tup, context& h) const {");
-        CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(idx)), "contains", CppVar.mk("tup"), mkHint(idx));
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareContainsNoHint(PrintWriter out, int idx) {
-        String name = mkContainsName(idx);
-        out.println("  inline bool " + name + "(const " + mkTupleType() + "& tup) const {");
-        CppCtor.mk("context", "h").println(out, 2);
-        CppExpr call = CppFuncCall.mk(name, CppVar.mk("tup"), CppVar.mk("h"));
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareEmpty(PrintWriter out) {
-        out.println("  inline bool empty() const {");
-        CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "empty");
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareInsert(PrintWriter out) {
-        declareInsertHint(out);
-        declareInsertNoHint(out);
-    }
-
-    private void declareInsertHint(PrintWriter out) {
-        out.println("  inline bool insert(const " + mkTupleType() + "& tup, context& h) {");
-        CppVar tup = CppVar.mk("tup");
-        List<CppStmt> inserts = new ArrayList<>();
-        for (int i = 0; i < indexInfo.size(); ++i) {
-            if (i != masterIndex) {
-                inserts.add(CppMethodCall.mk(CppVar.mk(mkIndexName(i)), "insert", tup, mkHint(i)).toStmt());
-            }
-        }
-        inserts.add(CppReturn.mk(CppConst.mkTrue()));
-        CppStmt body = CppSeq.mk(inserts);
-        CppExpr guard = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "insert", tup, mkHint(masterIndex));
-        CppIf.mk(guard, body, CppReturn.mk(CppConst.mkFalse())).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareInsertNoHint(PrintWriter out) {
-        out.println("  inline bool insert(const " + mkTupleType() + "& tup) {");
-        CppCtor.mk("context", "h").println(out, 2);
-        CppExpr call = CppFuncCall.mk("insert", CppVar.mk("tup"), CppVar.mk("h"));
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareInsertAll(PrintWriter out) {
-        declareGenericInsertAll(out);
-    }
-
-    private void declareGenericInsertAll(PrintWriter out) {
-        out.println("  template<typename T> inline void insertAll(T& other) {");
-        CppCtor.mk("context", "h").println(out, 2);
-        CppExpr call = CppFuncCall.mk("insert", CppVar.mk("cur"), CppVar.mk("h"));
-        CppForEach.mk("cur", CppVar.mk("other"), call.toStmt()).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareLookup(PrintWriter out) {
-        for (Map.Entry<Integer, IndexInfo> e : indexInfo.entrySet()) {
-            BindingType[] pat = e.getValue().getPattern();
-            int idx = e.getKey();
-            declareLookupHint(out, idx, pat);
-            declareLookupNoHint(out, idx, pat);
-        }
-    }
-
-    private void declareLookupHint(PrintWriter out, int idx, BindingType[] pat) {
-        out.print("  inline souffle::range<" + mkIndexType(idx) + "::iterator> ");
-        out.println(mkLookupName(idx, pat) + "(const " + mkTupleType() + "& key, context& h) const {");
-        List<Integer> emptyArgs = new ArrayList<>();
-        int i = 0;
-        for (BindingType ty : pat) {
-            switch (ty) {
-                case BOUND:
-                    break;
-                case FREE:
-                case IGNORED:
-                    emptyArgs.add(i);
-            }
-            i++;
-        }
-        if (emptyArgs.size() == pat.length) {
-            mkLookupAll(idx).println(out, 2);
-        } else {
-            mkLookupSome(idx, emptyArgs).println(out, 2);
-        }
-        out.println("  }");
-    }
-
-    private void declareLookupNoHint(PrintWriter out, int idx, BindingType[] pat) {
-        String name = mkLookupName(idx, pat);
-        out.print("  inline souffle::range<" + mkIndexType(idx) + "::iterator> ");
-        out.println(name + "(const " + mkTupleType() + "& key) const {");
-        CppCtor.mk("context", "h").println(out, 2);
-        CppExpr call = CppFuncCall.mk(name, CppVar.mk("key"), CppVar.mk("h"));
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private CppStmt mkLookupAll(int idx) {
-        CppVar index = CppVar.mk(mkIndexName(idx));
-        CppExpr begin = CppMethodCall.mk(index, "begin");
-        CppExpr end = CppMethodCall.mk(index, "end");
-        return CppReturn.mk(CppFuncCall.mk("souffle::make_range", begin, end));
-    }
-
-    private CppStmt mkLookupSome(int idx, List<Integer> emptyArgs) {
-        CppVar index = CppVar.mk(mkIndexName(idx));
-        List<CppStmt> stmts = new ArrayList<>();
-        stmts.add(CppCtor.mk(mkTupleType(), "lo", CppVar.mk("key")));
-        stmts.add(CppCtor.mk(mkTupleType(), "hi", CppVar.mk("key")));
-        CppVar lo = CppVar.mk("lo");
-        CppVar hi = CppVar.mk("hi");
-        CppVar minTerm = CppVar.mk("min_term");
-        CppVar maxTerm = CppVar.mk("max_term");
-        for (int i : emptyArgs) {
-            CppExpr subscript = CppConst.mkInt(i);
-            stmts.add(CppBinop.mkAssign(CppSubscript.mk(lo, subscript), minTerm).toStmt());
-            stmts.add(CppBinop.mkAssign(CppSubscript.mk(hi, subscript), maxTerm).toStmt());
-        }
-        CppExpr getLower = CppMethodCall.mk(index, "lower_bound", lo, mkHint(idx));
-        CppExpr getUpper = CppMethodCall.mk(index, "upper_bound", hi, mkHint(idx));
-        CppExpr call = CppFuncCall.mk("souffle::make_range", getLower, getUpper);
-        stmts.add(CppReturn.mk(call));
-        return CppSeq.mk(stmts);
-    }
-
-    private void declareBegin(PrintWriter out) {
-        out.println("  inline iterator begin() const {");
-        CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "begin");
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareEnd(PrintWriter out) {
-        out.println("  inline iterator end() const {");
-        CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "end");
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private void declareSize(PrintWriter out) {
-        out.println("  inline size_t size() const {");
-        CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "size");
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    private String mkIndexType(int index) {
-        return mkIndexName(index) + "_t";
-    }
-
-    private String mkIndexName(int index) {
-        return "index_" + index;
-    }
-
-    private String mkTupleType() {
-        return "Tuple<" + arity + ">";
-    }
-
-    private String mkLookupName(int index, BindingType[] pat) {
-        return "lookup_" + index + "_" + Util.lookupOrCreate(pats, Arrays.asList(pat), () -> patCnt.getAndIncrement());
-    }
-
-    private String mkContainsName(int index) {
-        return "contains_" + index;
-    }
-
-    private String mkComparator(List<Integer> order) {
-        String s = "Comparator<";
-        for (Iterator<Integer> it = order.iterator(); it.hasNext(); ) {
-            s += it.next();
-            if (it.hasNext()) {
-                s += ", ";
-            }
-        }
-        return s + ">";
-    }
-
-    private void declarePartition(PrintWriter out) {
-        out.println("  inline vector<souffle::range<iterator>> partition() const {");
-        CppVar m = CppVar.mk(mkIndexName(masterIndex));
-        CppExpr call = CppMethodCall.mk(m, "getChunks", CppConst.mkInt(400));
-        CppReturn.mk(call).println(out, 2);
-        out.println("  }");
-    }
-
-    @Override
-    public Relation mkRelation(RelationSymbol sym) {
-        return new RelationImpl(sym);
-    }
-
-    private class RelationImpl implements Relation {
-
-        private final String name;
-        private final CppVar nameVar;
-
-        public RelationImpl(RelationSymbol sym) {
-            String s = "";
-            if (sym instanceof DeltaSymbol) {
-                sym = ((DeltaSymbol) sym).getBaseSymbol();
-                s += "_delta";
-            } else if (sym instanceof NewSymbol) {
-                sym = ((NewSymbol) sym).getBaseSymbol();
-                s += "_new";
-            }
-            name = CodeGenUtil.mkName(sym) + s;
-            nameVar = CppVar.mk("rels::" + name);
-        }
-
-        @Override
-        public void print(PrintWriter out) {
-            nameVar.print(out);
-        }
-
-        @Override
-        public CppStmt mkDecl() {
-            return new CppStmt() {
-
-                @Override
-                public void println(PrintWriter out, int indent) {
-                    CodeGenUtil.printIndent(out, indent);
-                    out.print("inline auto " + name);
-                    out.println(" = make_unique<" + BTreeRelationStruct.this.name + ">();");
-                }
-
-            };
-        }
-
-        @Override
-        public CppExpr mkContains(CppExpr expr, boolean useHints) {
-            return mkContains(masterIndex, expr, useHints);
-        }
-
-        @Override
-        public CppExpr mkContains(int idx, CppExpr expr, boolean useHints) {
-            List<CppExpr> args = new ArrayList<>();
-            args.add(expr);
-            if (useHints) {
-                args.add(CppVar.mk(mkContextName()));
-            }
-            return CppMethodCall.mkThruPtr(nameVar, mkContainsName(idx), args);
-        }
-
-        @Override
-        public CppExpr mkInsert(CppExpr expr, boolean useHints) {
-            List<CppExpr> args = new ArrayList<>();
-            args.add(expr);
-            if (useHints) {
-                args.add(CppVar.mk(mkContextName()));
-            }
-            return CppMethodCall.mkThruPtr(nameVar, "insert", args);
-        }
-
-        @Override
-        public CppExpr mkInsertAll(CppExpr expr) {
-            return CppMethodCall.mkThruPtr(nameVar, "insertAll", expr);
-        }
-
-        @Override
-        public CppExpr mkIsEmpty() {
-            return CppMethodCall.mkThruPtr(nameVar, "empty");
-        }
-
-        @Override
-        public CppStmt mkDeclTuple(String name) {
-            return CppCtor.mk(mkTupleType(), name);
-        }
-
-        @Override
-        public CppStmt mkDeclTuple(String name, List<CppExpr> exprs) {
-            return CppCtor.mkInitializer(mkTupleType(), name, exprs);
-        }
-
-        @Override
-        public CppExpr mkTuple(List<CppExpr> exprs) {
-            assert exprs.size() == arity;
-            return new CppExpr() {
-
-                @Override
-                public void print(PrintWriter out) {
-                    out.print(mkTupleType());
-                    out.print("{");
-                    CodeGenUtil.printSeparated(exprs, ", ", out);
-                    out.print("}");
-                }
-
-            };
-        }
-
-        @Override
-        public CppExpr mkTupleAccess(CppExpr tup, CppExpr idx) {
-            return CppSubscript.mk(tup, idx);
-        }
-
-        @Override
-        public CppStmt mkPrint() {
-            return CppMethodCall.mkThruPtr(nameVar, "print", CppConst.mkString(name)).toStmt();
-        }
-
-        @Override
-        public CppExpr mkPartition() {
-            return CppMethodCall.mkThruPtr(nameVar, "partition");
-        }
-
-        @Override
-        public CppStmt mkPurge() {
-            return CppMethodCall.mkThruPtr(nameVar, "purge").toStmt();
-        }
-
-        @Override
-        public CppExpr mkLookup(int idx, BindingType[] pat, CppExpr key, boolean useHints) {
-            List<CppExpr> args = new ArrayList<>();
-            args.add(key);
-            if (useHints) {
-                args.add(CppVar.mk(mkContextName()));
-            }
-            return CppMethodCall.mkThruPtr(nameVar, mkLookupName(idx, pat), args);
-        }
-
-        @Override
-        public CppExpr mkSize() {
-            return CppMethodCall.mkThruPtr(nameVar, "size");
-        }
-
-        @Override
-        public RelationStruct getStruct() {
-            return BTreeRelationStruct.this;
-        }
-
-        private String mkContextName() {
-            return "_" + name + "_context";
-        }
-
-        @Override
-        public CppStmt mkDeclContext() {
-            return CppDecl.mk(mkContextName(), CppMethodCall.mkThruPtr(nameVar, "create_context"));
-        }
-
-        @Override
-        public String toString() {
-            return "<" + name + ">";
-        }
-
-    }
+	private static AtomicInteger cnt = new AtomicInteger();
+	private AtomicInteger patCnt = new AtomicInteger();
+
+	private final int arity;
+	private final int masterIndex;
+	private final Map<Integer, IndexInfo> indexInfo;
+	private final String name;
+	private final Map<List<BindingType>, Integer> pats = new ConcurrentHashMap<>();
+
+	public BTreeRelationStruct(int arity, int masterIndex, Map<Integer, IndexInfo> indexInfo) {
+		this.arity = arity;
+		this.masterIndex = masterIndex;
+		this.indexInfo = indexInfo;
+		name = "btree_relation_" + cnt.getAndIncrement() + "_t";
+	}
+
+	@Override
+	public String getName() {
+		return "rels::" + name;
+	}
+
+	@Override
+	public void declare(PrintWriter out) {
+		out.print("struct ");
+		out.print(name);
+		out.println(" {");
+		declareArity(out);
+		declareIndices(out);
+		declareContextStruct(out);
+		declareCreateContext(out);
+		declareContains(out);
+		declareInsert(out);
+		declareInsertAll(out);
+		declareLookup(out);
+		declareEmpty(out);
+		declarePurge(out);
+		declarePrint(out);
+		declarePartition(out);
+		declareBegin(out);
+		declareEnd(out);
+		declareSize(out);
+		out.println("};");
+	}
+
+	private void declareArity(PrintWriter out) {
+		out.println("  enum { arity = " + arity + " };");
+	}
+
+	private void declareIndices(PrintWriter out) {
+		for (Map.Entry<Integer, IndexInfo> e : indexInfo.entrySet()) {
+			int index = e.getKey();
+			String type = mkIndexType(index);
+			out.print("  using " + type + " = souffle::btree_set<");
+			String cmp = mkComparator(e.getValue().getComparatorOrder());
+			out.println(mkTupleType() + ", " + cmp + ">;");
+			out.println("  " + type + " " + mkIndexName(index) + ";");
+			index++;
+		}
+		out.println("  using iterator = " + mkIndexType(masterIndex) + "::iterator;");
+	}
+
+	private void declareContextStruct(PrintWriter out) {
+		out.println("  struct context {");
+		for (int index : indexInfo.keySet()) {
+			out.println("    " + mkIndexType(index) + "::operation_hints " + mkHintName(index) + ";");
+		}
+		out.println("  };");
+	}
+
+	private void declareCreateContext(PrintWriter out) {
+		out.println("  inline context create_context() const { return context(); }");
+	}
+
+	private String mkHintName(int index) {
+		return mkIndexName(index) + "_hints";
+	}
+
+	private void declarePrint(PrintWriter out) {
+		out.println("  inline void print(const string& name, bool sorted = true) const {");
+		CppVar m = CppVar.mk(mkIndexName(masterIndex));
+		CppFuncCall.mk("print_relation", CppVar.mk("name"), CppVar.mk("sorted"), m).toStmt().println(out, 2);
+		out.println("  }");
+	}
+
+	private void declarePurge(PrintWriter out) {
+		out.println("  inline void purge() {");
+		for (int i = 0; i < indexInfo.size(); ++i) {
+			CppMethodCall.mk(CppVar.mk(mkIndexName(i)), "clear").toStmt().println(out, 2);
+		}
+		out.println("  }");
+	}
+
+	private void declareContains(PrintWriter out) {
+		for (int i = 0; i < indexInfo.size(); ++i) {
+			declareContains(out, i);
+		}
+	}
+
+	private void declareContains(PrintWriter out, int idx) {
+		declareContainsHint(out, idx);
+		declareContainsNoHint(out, idx);
+	}
+
+	private CppExpr mkHint(int idx) {
+		return CppAccess.mk(CppVar.mk("h"), mkHintName(idx));
+	}
+
+	private void declareContainsHint(PrintWriter out, int idx) {
+		out.println("  inline bool " + mkContainsName(idx) + "(const " + mkTupleType() + "& tup, context& h) const {");
+		CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(idx)), "contains", CppVar.mk("tup"), mkHint(idx));
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareContainsNoHint(PrintWriter out, int idx) {
+		String name = mkContainsName(idx);
+		out.println("  inline bool " + name + "(const " + mkTupleType() + "& tup) const {");
+		CppCtor.mk("context", "h").println(out, 2);
+		CppExpr call = CppFuncCall.mk(name, CppVar.mk("tup"), CppVar.mk("h"));
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareEmpty(PrintWriter out) {
+		out.println("  inline bool empty() const {");
+		CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "empty");
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareInsert(PrintWriter out) {
+		declareInsertHint(out);
+		declareInsertNoHint(out);
+	}
+
+	private void declareInsertHint(PrintWriter out) {
+		out.println("  inline bool insert(const " + mkTupleType() + "& tup, context& h) {");
+		CppVar tup = CppVar.mk("tup");
+		List<CppStmt> inserts = new ArrayList<>();
+		for (int i = 0; i < indexInfo.size(); ++i) {
+			if (i != masterIndex) {
+				inserts.add(CppMethodCall.mk(CppVar.mk(mkIndexName(i)), "insert", tup, mkHint(i)).toStmt());
+			}
+		}
+		inserts.add(CppReturn.mk(CppConst.mkTrue()));
+		CppStmt body = CppSeq.mk(inserts);
+		CppExpr guard = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "insert", tup, mkHint(masterIndex));
+		CppIf.mk(guard, body, CppReturn.mk(CppConst.mkFalse())).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareInsertNoHint(PrintWriter out) {
+		out.println("  inline bool insert(const " + mkTupleType() + "& tup) {");
+		CppCtor.mk("context", "h").println(out, 2);
+		CppExpr call = CppFuncCall.mk("insert", CppVar.mk("tup"), CppVar.mk("h"));
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareInsertAll(PrintWriter out) {
+		declareGenericInsertAll(out);
+	}
+
+	private void declareGenericInsertAll(PrintWriter out) {
+		out.println("  template<typename T> inline void insertAll(T& other) {");
+		CppCtor.mk("context", "h").println(out, 2);
+		CppExpr call = CppFuncCall.mk("insert", CppVar.mk("cur"), CppVar.mk("h"));
+		CppForEach.mk("cur", CppVar.mk("other"), call.toStmt()).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareLookup(PrintWriter out) {
+		for (Map.Entry<Integer, IndexInfo> e : indexInfo.entrySet()) {
+			BindingType[] pat = e.getValue().getPattern();
+			int idx = e.getKey();
+			declareLookupHint(out, idx, pat);
+			declareLookupNoHint(out, idx, pat);
+		}
+	}
+
+	private void declareLookupHint(PrintWriter out, int idx, BindingType[] pat) {
+		out.print("  inline souffle::range<" + mkIndexType(idx) + "::iterator> ");
+		out.println(mkLookupName(idx, pat) + "(const " + mkTupleType() + "& key, context& h) const {");
+		List<Integer> emptyArgs = new ArrayList<>();
+		int i = 0;
+		for (BindingType ty : pat) {
+			switch (ty) {
+			case BOUND:
+				break;
+			case FREE:
+			case IGNORED:
+				emptyArgs.add(i);
+			}
+			i++;
+		}
+		if (emptyArgs.size() == pat.length) {
+			mkLookupAll(idx).println(out, 2);
+		} else {
+			mkLookupSome(idx, emptyArgs).println(out, 2);
+		}
+		out.println("  }");
+	}
+
+	private void declareLookupNoHint(PrintWriter out, int idx, BindingType[] pat) {
+		String name = mkLookupName(idx, pat);
+		out.print("  inline souffle::range<" + mkIndexType(idx) + "::iterator> ");
+		out.println(name + "(const " + mkTupleType() + "& key) const {");
+		CppCtor.mk("context", "h").println(out, 2);
+		CppExpr call = CppFuncCall.mk(name, CppVar.mk("key"), CppVar.mk("h"));
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private CppStmt mkLookupAll(int idx) {
+		CppVar index = CppVar.mk(mkIndexName(idx));
+		CppExpr begin = CppMethodCall.mk(index, "begin");
+		CppExpr end = CppMethodCall.mk(index, "end");
+		return CppReturn.mk(CppFuncCall.mk("souffle::make_range", begin, end));
+	}
+
+	private CppStmt mkLookupSome(int idx, List<Integer> emptyArgs) {
+		CppVar index = CppVar.mk(mkIndexName(idx));
+		List<CppStmt> stmts = new ArrayList<>();
+		stmts.add(CppCtor.mk(mkTupleType(), "lo", CppVar.mk("key")));
+		stmts.add(CppCtor.mk(mkTupleType(), "hi", CppVar.mk("key")));
+		CppVar lo = CppVar.mk("lo");
+		CppVar hi = CppVar.mk("hi");
+		CppVar minTerm = CppVar.mk("min_term");
+		CppVar maxTerm = CppVar.mk("max_term");
+		for (int i : emptyArgs) {
+			CppExpr subscript = CppConst.mkInt(i);
+			stmts.add(CppBinop.mkAssign(CppSubscript.mk(lo, subscript), minTerm).toStmt());
+			stmts.add(CppBinop.mkAssign(CppSubscript.mk(hi, subscript), maxTerm).toStmt());
+		}
+		CppExpr getLower = CppMethodCall.mk(index, "lower_bound", lo, mkHint(idx));
+		CppExpr getUpper = CppMethodCall.mk(index, "upper_bound", hi, mkHint(idx));
+		CppExpr call = CppFuncCall.mk("souffle::make_range", getLower, getUpper);
+		stmts.add(CppReturn.mk(call));
+		return CppSeq.mk(stmts);
+	}
+
+	private void declareBegin(PrintWriter out) {
+		out.println("  inline iterator begin() const {");
+		CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "begin");
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareEnd(PrintWriter out) {
+		out.println("  inline iterator end() const {");
+		CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "end");
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private void declareSize(PrintWriter out) {
+		out.println("  inline size_t size() const {");
+		CppExpr call = CppMethodCall.mk(CppVar.mk(mkIndexName(masterIndex)), "size");
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	private String mkIndexType(int index) {
+		return mkIndexName(index) + "_t";
+	}
+
+	private String mkIndexName(int index) {
+		return "index_" + index;
+	}
+
+	private String mkTupleType() {
+		return "Tuple<" + arity + ">";
+	}
+
+	private String mkLookupName(int index, BindingType[] pat) {
+		return "lookup_" + index + "_" + Util.lookupOrCreate(pats, Arrays.asList(pat), () -> patCnt.getAndIncrement());
+	}
+
+	private String mkContainsName(int index) {
+		return "contains_" + index;
+	}
+
+	private String mkComparator(List<Integer> order) {
+		String s = "Comparator<";
+		for (Iterator<Integer> it = order.iterator(); it.hasNext();) {
+			s += it.next();
+			if (it.hasNext()) {
+				s += ", ";
+			}
+		}
+		return s + ">";
+	}
+
+	private void declarePartition(PrintWriter out) {
+		out.println("  inline vector<souffle::range<iterator>> partition() const {");
+		CppVar m = CppVar.mk(mkIndexName(masterIndex));
+		CppExpr call = CppMethodCall.mk(m, "getChunks", CppConst.mkInt(400));
+		CppReturn.mk(call).println(out, 2);
+		out.println("  }");
+	}
+
+	@Override
+	public Relation mkRelation(RelationSymbol sym) {
+		return new RelationImpl(sym);
+	}
+
+	private class RelationImpl implements Relation {
+
+		private final String name;
+		private final CppVar nameVar;
+
+		public RelationImpl(RelationSymbol sym) {
+			String s = "";
+			if (sym instanceof DeltaSymbol) {
+				sym = ((DeltaSymbol) sym).getBaseSymbol();
+				s += "_delta";
+			} else if (sym instanceof NewSymbol) {
+				sym = ((NewSymbol) sym).getBaseSymbol();
+				s += "_new";
+			}
+			name = CodeGenUtil.mkName(sym) + s;
+			nameVar = CppVar.mk("rels::" + name);
+		}
+
+		@Override
+		public void print(PrintWriter out) {
+			nameVar.print(out);
+		}
+
+		@Override
+		public CppStmt mkDecl() {
+			return new CppStmt() {
+
+				@Override
+				public void println(PrintWriter out, int indent) {
+					CodeGenUtil.printIndent(out, indent);
+					out.print("inline auto " + name);
+					out.println(" = make_unique<" + BTreeRelationStruct.this.name + ">();");
+				}
+
+			};
+		}
+
+		@Override
+		public CppExpr mkContains(CppExpr expr, boolean useHints) {
+			return mkContains(masterIndex, expr, useHints);
+		}
+
+		@Override
+		public CppExpr mkContains(int idx, CppExpr expr, boolean useHints) {
+			List<CppExpr> args = new ArrayList<>();
+			args.add(expr);
+			if (useHints) {
+				args.add(CppVar.mk(mkContextName()));
+			}
+			return CppMethodCall.mkThruPtr(nameVar, mkContainsName(idx), args);
+		}
+
+		@Override
+		public CppExpr mkInsert(CppExpr expr, boolean useHints) {
+			List<CppExpr> args = new ArrayList<>();
+			args.add(expr);
+			if (useHints) {
+				args.add(CppVar.mk(mkContextName()));
+			}
+			return CppMethodCall.mkThruPtr(nameVar, "insert", args);
+		}
+
+		@Override
+		public CppExpr mkInsertAll(CppExpr expr) {
+			return CppMethodCall.mkThruPtr(nameVar, "insertAll", expr);
+		}
+
+		@Override
+		public CppExpr mkIsEmpty() {
+			return CppMethodCall.mkThruPtr(nameVar, "empty");
+		}
+
+		@Override
+		public CppStmt mkDeclTuple(String name) {
+			return CppCtor.mk(mkTupleType(), name);
+		}
+
+		@Override
+		public CppStmt mkDeclTuple(String name, List<CppExpr> exprs) {
+			return CppCtor.mkInitializer(mkTupleType(), name, exprs);
+		}
+
+		@Override
+		public CppExpr mkTuple(List<CppExpr> exprs) {
+			assert exprs.size() == arity;
+			return new CppExpr() {
+
+				@Override
+				public void print(PrintWriter out) {
+					out.print(mkTupleType());
+					out.print("{");
+					CodeGenUtil.printSeparated(exprs, ", ", out);
+					out.print("}");
+				}
+
+			};
+		}
+
+		@Override
+		public CppExpr mkTupleAccess(CppExpr tup, CppExpr idx) {
+			return CppSubscript.mk(tup, idx);
+		}
+
+		@Override
+		public CppStmt mkPrint() {
+			return CppMethodCall.mkThruPtr(nameVar, "print", CppConst.mkString(name)).toStmt();
+		}
+
+		@Override
+		public CppExpr mkPartition() {
+			return CppMethodCall.mkThruPtr(nameVar, "partition");
+		}
+
+		@Override
+		public CppStmt mkPurge() {
+			return CppMethodCall.mkThruPtr(nameVar, "purge").toStmt();
+		}
+
+		@Override
+		public CppExpr mkLookup(int idx, BindingType[] pat, CppExpr key, boolean useHints) {
+			List<CppExpr> args = new ArrayList<>();
+			args.add(key);
+			if (useHints) {
+				args.add(CppVar.mk(mkContextName()));
+			}
+			return CppMethodCall.mkThruPtr(nameVar, mkLookupName(idx, pat), args);
+		}
+
+		@Override
+		public CppExpr mkSize() {
+			return CppMethodCall.mkThruPtr(nameVar, "size");
+		}
+
+		@Override
+		public RelationStruct getStruct() {
+			return BTreeRelationStruct.this;
+		}
+
+		private String mkContextName() {
+			return "_" + name + "_context";
+		}
+
+		@Override
+		public CppStmt mkDeclContext() {
+			return CppDecl.mk(mkContextName(), CppMethodCall.mkThruPtr(nameVar, "create_context"));
+		}
+
+		@Override
+		public String toString() {
+			return "<" + name + ">";
+		}
+
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenContext.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenContext.java
@@ -38,138 +38,138 @@ import java.util.stream.Collectors;
 
 public class CodeGenContext {
 
-    private final Map<ConstructorSymbol, String> ctorSymToRepr = new HashMap<>();
-    private final Map<FunctionSymbol, String> funcSymToRepr = new HashMap<>();
-    private final AtomicInteger id = new AtomicInteger();
-    private final Map<String, SFunctorBody> functorBody = new ConcurrentHashMap<>();
-    private final Set<SIntListType> souffleTypes = new HashSet<>();
-    private final Map<String, Pair<Integer, SRuleMode>> customRelations = new HashMap<>();
-    private final Map<Term, String> exprFunctorNames = new HashMap<>();
-    private final Map<ConstructorSymbol, String> dtorFunctorNames = new HashMap<>();
-    private final Map<String, RelationSymbol> reprToRelSym = new HashMap<>();
+	private final Map<ConstructorSymbol, String> ctorSymToRepr = new HashMap<>();
+	private final Map<FunctionSymbol, String> funcSymToRepr = new HashMap<>();
+	private final AtomicInteger id = new AtomicInteger();
+	private final Map<String, SFunctorBody> functorBody = new ConcurrentHashMap<>();
+	private final Set<SIntListType> souffleTypes = new HashSet<>();
+	private final Map<String, Pair<Integer, SRuleMode>> customRelations = new HashMap<>();
+	private final Map<Term, String> exprFunctorNames = new HashMap<>();
+	private final Map<ConstructorSymbol, String> dtorFunctorNames = new HashMap<>();
+	private final Map<String, RelationSymbol> reprToRelSym = new HashMap<>();
 
-    private final BasicProgram prog;
+	private final BasicProgram prog;
 
-    public CodeGenContext(BasicProgram prog) {
-        this.prog = prog;
-        new Worker().go();
-    }
+	public CodeGenContext(BasicProgram prog) {
+		this.prog = prog;
+		new Worker().go();
+	}
 
-    public BasicProgram getProgram() {
-        return prog;
-    }
+	public BasicProgram getProgram() {
+		return prog;
+	}
 
-    public Set<ConstructorSymbol> getConstructorSymbols() {
-        return Collections.unmodifiableSet(ctorSymToRepr.keySet());
-    }
+	public Set<ConstructorSymbol> getConstructorSymbols() {
+		return Collections.unmodifiableSet(ctorSymToRepr.keySet());
+	}
 
-    public synchronized String lookupUnqualifiedRepr(ConstructorSymbol sym) {
-        String repr = ctorSymToRepr.get(sym);
-        if (repr == null) {
-            repr = CodeGenUtil.mkName(sym);
-            String repr2 = ctorSymToRepr.putIfAbsent(sym, repr);
-            assert repr2 == null;
-        }
-        return repr;
-    }
+	public synchronized String lookupUnqualifiedRepr(ConstructorSymbol sym) {
+		String repr = ctorSymToRepr.get(sym);
+		if (repr == null) {
+			repr = CodeGenUtil.mkName(sym);
+			String repr2 = ctorSymToRepr.putIfAbsent(sym, repr);
+			assert repr2 == null;
+		}
+		return repr;
+	}
 
-    public synchronized String lookupRepr(ConstructorSymbol sym) {
-        return "Symbol::" + lookupUnqualifiedRepr(sym);
-    }
+	public synchronized String lookupRepr(ConstructorSymbol sym) {
+		return "Symbol::" + lookupUnqualifiedRepr(sym);
+	}
 
-    public synchronized String lookupRepr(FunctionSymbol sym) {
-        String repr = funcSymToRepr.get(sym);
-        assert repr != null : sym;
-        return "funcs::" + repr;
-    }
+	public synchronized String lookupRepr(FunctionSymbol sym) {
+		String repr = funcSymToRepr.get(sym);
+		assert repr != null : sym;
+		return "funcs::" + repr;
+	}
 
-    public synchronized String lookupRepr(RelationSymbol sym) {
-        var repr = sym.toString().replace(":", "__") + "_";
-        reprToRelSym.put(repr, sym);
-        return repr;
-    }
+	public synchronized String lookupRepr(RelationSymbol sym) {
+		var repr = sym.toString().replace(":", "__") + "_";
+		reprToRelSym.put(repr, sym);
+		return repr;
+	}
 
-    public synchronized RelationSymbol lookupRel(String repr) {
-        return reprToRelSym.get(repr);
-    }
+	public synchronized RelationSymbol lookupRel(String repr) {
+		return reprToRelSym.get(repr);
+	}
 
-    public synchronized void register(FunctionSymbol sym, String repr) {
-        String repr2 = funcSymToRepr.put(sym, repr);
-        assert repr2 == null || repr2.equals(repr);
-    }
+	public synchronized void register(FunctionSymbol sym, String repr) {
+		String repr2 = funcSymToRepr.put(sym, repr);
+		assert repr2 == null || repr2.equals(repr);
+	}
 
-    public synchronized void register(SIntListType type) {
-        souffleTypes.add(type);
-    }
+	public synchronized void register(SIntListType type) {
+		souffleTypes.add(type);
+	}
 
-    public synchronized Set<SIntListType> getSouffleTypes() {
-        return Collections.unmodifiableSet(souffleTypes);
-    }
+	public synchronized Set<SIntListType> getSouffleTypes() {
+		return Collections.unmodifiableSet(souffleTypes);
+	}
 
-    public String newId(String prefix) {
-        return prefix + id.getAndIncrement();
-    }
+	public String newId(String prefix) {
+		return prefix + id.getAndIncrement();
+	}
 
-    public synchronized String lookupOrCreateFunctorName(Term t) {
-        return Util.lookupOrCreate(exprFunctorNames, t, () -> "expr_" + id.getAndIncrement());
-    }
+	public synchronized String lookupOrCreateFunctorName(Term t) {
+		return Util.lookupOrCreate(exprFunctorNames, t, () -> "expr_" + id.getAndIncrement());
+	}
 
-    public synchronized String lookupOrCreateFunctorName(ConstructorSymbol sym) {
-        return Util.lookupOrCreate(dtorFunctorNames, sym, () -> "dtor_" + id.getAndIncrement());
-    }
+	public synchronized String lookupOrCreateFunctorName(ConstructorSymbol sym) {
+		return Util.lookupOrCreate(dtorFunctorNames, sym, () -> "dtor_" + id.getAndIncrement());
+	}
 
-    public void registerFunctorBody(String functor, SFunctorBody body) {
-        functorBody.put(functor, body);
-    }
+	public void registerFunctorBody(String functor, SFunctorBody body) {
+		functorBody.put(functor, body);
+	}
 
-    public Set<Pair<String, SFunctorBody>> getFunctors() {
-        Set<Pair<String, SFunctorBody>> s = new HashSet<>();
-        for (Map.Entry<String, SFunctorBody> e : functorBody.entrySet()) {
-            s.add(new Pair<>(e.getKey(), e.getValue()));
-        }
-        return Collections.unmodifiableSet(s);
-    }
+	public Set<Pair<String, SFunctorBody>> getFunctors() {
+		Set<Pair<String, SFunctorBody>> s = new HashSet<>();
+		for (Map.Entry<String, SFunctorBody> e : functorBody.entrySet()) {
+			s.add(new Pair<>(e.getKey(), e.getValue()));
+		}
+		return Collections.unmodifiableSet(s);
+	}
 
-    public Set<Pair<String, Pair<Integer, SRuleMode>>> getCustomRelations() {
-        return customRelations.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue()))
-                .collect(Collectors.toSet());
-    }
+	public Set<Pair<String, Pair<Integer, SRuleMode>>> getCustomRelations() {
+		return customRelations.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue()))
+				.collect(Collectors.toSet());
+	}
 
-    public void registerCustomRelation(String name, Integer arity, SRuleMode mode) {
-        var p = new Pair<>(arity, mode);
-        var other = customRelations.put(name, p);
-        assert other == null || other.equals(p);
-    }
+	public void registerCustomRelation(String name, Integer arity, SRuleMode mode) {
+		var p = new Pair<>(arity, mode);
+		var other = customRelations.put(name, p);
+		assert other == null || other.equals(p);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        public Worker() {
-        }
+		public Worker() {
+		}
 
-        public void go() {
-            processTypes(prog.getTypeSymbols());
-            for (ConstructorSymbol sym : BuiltInConstructorSymbol.values()) {
-                lookupRepr(sym);
-            }
-        }
+		public void go() {
+			processTypes(prog.getTypeSymbols());
+			for (ConstructorSymbol sym : BuiltInConstructorSymbol.values()) {
+				lookupRepr(sym);
+			}
+		}
 
-        private void processTypes(Set<TypeSymbol> typeSymbols) {
-            for (TypeSymbol sym : typeSymbols) {
-                if (!sym.isAlias()) {
-                    processType(AlgebraicDataType.makeWithFreshArgs(sym));
-                }
-            }
-        }
+		private void processTypes(Set<TypeSymbol> typeSymbols) {
+			for (TypeSymbol sym : typeSymbols) {
+				if (!sym.isAlias()) {
+					processType(AlgebraicDataType.makeWithFreshArgs(sym));
+				}
+			}
+		}
 
-        private void processType(AlgebraicDataType type) {
-            if (type.hasConstructors()) {
-                for (ConstructorScheme cs : type.getConstructors()) {
-                    ConstructorSymbol sym = cs.getSymbol();
-                    lookupRepr(sym);
-                }
-            }
-        }
+		private void processType(AlgebraicDataType type) {
+			if (type.hasConstructors()) {
+				for (ConstructorScheme cs : type.getConstructors()) {
+					ConstructorSymbol sym = cs.getSymbol();
+					lookupRepr(sym);
+				}
+			}
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenException.java
@@ -22,12 +22,12 @@ package edu.harvard.seas.pl.formulog.codegen;
 
 public class CodeGenException extends Exception {
 
-    public CodeGenException(String message) {
-        super(message);
-    }
+	public CodeGenException(String message) {
+		super(message);
+	}
 
-    public CodeGenException(Exception cause) {
-        super(cause);
-    }
+	public CodeGenException(Exception cause) {
+		super(cause);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenUtil.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGenUtil.java
@@ -32,80 +32,80 @@ import edu.harvard.seas.pl.formulog.symbols.parameterized.ParameterizedSymbol;
 
 public final class CodeGenUtil {
 
-    private CodeGenUtil() {
-        throw new AssertionError("impossible");
-    }
+	private CodeGenUtil() {
+		throw new AssertionError("impossible");
+	}
 
-    public static void printIndent(PrintWriter out, int indent) {
-        for (int i = 0; i < indent; ++i) {
-            out.print("  ");
-        }
-    }
+	public static void printIndent(PrintWriter out, int indent) {
+		for (int i = 0; i < indent; ++i) {
+			out.print("  ");
+		}
+	}
 
-    public static void print(Iterable<CppStmt> stmts, PrintWriter out, int indent) {
-        for (CppStmt stmt : stmts) {
-            stmt.println(out, indent);
-        }
-    }
+	public static void print(Iterable<CppStmt> stmts, PrintWriter out, int indent) {
+		for (CppStmt stmt : stmts) {
+			stmt.println(out, indent);
+		}
+	}
 
-    public static void printSeparated(Iterable<CppExpr> exprs, String sep, PrintWriter out) {
-        for (Iterator<CppExpr> it = exprs.iterator(); it.hasNext(); ) {
-            it.next().print(out);
-            if (it.hasNext()) {
-                out.print(sep);
-            }
-        }
-    }
+	public static void printSeparated(Iterable<CppExpr> exprs, String sep, PrintWriter out) {
+		for (Iterator<CppExpr> it = exprs.iterator(); it.hasNext();) {
+			it.next().print(out);
+			if (it.hasNext()) {
+				out.print(sep);
+			}
+		}
+	}
 
-    public static CppExpr mkComplexTermLookup(CppExpr base, int offset) {
-        CppExpr cast = CppCast.mkReinterpret("const ComplexTerm&", CppUnop.mkDeref(base));
-        CppExpr access = CppAccess.mk(cast, "val");
-        return CppSubscript.mk(access, CppConst.mkInt(offset));
-    }
+	public static CppExpr mkComplexTermLookup(CppExpr base, int offset) {
+		CppExpr cast = CppCast.mkReinterpret("const ComplexTerm&", CppUnop.mkDeref(base));
+		CppExpr access = CppAccess.mk(cast, "val");
+		return CppSubscript.mk(access, CppConst.mkInt(offset));
+	}
 
-    public static void copyOver(BufferedReader in, PrintWriter out, int stopAt) throws IOException {
-        String line;
-        while ((line = in.readLine()) != null && !line.equals("/* INSERT " + stopAt + " */")) {
-            out.println(line);
-        }
-    }
+	public static void copyOver(BufferedReader in, PrintWriter out, int stopAt) throws IOException {
+		String line;
+		while ((line = in.readLine()) != null && !line.equals("/* INSERT " + stopAt + " */")) {
+			out.println(line);
+		}
+	}
 
-    public static String mkName(Symbol sym) {
-        String s;
-        if (sym instanceof ParameterizedSymbol) {
-            ParameterizedSymbol psym = (ParameterizedSymbol) sym;
-            StringBuilder sb = new StringBuilder(psym.getBase().toString());
-            for (Param p : psym.getArgs()) {
-                sb.append("__");
-                String ty = p.getType().toString().replaceAll("[^A-Za-z0-9_]+", "_");
-                sb.append(ty);
-            }
-            s = sb.toString();
-        } else {
-            s = sym.toString().replaceAll("[^A-Za-z0-9_]+", "_");
-        }
-        if (sym instanceof FunctionSymbol && !(sym instanceof BuiltInFunctionSymbol)) {
-            s = "FLG_" + s;
-        }
-        return s;
-    }
+	public static String mkName(Symbol sym) {
+		String s;
+		if (sym instanceof ParameterizedSymbol) {
+			ParameterizedSymbol psym = (ParameterizedSymbol) sym;
+			StringBuilder sb = new StringBuilder(psym.getBase().toString());
+			for (Param p : psym.getArgs()) {
+				sb.append("__");
+				String ty = p.getType().toString().replaceAll("[^A-Za-z0-9_]+", "_");
+				sb.append(ty);
+			}
+			s = sb.toString();
+		} else {
+			s = sym.toString().replaceAll("[^A-Za-z0-9_]+", "_");
+		}
+		if (sym instanceof FunctionSymbol && !(sym instanceof BuiltInFunctionSymbol)) {
+			s = "FLG_" + s;
+		}
+		return s;
+	}
 
-    public static String toString(CppStmt stmt, int indent) {
-        StringWriter sw = new StringWriter();
-        stmt.println(new PrintWriter(sw), indent);
-        return sw.toString();
-    }
+	public static String toString(CppStmt stmt, int indent) {
+		StringWriter sw = new StringWriter();
+		stmt.println(new PrintWriter(sw), indent);
+		return sw.toString();
+	}
 
-    public static InputStream inputSrcFile(String file) {
-        var cl = CodeGenUtil.class.getClassLoader();
-        var path = Path.of("codegen", "src", file).toString();
-        var is = cl.getResourceAsStream(path);
-        assert is != null : path;
-        return is;
-    }
+	public static InputStream inputSrcFile(String file) {
+		var cl = CodeGenUtil.class.getClassLoader();
+		var path = Path.of("codegen", "src", file).toString();
+		var is = cl.getResourceAsStream(path);
+		assert is != null : path;
+		return is;
+	}
 
-    public static File outputSrcFile(File topDir, String file) {
-        return topDir.toPath().resolve("src").resolve(file).toFile();
-    }
+	public static File outputSrcFile(File topDir, String file) {
+		return topDir.toPath().resolve("src").resolve(file).toFile();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/DeltaFirstQueryPlanner.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/DeltaFirstQueryPlanner.java
@@ -57,7 +57,7 @@ public class DeltaFirstQueryPlanner implements QueryPlanner {
 		for (int i = 0; i < body.size(); ++i) {
 			var lit = body.get(i);
 			if (lit instanceof SAtom) {
-			    numAtoms++;
+				numAtoms++;
 				var pred = ((SAtom) lit).getSymbol();
 				var rel = ctx.lookupRel(pred);
 				if (rel != null && preds.contains(rel)) {
@@ -67,7 +67,7 @@ public class DeltaFirstQueryPlanner implements QueryPlanner {
 		}
 		return new Pair<>(numAtoms, l);
 	}
-	
+
 	private int[] genPlanForDelta(int delta, int numAtoms) {
 		int[] arr = new int[numAtoms];
 		Arrays.setAll(arr, (i) -> {

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/FuncsHpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/FuncsHpp.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.BindingType;
 import edu.harvard.seas.pl.formulog.ast.Var;
 import edu.harvard.seas.pl.formulog.codegen.ast.cpp.*;
@@ -36,551 +35,554 @@ import java.util.stream.Collectors;
 
 public class FuncsHpp extends TemplateSrcFile {
 
-    public FuncsHpp(CodeGenContext ctx) {
-        super("funcs.hpp", ctx);
-    }
+	public FuncsHpp(CodeGenContext ctx) {
+		super("funcs.hpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker pr = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        pr.makeDeclarations();
-        CodeGenUtil.copyOver(br, out, 1);
-        pr.makeDefinitions();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker pr = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		pr.makeDeclarations();
+		CodeGenUtil.copyOver(br, out, 1);
+		pr.makeDefinitions();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final PrintWriter out;
-        private final Set<FunctionSymbol> userDefinedFunctions = new HashSet<>();
-        private final Set<PredicateFunctionSymbol> predFunctions = new HashSet<>();
-        private final TermCodeGen tcg = new TermCodeGen(ctx);
+		private final PrintWriter out;
+		private final Set<FunctionSymbol> userDefinedFunctions = new HashSet<>();
+		private final Set<PredicateFunctionSymbol> predFunctions = new HashSet<>();
+		private final TermCodeGen tcg = new TermCodeGen(ctx);
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        private void makeDeclarations() {
-            for (FunctionSymbol sym : ctx.getProgram().getFunctionSymbols()) {
-                if (sym instanceof BuiltInFunctionSymbol) {
-                    registerBuiltInFunction((BuiltInFunctionSymbol) sym);
-                } else if (sym instanceof PredicateFunctionSymbol) {
-                    predFunctions.add((PredicateFunctionSymbol) sym);
-                    declareFunction(sym);
-                } else {
-                    FunctionDef def = ctx.getProgram().getDef(sym);
-                    if (def instanceof UserFunctionDef) {
-                        userDefinedFunctions.add(sym);
-                        declareFunction(sym);
-                    } else if (def instanceof RecordAccessor) {
-                        ctx.register(sym, "__access<" + ((RecordAccessor) def).getIndex() + ">");
-                    } else {
-                        throw new AssertionError("Unexpected function def: " + sym + " " + def.getClass());
-                    }
-                }
-            }
-        }
+		private void makeDeclarations() {
+			for (FunctionSymbol sym : ctx.getProgram().getFunctionSymbols()) {
+				if (sym instanceof BuiltInFunctionSymbol) {
+					registerBuiltInFunction((BuiltInFunctionSymbol) sym);
+				} else if (sym instanceof PredicateFunctionSymbol) {
+					predFunctions.add((PredicateFunctionSymbol) sym);
+					declareFunction(sym);
+				} else {
+					FunctionDef def = ctx.getProgram().getDef(sym);
+					if (def instanceof UserFunctionDef) {
+						userDefinedFunctions.add(sym);
+						declareFunction(sym);
+					} else if (def instanceof RecordAccessor) {
+						ctx.register(sym, "__access<" + ((RecordAccessor) def).getIndex() + ">");
+					} else {
+						throw new AssertionError("Unexpected function def: " + sym + " " + def.getClass());
+					}
+				}
+			}
+		}
 
-        private void declareFunction(FunctionSymbol sym) {
-            String name = CodeGenUtil.mkName(sym);
-            ctx.register(sym, name);
-            out.println();
-            out.print("term_ptr " + name + "(");
-            int n = sym.getArity();
-            for (int i = 0; i < n; ++i) {
-                out.print("term_ptr");
-                if (i < n - 1) {
-                    out.print(", ");
-                }
-            }
-            out.println(");");
-        }
+		private void declareFunction(FunctionSymbol sym) {
+			String name = CodeGenUtil.mkName(sym);
+			ctx.register(sym, name);
+			out.println();
+			out.print("term_ptr " + name + "(");
+			int n = sym.getArity();
+			for (int i = 0; i < n; ++i) {
+				out.print("term_ptr");
+				if (i < n - 1) {
+					out.print(", ");
+				}
+			}
+			out.println(");");
+		}
 
-        private void registerBuiltInFunction(BuiltInFunctionSymbol sym) {
-            switch (sym) {
-                case BEQ:
-                    ctx.register(sym, "beq");
-                    break;
-                case BNEQ:
-                    ctx.register(sym, "bneq");
-                    break;
-                case BNOT:
-                    ctx.register(sym, "bnot");
-                    break;
-                case FP32_ADD:
-                    ctx.register(sym, "__add<float>");
-                    break;
-                case FP32_DIV:
-                    ctx.register(sym, "__div<float>");
-                    break;
-                case FP32_EQ:
-                    ctx.register(sym, "__eq<float>");
-                    break;
-                case FP32_GE:
-                    ctx.register(sym, "__ge<float>");
-                    break;
-                case FP32_GT:
-                    ctx.register(sym, "__gt<float>");
-                    break;
-                case FP32_LE:
-                    ctx.register(sym, "__le<float>");
-                    break;
-                case FP32_LT:
-                    ctx.register(sym, "__lt<float>");
-                    break;
-                case FP32_MUL:
-                    ctx.register(sym, "__mul<float>");
-                    break;
-                case FP32_NEG:
-                    ctx.register(sym, "__neg<float>");
-                    break;
-                case FP32_REM:
-                    ctx.register(sym, "__rem<float>");
-                    break;
-                case FP32_SUB:
-                    ctx.register(sym, "__sub<float>");
-                    break;
-                case FP64_ADD:
-                    ctx.register(sym, "__add<double>");
-                    break;
-                case FP64_DIV:
-                    ctx.register(sym, "__div<double>");
-                    break;
-                case FP64_EQ:
-                    ctx.register(sym, "__eq<double>");
-                    break;
-                case FP64_GE:
-                    ctx.register(sym, "__ge<double>");
-                    break;
-                case FP64_GT:
-                    ctx.register(sym, "__gt<double>");
-                    break;
-                case FP64_LE:
-                    ctx.register(sym, "__le<double>");
-                    break;
-                case FP64_LT:
-                    ctx.register(sym, "__lt<double>");
-                    break;
-                case FP64_MUL:
-                    ctx.register(sym, "__mul<double>");
-                    break;
-                case FP64_NEG:
-                    ctx.register(sym, "__neg<double>");
-                    break;
-                case FP64_REM:
-                    ctx.register(sym, "__rem<double>");
-                    break;
-                case FP64_SUB:
-                    ctx.register(sym, "__sub<double>");
-                    break;
-                case I32_ADD:
-                    ctx.register(sym, "__add<int32_t>");
-                    break;
-                case I32_AND:
-                    ctx.register(sym, "__bitwise_and<int32_t>");
-                    break;
-                case I32_SDIV:
-                    ctx.register(sym, "__div<int32_t>");
-                    break;
-                case I32_GE:
-                    ctx.register(sym, "__ge<int32_t>");
-                    break;
-                case I32_GT:
-                    ctx.register(sym, "__gt<int32_t>");
-                    break;
-                case I32_LE:
-                    ctx.register(sym, "__le<int32_t>");
-                    break;
-                case I32_LT:
-                    ctx.register(sym, "__lt<int32_t>");
-                    break;
-                case I32_MUL:
-                    ctx.register(sym, "__mul<int32_t>");
-                    break;
-                case I32_NEG:
-                    ctx.register(sym, "__neg<int32_t>");
-                    break;
-                case I32_OR:
-                    ctx.register(sym, "__bitwise_or<int32_t>");
-                    break;
-                case I32_SREM:
-                    ctx.register(sym, "__rem<int32_t>");
-                    break;
-                case I32_SCMP:
-                    ctx.register(sym, "__cmp<int32_t>");
-                    break;
-                case I32_SUB:
-                    ctx.register(sym, "__sub<int32_t>");
-                    break;
-                case I32_UCMP:
-                    ctx.register(sym, "__cmp<uint32_t>");
-                    break;
-                case I32_XOR:
-                    ctx.register(sym, "__bitwise_xor<int32_t>");
-                    break;
-                case I32_SHL:
-                    ctx.register(sym, "__shl<int32_t>");
-                    break;
-                case I32_ASHR:
-                    ctx.register(sym, "__ashr<int32_t>");
-                    break;
-                case I32_LSHR:
-                    ctx.register(sym, "__lshr<int32_t, uint32_t>");
-                    break;
-                case I32_UREM:
-                    ctx.register(sym, "__urem<int32_t, uint32_t>");
-                    break;
-                case I32_UDIV:
-                    ctx.register(sym, "__udiv<int32_t, uint32_t>");
-                    break;
-                case I64_ADD:
-                    ctx.register(sym, "__add<int64_t>");
-                    break;
-                case I64_AND:
-                    ctx.register(sym, "__bitwise_and<int64_t>");
-                    break;
-                case I64_SDIV:
-                    ctx.register(sym, "__div<int64_t>");
-                    break;
-                case I64_GE:
-                    ctx.register(sym, "__ge<int64_t>");
-                    break;
-                case I64_GT:
-                    ctx.register(sym, "__gt<int64_t>");
-                    break;
-                case I64_LE:
-                    ctx.register(sym, "__le<int64_t>");
-                    break;
-                case I64_LT:
-                    ctx.register(sym, "__lt<int64_t>");
-                    break;
-                case I64_MUL:
-                    ctx.register(sym, "__mul<int64_t>");
-                    break;
-                case I64_NEG:
-                    ctx.register(sym, "__neg<int64_t>");
-                    break;
-                case I64_OR:
-                    ctx.register(sym, "__bitwise_or<int64_t>");
-                    break;
-                case I64_SREM:
-                    ctx.register(sym, "__rem<int64_t>");
-                    break;
-                case I64_SCMP:
-                    ctx.register(sym, "__cmp<int64_t>");
-                    break;
-                case I64_SUB:
-                    ctx.register(sym, "__sub<int64_t>");
-                    break;
-                case I64_UCMP:
-                    ctx.register(sym, "__cmp<uint64_t>");
-                    break;
-                case I64_XOR:
-                    ctx.register(sym, "__bitwise_xor<int64_t>");
-                    break;
-                case I64_SHL:
-                    ctx.register(sym, "__shl<int64_t>");
-                    break;
-                case I64_ASHR:
-                    ctx.register(sym, "__ashr<int64_t>");
-                    break;
-                case I64_LSHR:
-                    ctx.register(sym, "__lshr<int64_t, uint64_t>");
-                    break;
-                case I64_UREM:
-                    ctx.register(sym, "__urem<int64_t, uint64_t>");
-                    break;
-                case I64_UDIV:
-                    ctx.register(sym, "__udiv<int64_t, uint64_t>");
-                    break;
-                case IS_SAT:
-                    ctx.register(sym, "is_sat");
-                    break;
-                case IS_SAT_OPT:
-                    ctx.register(sym, "is_sat_opt");
-                    break;
-                case IS_VALID:
-                    ctx.register(sym, "is_valid");
-                    break;
-                case GET_MODEL:
-                    ctx.register(sym, "get_model");
-                    break;
-                case QUERY_MODEL:
-                    ctx.register(sym, "query_model");
-                    break;
-                case PRINT:
-                    ctx.register(sym, "print");
-                    break;
-                case STRING_CONCAT:
-                    ctx.register(sym, "string_concat");
-                    break;
-                case STRING_CMP:
-                    ctx.register(sym, "__cmp<string>");
-                    break;
-                case STRING_MATCHES:
-                    ctx.register(sym, "string_matches");
-                    break;
-                case STRING_STARTS_WITH:
-                    ctx.register(sym, "string_starts_with");
-                    break;
-                case TO_STRING:
-                    ctx.register(sym, "to_string");
-                    break;
-                case fp32ToFp64:
-                    ctx.register(sym, "__conv<float, double>");
-                    break;
-                case fp32ToI32:
-                    ctx.register(sym, "__conv<float, int32_t>");
-                    break;
-                case fp32ToI64:
-                    ctx.register(sym, "__conv<float, int64_t>");
-                    break;
-                case fp64ToFp32:
-                    ctx.register(sym, "__conv<double, float>");
-                    break;
-                case fp64ToI32:
-                    ctx.register(sym, "__conv<double, int32_t>");
-                    break;
-                case fp64ToI64:
-                    ctx.register(sym, "__conv<double, int64_t>");
-                    break;
-                case i32ToFp32:
-                    ctx.register(sym, "__conv<int32_t, float>");
-                    break;
-                case i32ToFp64:
-                    ctx.register(sym, "__conv<int32_t, double>");
-                    break;
-                case i32ToI64:
-                    ctx.register(sym, "__conv<int32_t, int64_t>");
-                    break;
-                case i64ToFp32:
-                    ctx.register(sym, "__conv<int64_t, float>");
-                    break;
-                case i64ToFp64:
-                    ctx.register(sym, "__conv<int64_t, double>");
-                    break;
-                case i64ToI32:
-                    ctx.register(sym, "__conv<int64_t, int32_t>");
-                    break;
-                case CHAR_AT:
-                    ctx.register(sym, "char_at");
-                    break;
-                case STRING_LENGTH:
-                    ctx.register(sym, "string_length");
-                    break;
-                case STRING_TO_LIST:
-                    ctx.register(sym, "string_to_list");
-                    break;
-                case LIST_TO_STRING:
-                    ctx.register(sym, "list_to_string");
-                    break;
-                case SUBSTRING:
-                    ctx.register(sym, "substring");
-                    break;
-                case stringToI32:
-                    ctx.register(sym, "string_to_i32");
-                    break;
-                case stringToI64:
-                    ctx.register(sym, "string_to_i64");
-                    break;
-                case OPAQUE_SET_EMPTY:
-                    ctx.register(sym, "opaque_set_empty");
-                    break;
-                case OPAQUE_SET_PLUS:
-                    ctx.register(sym, "opaque_set_plus");
-                    break;
-                case OPAQUE_SET_MINUS:
-                    ctx.register(sym, "opaque_set_minus");
-                    break;
-                case OPAQUE_SET_UNION:
-                    ctx.register(sym, "opaque_set_union");
-                    break;
-                case OPAQUE_SET_DIFF:
-                    ctx.register(sym, "opaque_set_diff");
-                    break;
-                case OPAQUE_SET_CHOOSE:
-                    ctx.register(sym, "opaque_set_choose");
-                    break;
-                case OPAQUE_SET_SIZE:
-                    ctx.register(sym, "opaque_set_size");
-                    break;
-                case OPAQUE_SET_MEMBER:
-                    ctx.register(sym, "opaque_set_member");
-                    break;
-                case OPAQUE_SET_SINGLETON:
-                    ctx.register(sym, "opaque_set_singleton");
-                    break;
-                case OPAQUE_SET_SUBSET:
-                    ctx.register(sym, "opaque_set_subset");
-                    break;
-                case OPAQUE_SET_FROM_LIST:
-                    ctx.register(sym, "opaque_set_from_list");
-                    break;
-                case IS_SET_SAT:
-                    ctx.register(sym, "is_set_sat");
-                    break;
-                default:
-                    throw new AssertionError("unhandled built-in function symbol: " + sym);
-            }
-        }
+		private void registerBuiltInFunction(BuiltInFunctionSymbol sym) {
+			switch (sym) {
+			case BEQ:
+				ctx.register(sym, "beq");
+				break;
+			case BNEQ:
+				ctx.register(sym, "bneq");
+				break;
+			case BNOT:
+				ctx.register(sym, "bnot");
+				break;
+			case FP32_ADD:
+				ctx.register(sym, "__add<float>");
+				break;
+			case FP32_DIV:
+				ctx.register(sym, "__div<float>");
+				break;
+			case FP32_EQ:
+				ctx.register(sym, "__eq<float>");
+				break;
+			case FP32_GE:
+				ctx.register(sym, "__ge<float>");
+				break;
+			case FP32_GT:
+				ctx.register(sym, "__gt<float>");
+				break;
+			case FP32_LE:
+				ctx.register(sym, "__le<float>");
+				break;
+			case FP32_LT:
+				ctx.register(sym, "__lt<float>");
+				break;
+			case FP32_MUL:
+				ctx.register(sym, "__mul<float>");
+				break;
+			case FP32_NEG:
+				ctx.register(sym, "__neg<float>");
+				break;
+			case FP32_REM:
+				ctx.register(sym, "__rem<float>");
+				break;
+			case FP32_SUB:
+				ctx.register(sym, "__sub<float>");
+				break;
+			case FP64_ADD:
+				ctx.register(sym, "__add<double>");
+				break;
+			case FP64_DIV:
+				ctx.register(sym, "__div<double>");
+				break;
+			case FP64_EQ:
+				ctx.register(sym, "__eq<double>");
+				break;
+			case FP64_GE:
+				ctx.register(sym, "__ge<double>");
+				break;
+			case FP64_GT:
+				ctx.register(sym, "__gt<double>");
+				break;
+			case FP64_LE:
+				ctx.register(sym, "__le<double>");
+				break;
+			case FP64_LT:
+				ctx.register(sym, "__lt<double>");
+				break;
+			case FP64_MUL:
+				ctx.register(sym, "__mul<double>");
+				break;
+			case FP64_NEG:
+				ctx.register(sym, "__neg<double>");
+				break;
+			case FP64_REM:
+				ctx.register(sym, "__rem<double>");
+				break;
+			case FP64_SUB:
+				ctx.register(sym, "__sub<double>");
+				break;
+			case I32_ADD:
+				ctx.register(sym, "__add<int32_t>");
+				break;
+			case I32_AND:
+				ctx.register(sym, "__bitwise_and<int32_t>");
+				break;
+			case I32_SDIV:
+				ctx.register(sym, "__div<int32_t>");
+				break;
+			case I32_GE:
+				ctx.register(sym, "__ge<int32_t>");
+				break;
+			case I32_GT:
+				ctx.register(sym, "__gt<int32_t>");
+				break;
+			case I32_LE:
+				ctx.register(sym, "__le<int32_t>");
+				break;
+			case I32_LT:
+				ctx.register(sym, "__lt<int32_t>");
+				break;
+			case I32_MUL:
+				ctx.register(sym, "__mul<int32_t>");
+				break;
+			case I32_NEG:
+				ctx.register(sym, "__neg<int32_t>");
+				break;
+			case I32_OR:
+				ctx.register(sym, "__bitwise_or<int32_t>");
+				break;
+			case I32_SREM:
+				ctx.register(sym, "__rem<int32_t>");
+				break;
+			case I32_SCMP:
+				ctx.register(sym, "__cmp<int32_t>");
+				break;
+			case I32_SUB:
+				ctx.register(sym, "__sub<int32_t>");
+				break;
+			case I32_UCMP:
+				ctx.register(sym, "__cmp<uint32_t>");
+				break;
+			case I32_XOR:
+				ctx.register(sym, "__bitwise_xor<int32_t>");
+				break;
+			case I32_SHL:
+				ctx.register(sym, "__shl<int32_t>");
+				break;
+			case I32_ASHR:
+				ctx.register(sym, "__ashr<int32_t>");
+				break;
+			case I32_LSHR:
+				ctx.register(sym, "__lshr<int32_t, uint32_t>");
+				break;
+			case I32_UREM:
+				ctx.register(sym, "__urem<int32_t, uint32_t>");
+				break;
+			case I32_UDIV:
+				ctx.register(sym, "__udiv<int32_t, uint32_t>");
+				break;
+			case I64_ADD:
+				ctx.register(sym, "__add<int64_t>");
+				break;
+			case I64_AND:
+				ctx.register(sym, "__bitwise_and<int64_t>");
+				break;
+			case I64_SDIV:
+				ctx.register(sym, "__div<int64_t>");
+				break;
+			case I64_GE:
+				ctx.register(sym, "__ge<int64_t>");
+				break;
+			case I64_GT:
+				ctx.register(sym, "__gt<int64_t>");
+				break;
+			case I64_LE:
+				ctx.register(sym, "__le<int64_t>");
+				break;
+			case I64_LT:
+				ctx.register(sym, "__lt<int64_t>");
+				break;
+			case I64_MUL:
+				ctx.register(sym, "__mul<int64_t>");
+				break;
+			case I64_NEG:
+				ctx.register(sym, "__neg<int64_t>");
+				break;
+			case I64_OR:
+				ctx.register(sym, "__bitwise_or<int64_t>");
+				break;
+			case I64_SREM:
+				ctx.register(sym, "__rem<int64_t>");
+				break;
+			case I64_SCMP:
+				ctx.register(sym, "__cmp<int64_t>");
+				break;
+			case I64_SUB:
+				ctx.register(sym, "__sub<int64_t>");
+				break;
+			case I64_UCMP:
+				ctx.register(sym, "__cmp<uint64_t>");
+				break;
+			case I64_XOR:
+				ctx.register(sym, "__bitwise_xor<int64_t>");
+				break;
+			case I64_SHL:
+				ctx.register(sym, "__shl<int64_t>");
+				break;
+			case I64_ASHR:
+				ctx.register(sym, "__ashr<int64_t>");
+				break;
+			case I64_LSHR:
+				ctx.register(sym, "__lshr<int64_t, uint64_t>");
+				break;
+			case I64_UREM:
+				ctx.register(sym, "__urem<int64_t, uint64_t>");
+				break;
+			case I64_UDIV:
+				ctx.register(sym, "__udiv<int64_t, uint64_t>");
+				break;
+			case IS_SAT:
+				ctx.register(sym, "is_sat");
+				break;
+			case IS_SAT_OPT:
+				ctx.register(sym, "is_sat_opt");
+				break;
+			case IS_VALID:
+				ctx.register(sym, "is_valid");
+				break;
+			case GET_MODEL:
+				ctx.register(sym, "get_model");
+				break;
+			case QUERY_MODEL:
+				ctx.register(sym, "query_model");
+				break;
+			case PRINT:
+				ctx.register(sym, "print");
+				break;
+			case STRING_CONCAT:
+				ctx.register(sym, "string_concat");
+				break;
+			case STRING_CMP:
+				ctx.register(sym, "__cmp<string>");
+				break;
+			case STRING_MATCHES:
+				ctx.register(sym, "string_matches");
+				break;
+			case STRING_STARTS_WITH:
+				ctx.register(sym, "string_starts_with");
+				break;
+			case TO_STRING:
+				ctx.register(sym, "to_string");
+				break;
+			case fp32ToFp64:
+				ctx.register(sym, "__conv<float, double>");
+				break;
+			case fp32ToI32:
+				ctx.register(sym, "__conv<float, int32_t>");
+				break;
+			case fp32ToI64:
+				ctx.register(sym, "__conv<float, int64_t>");
+				break;
+			case fp64ToFp32:
+				ctx.register(sym, "__conv<double, float>");
+				break;
+			case fp64ToI32:
+				ctx.register(sym, "__conv<double, int32_t>");
+				break;
+			case fp64ToI64:
+				ctx.register(sym, "__conv<double, int64_t>");
+				break;
+			case i32ToFp32:
+				ctx.register(sym, "__conv<int32_t, float>");
+				break;
+			case i32ToFp64:
+				ctx.register(sym, "__conv<int32_t, double>");
+				break;
+			case i32ToI64:
+				ctx.register(sym, "__conv<int32_t, int64_t>");
+				break;
+			case i64ToFp32:
+				ctx.register(sym, "__conv<int64_t, float>");
+				break;
+			case i64ToFp64:
+				ctx.register(sym, "__conv<int64_t, double>");
+				break;
+			case i64ToI32:
+				ctx.register(sym, "__conv<int64_t, int32_t>");
+				break;
+			case CHAR_AT:
+				ctx.register(sym, "char_at");
+				break;
+			case STRING_LENGTH:
+				ctx.register(sym, "string_length");
+				break;
+			case STRING_TO_LIST:
+				ctx.register(sym, "string_to_list");
+				break;
+			case LIST_TO_STRING:
+				ctx.register(sym, "list_to_string");
+				break;
+			case SUBSTRING:
+				ctx.register(sym, "substring");
+				break;
+			case stringToI32:
+				ctx.register(sym, "string_to_i32");
+				break;
+			case stringToI64:
+				ctx.register(sym, "string_to_i64");
+				break;
+			case OPAQUE_SET_EMPTY:
+				ctx.register(sym, "opaque_set_empty");
+				break;
+			case OPAQUE_SET_PLUS:
+				ctx.register(sym, "opaque_set_plus");
+				break;
+			case OPAQUE_SET_MINUS:
+				ctx.register(sym, "opaque_set_minus");
+				break;
+			case OPAQUE_SET_UNION:
+				ctx.register(sym, "opaque_set_union");
+				break;
+			case OPAQUE_SET_DIFF:
+				ctx.register(sym, "opaque_set_diff");
+				break;
+			case OPAQUE_SET_CHOOSE:
+				ctx.register(sym, "opaque_set_choose");
+				break;
+			case OPAQUE_SET_SIZE:
+				ctx.register(sym, "opaque_set_size");
+				break;
+			case OPAQUE_SET_MEMBER:
+				ctx.register(sym, "opaque_set_member");
+				break;
+			case OPAQUE_SET_SINGLETON:
+				ctx.register(sym, "opaque_set_singleton");
+				break;
+			case OPAQUE_SET_SUBSET:
+				ctx.register(sym, "opaque_set_subset");
+				break;
+			case OPAQUE_SET_FROM_LIST:
+				ctx.register(sym, "opaque_set_from_list");
+				break;
+			case IS_SET_SAT:
+				ctx.register(sym, "is_set_sat");
+				break;
+			default:
+				throw new AssertionError("unhandled built-in function symbol: " + sym);
+			}
+		}
 
-        private void makeDefinitions() {
-            var sorted = userDefinedFunctions.stream().sorted(Comparator.comparing(Object::toString)).collect(Collectors.toList());
-            for (FunctionSymbol sym : sorted) {
-                makeDefinitionForUserDefinedFunc(sym);
-            }
-            for (PredicateFunctionSymbol funcSym : predFunctions) {
-                makeDefinitionForPredFunc(funcSym);
-            }
-        }
+		private void makeDefinitions() {
+			var sorted = userDefinedFunctions.stream().sorted(Comparator.comparing(Object::toString))
+					.collect(Collectors.toList());
+			for (FunctionSymbol sym : sorted) {
+				makeDefinitionForUserDefinedFunc(sym);
+			}
+			for (PredicateFunctionSymbol funcSym : predFunctions) {
+				makeDefinitionForPredFunc(funcSym);
+			}
+		}
 
-        private void makeDefinitionForUserDefinedFunc(FunctionSymbol sym) {
-            UserFunctionDef def = (UserFunctionDef) ctx.getProgram().getDef(sym);
-            out.println();
-            out.print("term_ptr " + ctx.lookupRepr(sym) + "(");
-            Map<Var, CppExpr> env = new HashMap<>();
-            Iterator<Var> params = def.getParams().iterator();
-            int n = sym.getArity();
-            List<String> cppParams = new ArrayList<>();
-            for (int i = 0; i < n; ++i) {
-                String id = ctx.newId("x");
-                CppVar var = CppVar.mk(id);
-                env.put(params.next(), var);
-                out.print("term_ptr ");
-                var.print(out);
-                if (i < n - 1) {
-                    out.print(", ");
-                }
-                cppParams.add(var.toString());
-            }
-            out.println(") {");
-            if (n == 0) {
-                out.println("  static std::atomic<term_ptr> memo{nullptr};");
-                out.println("  if (memo) { return memo; }");
-            } else {
-                if (n == 1) {
-                    out.println("  typedef term_ptr Key;");
-                    out.println("  Key key = " + cppParams.get(0) + ";");
-                } else {
-                    out.println("  typedef std::array<term_ptr, " + n + "> Key;");
-                    out.println("  Key key = {" + String.join(", ", cppParams) + "};");
-                }
-                out.println("  static tbb::concurrent_unordered_map<Key, term_ptr, boost::hash<Key>> memo;");
-                out.println("  auto it = memo.find(key);");
-                out.println("  if (it != memo.end()) { return it->second; }");
-            }
-            Pair<CppStmt, CppExpr> p = tcg.gen(def.getBody(), env);
-            p.fst().println(out, 1);
-            String retVar = ctx.newId("ret");
-            CppDecl.mk(retVar, p.snd()).println(out, 1);
-            if (n == 0) {
-                out.println("  memo = " + retVar + ";");
-            } else {
-                out.println("  memo.emplace(key, " + retVar + ");");
-            }
-            CppReturn.mk(CppVar.mk(retVar)).println(out, 1);
-            out.println("}");
-        }
+		private void makeDefinitionForUserDefinedFunc(FunctionSymbol sym) {
+			UserFunctionDef def = (UserFunctionDef) ctx.getProgram().getDef(sym);
+			out.println();
+			out.print("term_ptr " + ctx.lookupRepr(sym) + "(");
+			Map<Var, CppExpr> env = new HashMap<>();
+			Iterator<Var> params = def.getParams().iterator();
+			int n = sym.getArity();
+			List<String> cppParams = new ArrayList<>();
+			for (int i = 0; i < n; ++i) {
+				String id = ctx.newId("x");
+				CppVar var = CppVar.mk(id);
+				env.put(params.next(), var);
+				out.print("term_ptr ");
+				var.print(out);
+				if (i < n - 1) {
+					out.print(", ");
+				}
+				cppParams.add(var.toString());
+			}
+			out.println(") {");
+			if (n == 0) {
+				out.println("  static std::atomic<term_ptr> memo{nullptr};");
+				out.println("  if (memo) { return memo; }");
+			} else {
+				if (n == 1) {
+					out.println("  typedef term_ptr Key;");
+					out.println("  Key key = " + cppParams.get(0) + ";");
+				} else {
+					out.println("  typedef std::array<term_ptr, " + n + "> Key;");
+					out.println("  Key key = {" + String.join(", ", cppParams) + "};");
+				}
+				out.println("  static tbb::concurrent_unordered_map<Key, term_ptr, boost::hash<Key>> memo;");
+				out.println("  auto it = memo.find(key);");
+				out.println("  if (it != memo.end()) { return it->second; }");
+			}
+			Pair<CppStmt, CppExpr> p = tcg.gen(def.getBody(), env);
+			p.fst().println(out, 1);
+			String retVar = ctx.newId("ret");
+			CppDecl.mk(retVar, p.snd()).println(out, 1);
+			if (n == 0) {
+				out.println("  memo = " + retVar + ";");
+			} else {
+				out.println("  memo.emplace(key, " + retVar + ");");
+			}
+			CppReturn.mk(CppVar.mk(retVar)).println(out, 1);
+			out.println("}");
+		}
 
-        private void makeDefinitionForPredFunc(PredicateFunctionSymbol funcSym) {
-            out.println();
-            out.print("term_ptr " + ctx.lookupRepr(funcSym) + "(");
-            RelationSymbol predSym = funcSym.getPredicateSymbol();
-            int n = predSym.getArity();
-            BindingType[] bindings = funcSym.getBindings();
-            int j = 0;
-            int nbound = numBound(bindings);
-            List<Integer> free = new ArrayList<>();
-            boolean hasIgnored = false;
-            CppVar[] args = new CppVar[bindings.length];
-            for (int i = 0; i < n; ++i) {
-                if (bindings[i].isBound()) {
-                    String id = ctx.newId("x");
-                    CppVar var = CppVar.mk(id);
-                    args[i] = var;
-                    out.print("term_ptr ");
-                    var.print(out);
-                    if (j < nbound - 1) {
-                        out.print(", ");
-                    }
-                    j++;
-                } else if (bindings[i].isFree()) {
-                    free.add(i);
-                } else if (bindings[i].isIgnored()) {
-                    hasIgnored = true;
-                }
-            }
-            if (hasIgnored) {
-                System.err.println("WARNING: relation query " + funcSym + " has ignored attribute; this might lead to slow performance");
-            }
-            out.println(") ");
-            Pair<CppStmt, CppExpr> p;
-            if (free.isEmpty()) {
-                p = genRelationContains(predSym, args, hasIgnored);
-            } else if (free.size() == 1) {
-                p = genRelationAggMono(predSym, args, free.get(0));
-            } else {
-                p = genRelationAggPoly(predSym, args, free);
-            }
-            CppStmt ret = CppReturn.mk(p.snd());
-            CppBlock.mk(CppSeq.mk(p.fst(), ret)).println(out, 0);
-        }
+		private void makeDefinitionForPredFunc(PredicateFunctionSymbol funcSym) {
+			out.println();
+			out.print("term_ptr " + ctx.lookupRepr(funcSym) + "(");
+			RelationSymbol predSym = funcSym.getPredicateSymbol();
+			int n = predSym.getArity();
+			BindingType[] bindings = funcSym.getBindings();
+			int j = 0;
+			int nbound = numBound(bindings);
+			List<Integer> free = new ArrayList<>();
+			boolean hasIgnored = false;
+			CppVar[] args = new CppVar[bindings.length];
+			for (int i = 0; i < n; ++i) {
+				if (bindings[i].isBound()) {
+					String id = ctx.newId("x");
+					CppVar var = CppVar.mk(id);
+					args[i] = var;
+					out.print("term_ptr ");
+					var.print(out);
+					if (j < nbound - 1) {
+						out.print(", ");
+					}
+					j++;
+				} else if (bindings[i].isFree()) {
+					free.add(i);
+				} else if (bindings[i].isIgnored()) {
+					hasIgnored = true;
+				}
+			}
+			if (hasIgnored) {
+				System.err.println("WARNING: relation query " + funcSym
+						+ " has ignored attribute; this might lead to slow performance");
+			}
+			out.println(") ");
+			Pair<CppStmt, CppExpr> p;
+			if (free.isEmpty()) {
+				p = genRelationContains(predSym, args, hasIgnored);
+			} else if (free.size() == 1) {
+				p = genRelationAggMono(predSym, args, free.get(0));
+			} else {
+				p = genRelationAggPoly(predSym, args, free);
+			}
+			CppStmt ret = CppReturn.mk(p.snd());
+			CppBlock.mk(CppSeq.mk(p.fst(), ret)).println(out, 0);
+		}
 
-        private CppExpr mkArgsVec(CppVar[] args) {
-            var cppArgs = Arrays.stream(args).map(x -> x == null ? CppNullptr.INSTANCE : x).collect(Collectors.toList());
-            return CppVectorLiteral.mk(cppArgs);
-        }
+		private CppExpr mkArgsVec(CppVar[] args) {
+			var cppArgs = Arrays.stream(args).map(x -> x == null ? CppNullptr.INSTANCE : x)
+					.collect(Collectors.toList());
+			return CppVectorLiteral.mk(cppArgs);
+		}
 
-        private Pair<CppStmt, CppExpr> genRelationAggMono(RelationSymbol predSym, CppVar[] args, int pos) {
-            CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
-            CppExpr vec = mkArgsVec(args);
-            CppExpr call = CppFuncCall.mk("_relation_agg_mono", name, vec, CppConst.mkInt(pos));
-            return new Pair<>(CppSeq.skip(), call);
-        }
+		private Pair<CppStmt, CppExpr> genRelationAggMono(RelationSymbol predSym, CppVar[] args, int pos) {
+			CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
+			CppExpr vec = mkArgsVec(args);
+			CppExpr call = CppFuncCall.mk("_relation_agg_mono", name, vec, CppConst.mkInt(pos));
+			return new Pair<>(CppSeq.skip(), call);
+		}
 
-        private Pair<CppStmt, CppExpr> genRelationAggPoly(RelationSymbol predSym, CppVar[] args, List<Integer> free) {
-            CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
-            CppExpr vec = mkArgsVec(args);
-            List<CppExpr> projection = new ArrayList<>();
-            int pos = 0;
-            for (int i = 0; i < predSym.getArity(); ++i) {
-                if (i == free.get(pos)) {
-                    projection.add(CppConst.mkTrue());
-                    pos++;
-                } else {
-                    projection.add(CppConst.mkFalse());
-                }
-            }
-            assert pos == free.size();
-            ConstructorSymbol tupleSym = GlobalSymbolManager.lookupTupleSymbol(free.size());
-            String funcName = "_relation_agg_poly<" + ctx.lookupRepr(tupleSym) + ">";
-            CppExpr call = CppFuncCall.mk(funcName, name, vec, CppVectorLiteral.mk(projection));
-            return new Pair<>(CppSeq.skip(), call);
-        }
+		private Pair<CppStmt, CppExpr> genRelationAggPoly(RelationSymbol predSym, CppVar[] args, List<Integer> free) {
+			CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
+			CppExpr vec = mkArgsVec(args);
+			List<CppExpr> projection = new ArrayList<>();
+			int pos = 0;
+			for (int i = 0; i < predSym.getArity(); ++i) {
+				if (i == free.get(pos)) {
+					projection.add(CppConst.mkTrue());
+					pos++;
+				} else {
+					projection.add(CppConst.mkFalse());
+				}
+			}
+			assert pos == free.size();
+			ConstructorSymbol tupleSym = GlobalSymbolManager.lookupTupleSymbol(free.size());
+			String funcName = "_relation_agg_poly<" + ctx.lookupRepr(tupleSym) + ">";
+			CppExpr call = CppFuncCall.mk(funcName, name, vec, CppVectorLiteral.mk(projection));
+			return new Pair<>(CppSeq.skip(), call);
+		}
 
-        private Pair<CppStmt, CppExpr> genRelationContains(RelationSymbol predSym, CppVar[] args, boolean hasIgnored) {
-            CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
-            CppExpr vec = mkArgsVec(args);
-            String func;
-            if (hasIgnored) {
-                func = "_relation_contains";
-            } else {
-                func = "_relation_contains_complete";
-            }
-            CppExpr call = CppFuncCall.mk(func, name, vec);
-            return new Pair<>(CppSeq.skip(), call);
-        }
+		private Pair<CppStmt, CppExpr> genRelationContains(RelationSymbol predSym, CppVar[] args, boolean hasIgnored) {
+			CppExpr name = CppConst.mkString(ctx.lookupRepr(predSym));
+			CppExpr vec = mkArgsVec(args);
+			String func;
+			if (hasIgnored) {
+				func = "_relation_contains";
+			} else {
+				func = "_relation_contains_complete";
+			}
+			CppExpr call = CppFuncCall.mk(func, name, vec);
+			return new Pair<>(CppSeq.skip(), call);
+		}
 
-        private int numBound(BindingType[] bindings) {
-            int n = 0;
-            for (BindingType binding : bindings) {
-                if (binding.isBound()) {
-                    n++;
-                }
-            }
-            return n;
-        }
+		private int numBound(BindingType[] bindings) {
+			int n = 0;
+			for (BindingType binding : bindings) {
+				if (binding.isBound()) {
+					n++;
+				}
+			}
+			return n;
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/FunctorCodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/FunctorCodeGen.java
@@ -33,138 +33,138 @@ import java.util.*;
 
 public class FunctorCodeGen {
 
-    private final CodeGenContext ctx;
+	private final CodeGenContext ctx;
 
-    private final static String headerName = "functors.h";
-    private final static String sourceName = "functors.cpp";
+	private final static String headerName = "functors.h";
+	private final static String sourceName = "functors.cpp";
 
-    public FunctorCodeGen(CodeGenContext ctx) {
-        this.ctx = ctx;
-    }
+	public FunctorCodeGen(CodeGenContext ctx) {
+		this.ctx = ctx;
+	}
 
-    public void emitFunctors(File directory) throws CodeGenException {
-        emitHeader(directory);
-        emitSource(directory);
-    }
+	public void emitFunctors(File directory) throws CodeGenException {
+		emitHeader(directory);
+		emitSource(directory);
+	}
 
-    private void emitHeader(File directory) throws CodeGenException {
-        try (InputStream is = CodeGenUtil.inputSrcFile(headerName)) {
-            assert is != null;
-            File outHeader = CodeGenUtil.outputSrcFile(directory, headerName);
-            try (InputStreamReader isr = new InputStreamReader(is);
-                 BufferedReader br = new BufferedReader(isr);
-                 PrintWriter out = new PrintWriter(outHeader)) {
-                CodeGenUtil.copyOver(br, out, 0);
-                for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
-                    emitSignature(p.fst(), p.snd(), out);
-                    out.println(";");
-                }
-                CodeGenUtil.copyOver(br, out, -1);
-            }
-        } catch (IOException e) {
-            throw new CodeGenException(e);
-        }
-    }
+	private void emitHeader(File directory) throws CodeGenException {
+		try (InputStream is = CodeGenUtil.inputSrcFile(headerName)) {
+			assert is != null;
+			File outHeader = CodeGenUtil.outputSrcFile(directory, headerName);
+			try (InputStreamReader isr = new InputStreamReader(is);
+					BufferedReader br = new BufferedReader(isr);
+					PrintWriter out = new PrintWriter(outHeader)) {
+				CodeGenUtil.copyOver(br, out, 0);
+				for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
+					emitSignature(p.fst(), p.snd(), out);
+					out.println(";");
+				}
+				CodeGenUtil.copyOver(br, out, -1);
+			}
+		} catch (IOException e) {
+			throw new CodeGenException(e);
+		}
+	}
 
-    private Map<Var, CppVar> emitSignature(String functor, SFunctorBody body, PrintWriter out) {
-        out.print("souffle::RamDomain ");
-        out.print(functor);
-        out.print("(");
-        if (body.isStateful()) {
-            out.print("souffle::SymbolTable *st, souffle::RecordTable *rt");
-            if (body.getArity() > 0) {
-                out.print(", ");
-            }
-        }
-        List<Var> flgArgs = body.getArgs();
-        Map<Var, CppVar> m = new LinkedHashMap<>();
-        for (int i = 0; i < body.getArity(); ++i) {
-            out.print("souffle::RamDomain ");
-            String arg = "arg" + i;
-            m.put(flgArgs.get(i), CppVar.mk(arg));
-            out.print(arg);
-            if (i < body.getArity() - 1) {
-                out.print(", ");
-            }
-        }
-        out.print(")");
-        return m;
-    }
+	private Map<Var, CppVar> emitSignature(String functor, SFunctorBody body, PrintWriter out) {
+		out.print("souffle::RamDomain ");
+		out.print(functor);
+		out.print("(");
+		if (body.isStateful()) {
+			out.print("souffle::SymbolTable *st, souffle::RecordTable *rt");
+			if (body.getArity() > 0) {
+				out.print(", ");
+			}
+		}
+		List<Var> flgArgs = body.getArgs();
+		Map<Var, CppVar> m = new LinkedHashMap<>();
+		for (int i = 0; i < body.getArity(); ++i) {
+			out.print("souffle::RamDomain ");
+			String arg = "arg" + i;
+			m.put(flgArgs.get(i), CppVar.mk(arg));
+			out.print(arg);
+			if (i < body.getArity() - 1) {
+				out.print(", ");
+			}
+		}
+		out.print(")");
+		return m;
+	}
 
-    private void emitSource(File directory) throws CodeGenException {
-        try (InputStream is = CodeGenUtil.inputSrcFile(sourceName)) {
-            assert is != null;
-            File outSource = CodeGenUtil.outputSrcFile(directory, sourceName);
-            try (InputStreamReader isr = new InputStreamReader(is);
-                 BufferedReader br = new BufferedReader(isr);
-                 PrintWriter out = new PrintWriter(outSource)) {
-                CodeGenUtil.copyOver(br, out, 0);
-                new SourceWorker(out).emitFunctors();
-                CodeGenUtil.copyOver(br, out, -1);
-            }
-        } catch (IOException e) {
-            throw new CodeGenException(e);
-        }
-    }
+	private void emitSource(File directory) throws CodeGenException {
+		try (InputStream is = CodeGenUtil.inputSrcFile(sourceName)) {
+			assert is != null;
+			File outSource = CodeGenUtil.outputSrcFile(directory, sourceName);
+			try (InputStreamReader isr = new InputStreamReader(is);
+					BufferedReader br = new BufferedReader(isr);
+					PrintWriter out = new PrintWriter(outSource)) {
+				CodeGenUtil.copyOver(br, out, 0);
+				new SourceWorker(out).emitFunctors();
+				CodeGenUtil.copyOver(br, out, -1);
+			}
+		} catch (IOException e) {
+			throw new CodeGenException(e);
+		}
+	}
 
-    private class SourceWorker {
+	private class SourceWorker {
 
-        private final PrintWriter out;
+		private final PrintWriter out;
 
-        public SourceWorker(PrintWriter out_) {
-            out = out_;
-        }
+		public SourceWorker(PrintWriter out_) {
+			out = out_;
+		}
 
-        public void emitFunctors() {
-            for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
-                emitFunctor(p.fst(), p.snd());
-                out.println();
-            }
-        }
+		public void emitFunctors() {
+			for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
+				emitFunctor(p.fst(), p.snd());
+				out.println();
+			}
+		}
 
-        private void emitFunctor(String functor, SFunctorBody body) {
-            Map<Var, CppVar> params = emitSignature(functor, body, out);
-            out.print(" ");
-            Pair<CppStmt, Map<Var, CppExpr>> p1 = unpackParams(params);
-            Pair<CppStmt, CppExpr> p2;
-            if (body instanceof SExprBody) {
-                p2 = genTermBody(((SExprBody) body).getBody(), p1.snd());
-            } else {
-                assert body instanceof SDestructorBody;
-                p2 = genDtorBody((SDestructorBody) body, p1.snd());
-            }
-            CppStmt ret = CppReturn.mk(p2.snd());
-            CppStmt block = CppBlock.mk(CppSeq.mk(p1.fst(), p2.fst(), ret));
-            block.println(out, 0);
-        }
+		private void emitFunctor(String functor, SFunctorBody body) {
+			Map<Var, CppVar> params = emitSignature(functor, body, out);
+			out.print(" ");
+			Pair<CppStmt, Map<Var, CppExpr>> p1 = unpackParams(params);
+			Pair<CppStmt, CppExpr> p2;
+			if (body instanceof SExprBody) {
+				p2 = genTermBody(((SExprBody) body).getBody(), p1.snd());
+			} else {
+				assert body instanceof SDestructorBody;
+				p2 = genDtorBody((SDestructorBody) body, p1.snd());
+			}
+			CppStmt ret = CppReturn.mk(p2.snd());
+			CppStmt block = CppBlock.mk(CppSeq.mk(p1.fst(), p2.fst(), ret));
+			block.println(out, 0);
+		}
 
-        private Pair<CppStmt, Map<Var, CppExpr>> unpackParams(Map<Var, CppVar> params) {
-            List<CppStmt> stmts = new ArrayList<>();
-            Map<Var, CppExpr> env = new HashMap<>();
-            for (Map.Entry<Var, CppVar> e : params.entrySet()) {
-                String x = ctx.newId("x");
-                CppExpr call = TermCodeGen.genUnintizeTerm(e.getValue());
-                CppStmt stmt = CppDecl.mk(x, call);
-                stmts.add(stmt);
-                env.put(e.getKey(), CppVar.mk(x));
-            }
-            return new Pair<>(CppSeq.mk(stmts), env);
-        }
+		private Pair<CppStmt, Map<Var, CppExpr>> unpackParams(Map<Var, CppVar> params) {
+			List<CppStmt> stmts = new ArrayList<>();
+			Map<Var, CppExpr> env = new HashMap<>();
+			for (Map.Entry<Var, CppVar> e : params.entrySet()) {
+				String x = ctx.newId("x");
+				CppExpr call = TermCodeGen.genUnintizeTerm(e.getValue());
+				CppStmt stmt = CppDecl.mk(x, call);
+				stmts.add(stmt);
+				env.put(e.getKey(), CppVar.mk(x));
+			}
+			return new Pair<>(CppSeq.mk(stmts), env);
+		}
 
-        private Pair<CppStmt, CppExpr> genTermBody(Term t, Map<Var, CppExpr> env) {
-            TermCodeGen tcg = new TermCodeGen(ctx);
-            Pair<CppStmt, CppExpr> p = tcg.gen(t, env);
-            CppExpr pack = TermCodeGen.genIntizeTerm(p.snd());
-            return new Pair<>(p.fst(), pack);
-        }
+		private Pair<CppStmt, CppExpr> genTermBody(Term t, Map<Var, CppExpr> env) {
+			TermCodeGen tcg = new TermCodeGen(ctx);
+			Pair<CppStmt, CppExpr> p = tcg.gen(t, env);
+			CppExpr pack = TermCodeGen.genIntizeTerm(p.snd());
+			return new Pair<>(p.fst(), pack);
+		}
 
-        private Pair<CppStmt, CppExpr> genDtorBody(SDestructorBody body, Map<Var, CppExpr> env) {
-            Pair<CppStmt, CppExpr> p = new TermCodeGen(ctx).gen(body.getScrutinee(), env);
-            String func = "dtor<" + ctx.lookupRepr(body.getSymbol()) + ">";
-            CppExpr call = CppFuncCall.mk(func, p.snd());
-            return new Pair<>(p.fst(), call);
-        }
+		private Pair<CppStmt, CppExpr> genDtorBody(SDestructorBody body, Map<Var, CppExpr> env) {
+			Pair<CppStmt, CppExpr> p = new TermCodeGen(ctx).gen(body.getScrutinee(), env);
+			String func = "dtor<" + ctx.lookupRepr(body.getSymbol()) + ">";
+			CppExpr call = CppFuncCall.mk(func, p.snd());
+			return new Pair<>(p.fst(), call);
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/MainCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/MainCpp.java
@@ -35,159 +35,137 @@ import java.util.*;
 
 public class MainCpp extends TemplateSrcFile {
 
-    private final TermCodeGen tcg;
+	private final TermCodeGen tcg;
 
-    public MainCpp(CodeGenContext ctx) {
-        super("main.cpp", ctx);
-        this.tcg = new TermCodeGen(ctx);
-    }
+	public MainCpp(CodeGenContext ctx) {
+		super("main.cpp", ctx);
+		this.tcg = new TermCodeGen(ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException {
-        Worker pr = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        pr.loadExternalEdbs();
-        CodeGenUtil.copyOver(br, out, 1);
-        pr.loadStaticFacts();
-        /*
-        CodeGenUtil.copyOver(br, out, 2);
-        pr.printStratumFuncs();
-        CodeGenUtil.copyOver(br, out, 3);
-        pr.evaluate();
-        CodeGenUtil.copyOver(br, out, 4);
-        pr.printResults();
-        */
-        CodeGenUtil.copyOver(br, out, 4);
-        pr.printIdbsToDisk();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException {
+		Worker pr = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		pr.loadExternalEdbs();
+		CodeGenUtil.copyOver(br, out, 1);
+		pr.loadStaticFacts();
+		/*
+		 * CodeGenUtil.copyOver(br, out, 2); pr.printStratumFuncs();
+		 * CodeGenUtil.copyOver(br, out, 3); pr.evaluate(); CodeGenUtil.copyOver(br,
+		 * out, 4); pr.printResults();
+		 */
+		CodeGenUtil.copyOver(br, out, 4);
+		pr.printIdbsToDisk();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        //    private final SortedIndexedFactDb db = ctx.getEval().getDb();
-        private final PrintWriter out;
+		// private final SortedIndexedFactDb db = ctx.getEval().getDb();
+		private final PrintWriter out;
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        public void loadExternalEdbs() {
-            for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
-                if (sym.isDisk()) {
-                    loadExternalEdbs(sym);
-                }
-            }
-        }
+		public void loadExternalEdbs() {
+			for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
+				if (sym.isDisk()) {
+					loadExternalEdbs(sym);
+				}
+			}
+		}
 
-        public void loadExternalEdbs(RelationSymbol sym) {
-            String func = "loadEdbs";
-            CppExpr file = CppConst.mkString(sym + ".tsv");
-            CppExpr repr = CppConst.mkString(ctx.lookupRepr(sym));
-            CppExpr rel = CppMethodCall.mkThruPtr(CppVar.mk("globals::program"), "getRelation", repr);
-            CppExpr call = CppFuncCall.mk(func, CppVar.mk("dir"), file, rel);
-            call.toStmt().println(out, 1);
-        }
+		public void loadExternalEdbs(RelationSymbol sym) {
+			String func = "loadEdbs";
+			CppExpr file = CppConst.mkString(sym + ".tsv");
+			CppExpr repr = CppConst.mkString(ctx.lookupRepr(sym));
+			CppExpr rel = CppMethodCall.mkThruPtr(CppVar.mk("globals::program"), "getRelation", repr);
+			CppExpr call = CppFuncCall.mk(func, CppVar.mk("dir"), file, rel);
+			call.toStmt().println(out, 1);
+		}
 
-        public void loadStaticFacts() throws CodeGenException {
-            var prog = ctx.getProgram();
-            prog.getFunctionCallFactory().getDefManager().loadBuiltInFunctions(new PushPopSolver());
-            for (RelationSymbol sym : prog.getFactSymbols()) {
-                for (Term[] tup : prog.getFacts(sym)) {
-                    loadStaticFact(sym, tup);
-                }
-            }
-        }
+		public void loadStaticFacts() throws CodeGenException {
+			var prog = ctx.getProgram();
+			prog.getFunctionCallFactory().getDefManager().loadBuiltInFunctions(new PushPopSolver());
+			for (RelationSymbol sym : prog.getFactSymbols()) {
+				for (Term[] tup : prog.getFacts(sym)) {
+					loadStaticFact(sym, tup);
+				}
+			}
+		}
 
-        public void loadStaticFact(RelationSymbol sym, Term[] tup) throws CodeGenException {
-            List<CppExpr> args = new ArrayList<>();
-            List<CppStmt> stmts = new ArrayList<>();
-            TermCodeGen tcg = new TermCodeGen(ctx);
-            for (Term t : tup) {
-                try {
-                    t = t.normalize(new SimpleSubstitution());
-                } catch (EvaluationException e) {
-                    throw new CodeGenException("Could not normalize term occurring in fact: " + t);
-                }
-                Pair<CppStmt, CppExpr> p = tcg.gen(t, Collections.emptyMap());
-                stmts.add(p.fst());
-                args.add(p.snd());
-            }
-            CppExpr rel = CppConst.mkString(ctx.lookupRepr(sym));
-            stmts.add(CppFuncCall.mk("loadFact", rel, CppVectorLiteral.mk(args)).toStmt());
-            CppSeq.mk(stmts).println(out, 1);
-        }
+		public void loadStaticFact(RelationSymbol sym, Term[] tup) throws CodeGenException {
+			List<CppExpr> args = new ArrayList<>();
+			List<CppStmt> stmts = new ArrayList<>();
+			TermCodeGen tcg = new TermCodeGen(ctx);
+			for (Term t : tup) {
+				try {
+					t = t.normalize(new SimpleSubstitution());
+				} catch (EvaluationException e) {
+					throw new CodeGenException("Could not normalize term occurring in fact: " + t);
+				}
+				Pair<CppStmt, CppExpr> p = tcg.gen(t, Collections.emptyMap());
+				stmts.add(p.fst());
+				args.add(p.snd());
+			}
+			CppExpr rel = CppConst.mkString(ctx.lookupRepr(sym));
+			stmts.add(CppFuncCall.mk("loadFact", rel, CppVectorLiteral.mk(args)).toStmt());
+			CppSeq.mk(stmts).println(out, 1);
+		}
 
-        /*
-        public void loadEdbs() {
-            for (RelationSymbol sym : db.getSymbols()) {
-                if (sym.isEdbSymbol()) {
-                    // XXX Should probably change this so that we explicitly
-                    // load up only the master index, and then add the
-                    // master index to all the other ones.
-                    loadEdb(sym);
-                }
-            }
-        }
+		/*
+		 * public void loadEdbs() { for (RelationSymbol sym : db.getSymbols()) { if
+		 * (sym.isEdbSymbol()) { // XXX Should probably change this so that we
+		 * explicitly // load up only the master index, and then add the // master index
+		 * to all the other ones. loadEdb(sym); } } }
+		 * 
+		 * public void loadEdb(RelationSymbol sym) { Relation rel =
+		 * ctx.lookupRelation(sym); for (Term[] tup : db.getAll(sym)) { Pair<CppStmt,
+		 * List<CppExpr>> p = tcg.gen(Arrays.asList(tup), Collections.emptyMap());
+		 * p.fst().println(out, 1); rel.mkInsert(rel.mkTuple(p.snd()),
+		 * false).toStmt().println(out, 1); } }
+		 * 
+		 * public void printStratumFuncs() { StratumCodeGen scg = new
+		 * StratumCodeGen(ctx); List<Stratum> strata = ctx.getEval().getStrata(); for
+		 * (Iterator<Stratum> it = strata.iterator(); it.hasNext(); ) {
+		 * printStratumFunc(it.next(), scg); if (it.hasNext()) { out.println(); } } }
+		 * 
+		 * public void printStratumFunc(Stratum stratum, StratumCodeGen sgc) {
+		 * out.println("void stratum_" + stratum.getRank() + "() {");
+		 * sgc.gen(stratum).println(out, 1); out.println("}"); }
+		 * 
+		 * public void evaluate() { int n = ctx.getEval().getStrata().size(); for (int i
+		 * = 0; i < n; ++i) { CppFuncCall.mk("stratum_" + i,
+		 * Collections.emptyList()).toStmt().println(out, 1); } }
+		 * 
+		 */
 
-        public void loadEdb(RelationSymbol sym) {
-            Relation rel = ctx.lookupRelation(sym);
-            for (Term[] tup : db.getAll(sym)) {
-                Pair<CppStmt, List<CppExpr>> p = tcg.gen(Arrays.asList(tup), Collections.emptyMap());
-                p.fst().println(out, 1);
-                rel.mkInsert(rel.mkTuple(p.snd()), false).toStmt().println(out, 1);
-            }
-        }
+		public void printResults() {
+			for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
+				out.print("  cout << \"");
+				out.print(sym);
+				out.print(": \" << ");
+				genRelationSize(sym).print(out);
+				out.println(" << endl;");
+				// CppIf.mk(CppVar.mk("dump"), ctx.lookupRelation(sym).mkPrint()).println(out,
+				// 1);
+			}
+		}
 
-        public void printStratumFuncs() {
-            StratumCodeGen scg = new StratumCodeGen(ctx);
-            List<Stratum> strata = ctx.getEval().getStrata();
-            for (Iterator<Stratum> it = strata.iterator(); it.hasNext(); ) {
-                printStratumFunc(it.next(), scg);
-                if (it.hasNext()) {
-                    out.println();
-                }
-            }
-        }
+		private CppExpr genRelationSize(RelationSymbol sym) {
+			String repr = ctx.lookupRepr(sym);
+			CppExpr rel = CppMethodCall.mk(CppVar.mk("prog"), "getRelation", CppConst.mkString(repr));
+			return CppMethodCall.mkThruPtr(rel, "size");
+		}
 
-        public void printStratumFunc(Stratum stratum, StratumCodeGen sgc) {
-            out.println("void stratum_" + stratum.getRank() + "() {");
-            sgc.gen(stratum).println(out, 1);
-            out.println("}");
-        }
+		public void printIdbsToDisk() {
+			for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
+				if (sym.isDisk()) {
+					out.println("    saveToDisk(\"" + ctx.lookupRepr(sym) + "\");");
+				}
+			}
+		}
 
-        public void evaluate() {
-            int n = ctx.getEval().getStrata().size();
-            for (int i = 0; i < n; ++i) {
-                CppFuncCall.mk("stratum_" + i, Collections.emptyList()).toStmt().println(out, 1);
-            }
-        }
-
-     */
-
-        public void printResults() {
-            for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
-                out.print("  cout << \"");
-                out.print(sym);
-                out.print(": \" << ");
-                genRelationSize(sym).print(out);
-                out.println(" << endl;");
-                //CppIf.mk(CppVar.mk("dump"), ctx.lookupRelation(sym).mkPrint()).println(out, 1);
-            }
-        }
-
-        private CppExpr genRelationSize(RelationSymbol sym) {
-            String repr = ctx.lookupRepr(sym);
-            CppExpr rel = CppMethodCall.mk(CppVar.mk("prog"), "getRelation", CppConst.mkString(repr));
-            return CppMethodCall.mkThruPtr(rel, "size");
-        }
-        
-        public void printIdbsToDisk() {
-            for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
-                if (sym.isDisk()) {
-                    out.println("    saveToDisk(\"" + ctx.lookupRepr(sym) + "\");");
-                }
-            }
-        }
-
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/MatchCodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/MatchCodeGen.java
@@ -56,359 +56,359 @@ import org.pcollections.HashTreePMap;
  */
 public class MatchCodeGen {
 
-    private final CodeGenContext ctx;
-    private final TermCodeGen tcg;
+	private final CodeGenContext ctx;
+	private final TermCodeGen tcg;
 
-    public MatchCodeGen(CodeGenContext ctx) {
-        this.ctx = ctx;
-        tcg = new TermCodeGen(ctx);
-    }
+	public MatchCodeGen(CodeGenContext ctx) {
+		this.ctx = ctx;
+		tcg = new TermCodeGen(ctx);
+	}
 
-    /**
-     * Generate C++ code computing a match expression.
-     *
-     * @param match The match expression
-     * @param env   The current variable environment
-     * @return A pair of the C++ code for the match expression and an expression
-     * representing the result of the match
-     */
-    public Pair<CppStmt, CppExpr> gen(MatchExpr match, Map<Var, CppExpr> env) {
-        return new Worker(new HashMap<>(env)).go(match);
-    }
+	/**
+	 * Generate C++ code computing a match expression.
+	 *
+	 * @param match The match expression
+	 * @param env   The current variable environment
+	 * @return A pair of the C++ code for the match expression and an expression
+	 *         representing the result of the match
+	 */
+	public Pair<CppStmt, CppExpr> gen(MatchExpr match, Map<Var, CppExpr> env) {
+		return new Worker(new HashMap<>(env)).go(match);
+	}
 
+	/**
+	 * This class actually does all the work of generating the C++ code. It has a
+	 * few "globals" that are available throughout the pattern-matching computation:
+	 * a variable {@link #res res} to store the result of the pattern matching
+	 * computation, and a label {@link #end end} to jump to after the pattern
+	 * matching computation is complete.
+	 * <p>
+	 * It essentially generates a bunch of nested if statements; the innermost code
+	 * jumps to {@link #end end} after assigning to {@link #res res}. Backtracking
+	 * is implemented by falling through to the next case.
+	 */
+	private class Worker {
 
-    /**
-     * This class actually does all the work of generating the C++ code. It has a
-     * few "globals" that are available throughout the pattern-matching computation:
-     * a variable {@link #res res} to store the result of the pattern matching
-     * computation, and a label {@link #end end} to jump to after the pattern
-     * matching computation is complete.
-     * <p>
-     * It essentially generates a bunch of nested if statements; the innermost code
-     * jumps to {@link #end end} after assigning to {@link #res res}. Backtracking
-     * is implemented by falling through to the next case.
-     */
-    private class Worker {
+		private final Map<Var, CppExpr> env;
+		private final List<CppStmt> acc = new ArrayList<>();
+		/**
+		 * A variable to store the result of the pattern match in.
+		 */
+		private final String res = ctx.newId("res");
+		/**
+		 * A label to jump to once the match expression has been computed.
+		 */
+		private final String end = ctx.newId("end");
 
-        private final Map<Var, CppExpr> env;
-        private final List<CppStmt> acc = new ArrayList<>();
-        /**
-         * A variable to store the result of the pattern match in.
-         */
-        private final String res = ctx.newId("res");
-        /**
-         * A label to jump to once the match expression has been computed.
-         */
-        private final String end = ctx.newId("end");
+		public Worker(Map<Var, CppExpr> env) {
+			this.env = env;
+		}
 
-        public Worker(Map<Var, CppExpr> env) {
-            this.env = env;
-        }
+		/**
+		 * Generate the C++ code for a match expression.
+		 *
+		 * @param match The match expression
+		 * @return A pair of the code and an expression holding the result of the match
+		 *         computation
+		 */
+		public Pair<CppStmt, CppExpr> go(MatchExpr match) {
+			var p = optimizeIfExpr(match);
+			if (p != null) {
+				return p;
+			}
+			acc.add(CppCtor.mk("term_ptr", res));
+			p = tcg.gen(match.getMatchee(), env);
+			acc.add(p.fst());
+			String scrutineeVar = ctx.newId("scrutinee");
+			acc.add(CppDecl.mk(scrutineeVar, p.snd()));
+			CppExpr scrutinee = CppVar.mk(scrutineeVar);
+			List<Pair<Term, Term>> clauses = preprocess(match.getClauses());
+			PatternMatchTree tree = new PatternMatchTree(clauses);
+			acc.add(processTree(scrutinee, tree));
+			/* Generate some code that dies if no pattern has been matched. */
+			acc.add(new CppStmt() {
 
-        /**
-         * Generate the C++ code for a match expression.
-         *
-         * @param match The match expression
-         * @return A pair of the code and an expression holding the result of the match
-         * computation
-         */
-        public Pair<CppStmt, CppExpr> go(MatchExpr match) {
-            var p = optimizeIfExpr(match);
-            if (p != null) {
-                return p;
-            }
-            acc.add(CppCtor.mk("term_ptr", res));
-            p = tcg.gen(match.getMatchee(), env);
-            acc.add(p.fst());
-            String scrutineeVar = ctx.newId("scrutinee");
-            acc.add(CppDecl.mk(scrutineeVar, p.snd()));
-            CppExpr scrutinee = CppVar.mk(scrutineeVar);
-            List<Pair<Term, Term>> clauses = preprocess(match.getClauses());
-            PatternMatchTree tree = new PatternMatchTree(clauses);
-            acc.add(processTree(scrutinee, tree));
-            /* Generate some code that dies if no pattern has been matched. */
-            acc.add(new CppStmt() {
+				@Override
+				public void println(PrintWriter out, int indent) {
+					CodeGenUtil.printIndent(out, indent);
+					out.print("cerr << \"No matching case for term: \" << ");
+					CppUnop.mkDeref(scrutinee).print(out);
+					out.println(" << endl;");
+					CodeGenUtil.printIndent(out, indent);
+					out.println("cerr << ");
+					out.println("R\"_(" + match + ")_\" << endl;");
+					CppFuncCall.mk("abort").toStmt().println(out, indent);
+				}
 
-                @Override
-                public void println(PrintWriter out, int indent) {
-                    CodeGenUtil.printIndent(out, indent);
-                    out.print("cerr << \"No matching case for term: \" << ");
-                    CppUnop.mkDeref(scrutinee).print(out);
-                    out.println(" << endl;");
-                    CodeGenUtil.printIndent(out, indent);
-                    out.println("cerr << ");
-                    out.println("R\"_(" + match + ")_\" << endl;");
-                    CppFuncCall.mk("abort").toStmt().println(out, indent);
-                }
+			});
+			acc.add(CppLabel.mk(end));
+			return new Pair<>(CppSeq.mk(acc), CppVar.mk(res));
+		}
 
-            });
-            acc.add(CppLabel.mk(end));
-            return new Pair<>(CppSeq.mk(acc), CppVar.mk(res));
-        }
+		private Pair<CppStmt, CppExpr> optimizeIfExpr(MatchExpr match) {
+			var scrutinee = match.getMatchee();
+			if (!(scrutinee instanceof FunctionCallFactory.FunctionCall)) {
+				return null;
+			}
+			var call = (FunctionCallFactory.FunctionCall) scrutinee;
+			var sym = call.getSymbol();
+			if (sym != BuiltInFunctionSymbol.BEQ && sym != BuiltInFunctionSymbol.BNEQ) {
+				return null;
+			}
+			var clauses = match.getClauses();
+			if (clauses.size() != 2) {
+				return null;
+			}
+			if (clauses.get(0).getLhs() != BoolTerm.mkTrue() || clauses.get(1).getLhs() != BoolTerm.mkFalse()) {
+				return null;
+			}
+			var args = call.getArgs();
+			return optimizeIfExpr(sym == BuiltInFunctionSymbol.BEQ, args[0], args[1], clauses.get(0).getRhs(),
+					clauses.get(1).getRhs());
+		}
 
-        private Pair<CppStmt, CppExpr> optimizeIfExpr(MatchExpr match) {
-            var scrutinee = match.getMatchee();
-            if (!(scrutinee instanceof FunctionCallFactory.FunctionCall)) {
-                return null;
-            }
-            var call = (FunctionCallFactory.FunctionCall) scrutinee;
-            var sym = call.getSymbol();
-            if (sym != BuiltInFunctionSymbol.BEQ && sym != BuiltInFunctionSymbol.BNEQ) {
-                return null;
-            }
-            var clauses = match.getClauses();
-            if (clauses.size() != 2) {
-                return null;
-            }
-            if (clauses.get(0).getLhs() != BoolTerm.mkTrue() || clauses.get(1).getLhs() != BoolTerm.mkFalse()) {
-                return null;
-            }
-            var args = call.getArgs();
-            return optimizeIfExpr(sym == BuiltInFunctionSymbol.BEQ, args[0], args[1], clauses.get(0).getRhs(), clauses.get(1).getRhs());
-        }
+		private Pair<CppStmt, CppExpr> optimizeIfExpr(boolean equals, Term t1, Term t2, Term ifTrue, Term ifFalse) {
+			List<CppStmt> stmts = new ArrayList<>();
+			var p1 = tcg.gen(t1, env);
+			var p2 = tcg.gen(t2, env);
+			stmts.add(p1.fst());
+			stmts.add(p2.fst());
+			String res = ctx.newId("res");
+			stmts.add(CppCtor.mk("term_ptr", res));
+			CppExpr cond;
+			if (equals) {
+				cond = CppBinop.mkEq(p1.snd(), p2.snd());
+			} else {
+				cond = CppBinop.mkNotEq(p1.snd(), p2.snd());
+			}
+			p1 = tcg.gen(ifTrue, env);
+			p2 = tcg.gen(ifFalse, env);
+			CppExpr resVar = CppVar.mk(res);
+			CppStmt trueBranch = CppSeq.mk(p1.fst(), CppBinop.mkAssign(resVar, p1.snd()).toStmt());
+			CppStmt falseBranch = CppSeq.mk(p2.fst(), CppBinop.mkAssign(resVar, p2.snd()).toStmt());
+			stmts.add(CppIf.mk(cond, trueBranch, falseBranch));
+			return new Pair<>(CppSeq.mk(stmts), resVar);
+		}
 
-        private Pair<CppStmt, CppExpr> optimizeIfExpr(boolean equals, Term t1, Term t2, Term ifTrue, Term ifFalse) {
-            List<CppStmt> stmts = new ArrayList<>();
-            var p1 = tcg.gen(t1, env);
-            var p2 = tcg.gen(t2, env);
-            stmts.add(p1.fst());
-            stmts.add(p2.fst());
-            String res = ctx.newId("res");
-            stmts.add(CppCtor.mk("term_ptr", res));
-            CppExpr cond;
-            if (equals) {
-                cond = CppBinop.mkEq(p1.snd(), p2.snd());
-            } else {
-                cond = CppBinop.mkNotEq(p1.snd(), p2.snd());
-            }
-            p1 = tcg.gen(ifTrue, env);
-            p2 = tcg.gen(ifFalse, env);
-            CppExpr resVar = CppVar.mk(res);
-            CppStmt trueBranch = CppSeq.mk(p1.fst(), CppBinop.mkAssign(resVar, p1.snd()).toStmt());
-            CppStmt falseBranch = CppSeq.mk(p2.fst(), CppBinop.mkAssign(resVar, p2.snd()).toStmt());
-            stmts.add(CppIf.mk(cond, trueBranch, falseBranch));
-            return new Pair<>(CppSeq.mk(stmts), resVar);
-        }
+		/**
+		 * Preprocess a list of match clauses, i.e., (pattern => expression) pairs.
+		 *
+		 * @param clauses The match clauses
+		 * @return The updated (pattern => expression) pairs
+		 */
+		private List<Pair<Term, Term>> preprocess(List<MatchClause> clauses) {
+			List<Pair<Term, Term>> l = new ArrayList<>();
+			Substitution s = new SimpleSubstitution();
+			Set<Var> vars = new HashSet<>();
+			/*
+			 * Rename variables in patterns, to ensure that patterns do not share variables
+			 * with each other.
+			 */
+			for (MatchClause clause : clauses) {
+				Pair<Term, Set<Var>> p = renameVars(clause.getLhs(), s);
+				Term rhs = clause.getRhs().applySubstitution(s);
+				l.add(new Pair<>(p.fst(), rhs));
+				vars.addAll(p.snd());
+			}
+			/*
+			 * Declare all the variables used in patterns.
+			 */
+			for (Var x : vars) {
+				String id = ctx.newId("y");
+				CppVar cppX = CppVar.mk(id);
+				env.put(x, cppX);
+				acc.add(CppCtor.mk("term_ptr", id));
+			}
+			return l;
+		}
 
-        /**
-         * Preprocess a list of match clauses, i.e., (pattern => expression) pairs.
-         *
-         * @param clauses The match clauses
-         * @return The updated (pattern => expression) pairs
-         */
-        private List<Pair<Term, Term>> preprocess(List<MatchClause> clauses) {
-            List<Pair<Term, Term>> l = new ArrayList<>();
-            Substitution s = new SimpleSubstitution();
-            Set<Var> vars = new HashSet<>();
-            /*
-             * Rename variables in patterns, to ensure that patterns do not share variables
-             * with each other.
-             */
-            for (MatchClause clause : clauses) {
-                Pair<Term, Set<Var>> p = renameVars(clause.getLhs(), s);
-                Term rhs = clause.getRhs().applySubstitution(s);
-                l.add(new Pair<>(p.fst(), rhs));
-                vars.addAll(p.snd());
-            }
-            /*
-             * Declare all the variables used in patterns.
-             */
-            for (Var x : vars) {
-                String id = ctx.newId("y");
-                CppVar cppX = CppVar.mk(id);
-                env.put(x, cppX);
-                acc.add(CppCtor.mk("term_ptr", id));
-            }
-            return l;
-        }
+		/**
+		 * Rename the variables in a term.
+		 *
+		 * @param t The term
+		 * @param s A substitution to update with bindings from old variables to new
+		 *          ones
+		 * @return A pair of the new term and the set of variables in that term
+		 */
+		private Pair<Term, Set<Var>> renameVars(Term t, Substitution s) {
+			Set<Var> seen = new HashSet<>();
+			Set<Var> newVars = new HashSet<>();
+			Term newT = t.accept(new TermVisitor<Void, Term>() {
 
-        /**
-         * Rename the variables in a term.
-         *
-         * @param t The term
-         * @param s A substitution to update with bindings from old variables to new
-         *          ones
-         * @return A pair of the new term and the set of variables in that term
-         */
-        private Pair<Term, Set<Var>> renameVars(Term t, Substitution s) {
-            Set<Var> seen = new HashSet<>();
-            Set<Var> newVars = new HashSet<>();
-            Term newT = t.accept(new TermVisitor<Void, Term>() {
+				@Override
+				public Term visit(Var old, Void in) {
+					assert seen.add(old) : "Cannot handle patterns with multiple uses of the same variable: " + t;
+					Var renamed = Var.fresh();
+					newVars.add(renamed);
+					s.put(old, renamed);
+					return renamed;
+				}
 
-                @Override
-                public Term visit(Var old, Void in) {
-                    assert seen.add(old) : "Cannot handle patterns with multiple uses of the same variable: " + t;
-                    Var renamed = Var.fresh();
-                    newVars.add(renamed);
-                    s.put(old, renamed);
-                    return renamed;
-                }
+				@Override
+				public Term visit(Constructor c, Void in) {
+					Term[] args = c.getArgs();
+					Term[] newArgs = new Term[args.length];
+					for (int i = 0; i < args.length; ++i) {
+						newArgs[i] = args[i].accept(this, in);
+					}
+					return c.copyWithNewArgs(newArgs);
+				}
 
-                @Override
-                public Term visit(Constructor c, Void in) {
-                    Term[] args = c.getArgs();
-                    Term[] newArgs = new Term[args.length];
-                    for (int i = 0; i < args.length; ++i) {
-                        newArgs[i] = args[i].accept(this, in);
-                    }
-                    return c.copyWithNewArgs(newArgs);
-                }
+				@Override
+				public Term visit(Primitive<?> p, Void in) {
+					return p;
+				}
 
-                @Override
-                public Term visit(Primitive<?> p, Void in) {
-                    return p;
-                }
+				@Override
+				public Term visit(Expr e, Void in) {
+					throw new AssertionError("impossible");
+				}
 
-                @Override
-                public Term visit(Expr e, Void in) {
-                    throw new AssertionError("impossible");
-                }
+			}, null);
+			return new Pair<>(newT, newVars);
+		}
 
-            }, null);
-            return new Pair<>(newT, newVars);
-        }
+		/**
+		 * Given a C++ expression representing the scrutinee of a match expression and a
+		 * pattern-matching tree encoding the match expression's logic, generate C++
+		 * code implementing the match expression.
+		 *
+		 * @param scrutinee The scrutinee
+		 * @param tree      The pattern-matching tree
+		 * @return The generated C++ code
+		 */
+		private CppStmt processTree(CppExpr scrutinee, PatternMatchTree tree) {
+			return new TreeProcessor(scrutinee, tree).go();
+		}
 
-        /**
-         * Given a C++ expression representing the scrutinee of a match expression and a
-         * pattern-matching tree encoding the match expression's logic, generate C++
-         * code implementing the match expression.
-         *
-         * @param scrutinee The scrutinee
-         * @param tree      The pattern-matching tree
-         * @return The generated C++ code
-         */
-        private CppStmt processTree(CppExpr scrutinee, PatternMatchTree tree) {
-            return new TreeProcessor(scrutinee, tree).go();
-        }
+		/**
+		 * This class is used to turn a pattern-matching tree into C++ code.
+		 */
+		private class TreeProcessor {
 
-        /**
-         * This class is used to turn a pattern-matching tree into C++ code.
-         */
-        private class TreeProcessor {
+			private final CppExpr scrutinee;
+			private final PatternMatchTree tree;
 
-            private final CppExpr scrutinee;
-            private final PatternMatchTree tree;
+			public TreeProcessor(CppExpr scrutinee, PatternMatchTree tree) {
+				this.scrutinee = scrutinee;
+				this.tree = tree;
+			}
 
-            public TreeProcessor(CppExpr scrutinee, PatternMatchTree tree) {
-                this.scrutinee = scrutinee;
-                this.tree = tree;
-            }
+			/**
+			 * Generate the C++ code encoding the pattern-matching logic of this object's
+			 * pattern-matching tree.
+			 *
+			 * @return The generated C++ code
+			 */
+			public CppStmt go() {
+				return go(tree.getRoot(), HashTreePMap.empty());
+			}
 
-            /**
-             * Generate the C++ code encoding the pattern-matching logic of this object's
-             * pattern-matching tree.
-             *
-             * @return The generated C++ code
-             */
-            public CppStmt go() {
-                return go(tree.getRoot(), HashTreePMap.empty());
-            }
+			/**
+			 * Generate the C++ code corresponding to a node in the pattern matching tree.
+			 *
+			 * @param node The node
+			 * @return
+			 */
+			private CppStmt go(Node node, HashPMap<SymbolicTerm, CppExpr> symMap) {
+				return node.accept(new NodeVisitor<Void, CppStmt>() {
 
-            /**
-             * Generate the C++ code corresponding to a node in the pattern matching tree.
-             *
-             * @param node The node
-             * @return
-             */
-            private CppStmt go(Node node, HashPMap<SymbolicTerm, CppExpr> symMap) {
-                return node.accept(new NodeVisitor<Void, CppStmt>() {
+					@Override
+					public CppStmt visit(InternalNode node, Void in) {
+						/*
+						 * You're at an internal node that is associated with a symbolic term (derived
+						 * from the scrutinee). Generate a C++ expression for the symbolic term, and
+						 * then generate code for checking that term against each outgoing edge of that
+						 * node.
+						 */
+						List<CppStmt> stmts = new ArrayList<>();
+						SymbolicTerm symTerm = node.getSymbolicTerm();
+						/* Generate the C++ expression for the symbolic term. */
+						CppExpr expr;
+						if (symTerm == BaseSymbolicTerm.INSTANCE) {
+							expr = scrutinee;
+						} else {
+							DerivedSymbolicTerm dst = (DerivedSymbolicTerm) symTerm;
+							CppExpr base = symMap.get(dst.getBase());
+							assert base != null;
+							String id = ctx.newId("s");
+							stmts.add(CppDecl.mk(id, CodeGenUtil.mkComplexTermLookup(base, dst.getIndex())));
+							expr = CppVar.mk(id);
+						}
+						assert !(symMap.containsKey(symTerm));
+						var newMap = symMap.plus(symTerm, expr);
+						/* Handle the outgoing edges. */
+						for (Pair<Edge<?>, Node> p : tree.getOutgoingEdges(node)) {
+							stmts.add(go(expr, p.fst(), p.snd(), newMap));
+						}
+						return CppSeq.mk(stmts);
+					}
 
-                    @Override
-                    public CppStmt visit(InternalNode node, Void in) {
-                        /*
-                         * You're at an internal node that is associated with a symbolic term (derived
-                         * from the scrutinee). Generate a C++ expression for the symbolic term, and
-                         * then generate code for checking that term against each outgoing edge of that
-                         * node.
-                         */
-                        List<CppStmt> stmts = new ArrayList<>();
-                        SymbolicTerm symTerm = node.getSymbolicTerm();
-                        /* Generate the C++ expression for the symbolic term. */
-                        CppExpr expr;
-                        if (symTerm == BaseSymbolicTerm.INSTANCE) {
-                            expr = scrutinee;
-                        } else {
-                            DerivedSymbolicTerm dst = (DerivedSymbolicTerm) symTerm;
-                            CppExpr base = symMap.get(dst.getBase());
-                            assert base != null;
-                            String id = ctx.newId("s");
-                            stmts.add(CppDecl.mk(id, CodeGenUtil.mkComplexTermLookup(base, dst.getIndex())));
-                            expr = CppVar.mk(id);
-                        }
-                        assert !(symMap.containsKey(symTerm));
-                        var newMap = symMap.plus(symTerm, expr);
-                        /* Handle the outgoing edges. */
-                        for (Pair<Edge<?>, Node> p : tree.getOutgoingEdges(node)) {
-                            stmts.add(go(expr, p.fst(), p.snd(), newMap));
-                        }
-                        return CppSeq.mk(stmts);
-                    }
+					@Override
+					public CppStmt visit(Leaf node, Void in) {
+						/*
+						 * You've reached a leaf, so you've successfully matched the scrutinee against a
+						 * pattern. Evaluate the expression on the right-hand side of that pattern,
+						 * assign it to the result variable, and jump to the end label.
+						 */
+						Pair<CppStmt, CppExpr> p = tcg.gen(node.getTerm(), env);
+						CppStmt assign = CppBinop.mkAssign(CppVar.mk(res), p.snd()).toStmt();
+						CppStmt jump = CppGoto.mk(end);
+						return CppSeq.mk(p.fst(), assign, jump);
+					}
 
-                    @Override
-                    public CppStmt visit(Leaf node, Void in) {
-                        /*
-                         * You've reached a leaf, so you've successfully matched the scrutinee against a
-                         * pattern. Evaluate the expression on the right-hand side of that pattern,
-                         * assign it to the result variable, and jump to the end label.
-                         */
-                        Pair<CppStmt, CppExpr> p = tcg.gen(node.getTerm(), env);
-                        CppStmt assign = CppBinop.mkAssign(CppVar.mk(res), p.snd()).toStmt();
-                        CppStmt jump = CppGoto.mk(end);
-                        return CppSeq.mk(p.fst(), assign, jump);
-                    }
+				}, null);
+			}
 
-                }, null);
-            }
+			/**
+			 * Given a C++ expression representing the current sub-scrutinee, generate C++
+			 * code implementing the pattern-matching logic encoded by the given edge and
+			 * the rest of the tree it leads to.
+			 *
+			 * @param expr The sub-scrutinee
+			 * @param edge The edge encoding the next step of pattern-matching logic
+			 * @param dest The destination of the edge, which leads to subsequent
+			 *             pattern-matching logic
+			 * @return The generated C++ code
+			 */
+			private CppStmt go(CppExpr expr, Edge<?> edge, Node dest, HashPMap<SymbolicTerm, CppExpr> symMap) {
+				return edge.accept(new EdgeVisitor<Void, CppStmt>() {
 
-            /**
-             * Given a C++ expression representing the current sub-scrutinee, generate C++
-             * code implementing the pattern-matching logic encoded by the given edge and
-             * the rest of the tree it leads to.
-             *
-             * @param expr The sub-scrutinee
-             * @param edge The edge encoding the next step of pattern-matching logic
-             * @param dest The destination of the edge, which leads to subsequent
-             *             pattern-matching logic
-             * @return The generated C++ code
-             */
-            private CppStmt go(CppExpr expr, Edge<?> edge, Node dest, HashPMap<SymbolicTerm, CppExpr> symMap) {
-                return edge.accept(new EdgeVisitor<Void, CppStmt>() {
+					@Override
+					public CppStmt visit(VarEdge e, Void in) {
+						CppExpr x = env.get(e.getLabel());
+						assert x instanceof CppVar;
+						// Here, the enclosing `CppBlock` is necessary so that possible variable
+						// initializations aren't in the outside scope, due to limitations of `goto`
+						return CppBlock.mk(CppSeq.mk(CppBinop.mkAssign(x, expr).toStmt(), go(dest, symMap)));
+					}
 
-                    @Override
-                    public CppStmt visit(VarEdge e, Void in) {
-                        CppExpr x = env.get(e.getLabel());
-                        assert x instanceof CppVar;
-                        // Here, the enclosing `CppBlock` is necessary so that possible variable
-                        // initializations aren't in the outside scope, due to limitations of `goto`
-                        return CppBlock.mk(CppSeq.mk(CppBinop.mkAssign(x, expr).toStmt(), go(dest, symMap)));
-                    }
+					@Override
+					public CppStmt visit(PrimEdge e, Void in) {
+						Pair<CppStmt, CppExpr> p = tcg.gen(e.getLabel(), env);
+						// Primitive edge should have no statements; otherwise, this could pollute the
+						// enclosing scope and cause a compilation error, since `goto` can't jump over
+						// variable initializations in C++
+						assert CodeGenUtil.toString(p.fst(), 0).isEmpty();
+						CppExpr rhs = p.snd();
+						CppExpr guard = CppBinop.mkEq(expr, rhs);
+						CppStmt body = go(dest, symMap);
+						return CppIf.mk(guard, body);
+					}
 
-                    @Override
-                    public CppStmt visit(PrimEdge e, Void in) {
-                        Pair<CppStmt, CppExpr> p = tcg.gen(e.getLabel(), env);
-                        // Primitive edge should have no statements; otherwise, this could pollute the
-                        // enclosing scope and cause a compilation error, since `goto` can't jump over
-                        // variable initializations in C++
-                        assert CodeGenUtil.toString(p.fst(), 0).isEmpty();
-                        CppExpr rhs = p.snd();
-                        CppExpr guard = CppBinop.mkEq(expr, rhs);
-                        CppStmt body = go(dest, symMap);
-                        return CppIf.mk(guard, body);
-                    }
+					@Override
+					public CppStmt visit(CtorEdge e, Void in) {
+						CppExpr symbol = CppVar.mk(ctx.lookupRepr(e.getLabel()));
+						CppExpr guard = CppBinop.mkEq(CppAccess.mkThruPtr(expr, "sym"), symbol);
+						CppStmt body = go(dest, symMap);
+						return CppIf.mk(guard, body);
+					}
 
-                    @Override
-                    public CppStmt visit(CtorEdge e, Void in) {
-                        CppExpr symbol = CppVar.mk(ctx.lookupRepr(e.getLabel()));
-                        CppExpr guard = CppBinop.mkEq(CppAccess.mkThruPtr(expr, "sym"), symbol);
-                        CppStmt body = go(dest, symMap);
-                        return CppIf.mk(guard, body);
-                    }
+				}, null);
+			}
 
-                }, null);
-            }
+		}
 
-        }
-
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/NewSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/NewSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.symbols.AbstractWrappedRelationSymbol;
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 
@@ -29,7 +28,7 @@ public class NewSymbol extends AbstractWrappedRelationSymbol<RelationSymbol> {
 	public NewSymbol(RelationSymbol baseSymbol) {
 		super(baseSymbol);
 	}
-	
+
 	@Override
 	public String toString() {
 		return "new:" + getBaseSymbol();

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/PatternMatchTree.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/PatternMatchTree.java
@@ -74,8 +74,7 @@ public class PatternMatchTree {
 	/**
 	 * Construct a pattern match tree from a list of (pattern => expression) pairs
 	 * 
-	 * @param clauses
-	 *            The (pattern => expression) pairs
+	 * @param clauses The (pattern => expression) pairs
 	 */
 	public PatternMatchTree(List<Pair<Term, Term>> clauses) {
 		PatternMatchingComputation k = PatternMatchingComputation.mk(clauses);
@@ -95,8 +94,7 @@ public class PatternMatchTree {
 	 * Get a map from representing the outgoing edges of the given node. The map's
 	 * iterator order matches the priority of the edges (high to low).
 	 * 
-	 * @param node
-	 *            The node
+	 * @param node The node
 	 * @return Map with the outgoing edges
 	 */
 	public Iterable<Pair<Edge<?>, Node>> getOutgoingEdges(Node node) {
@@ -116,8 +114,7 @@ public class PatternMatchTree {
 	 * Turn a pattern-matching computation into a tree representing that
 	 * computation.
 	 * 
-	 * @param k
-	 *            The computation
+	 * @param k The computation
 	 * @return return The node at the root of that tree
 	 */
 	private Node build(PatternMatchingComputation k) {
@@ -216,8 +213,7 @@ public class PatternMatchTree {
 		 * Construct a pattern-matching computation from a list of (pattern =>
 		 * expression) pairs.
 		 * 
-		 * @param clauses
-		 *            The (pattern => expression) pairs
+		 * @param clauses The (pattern => expression) pairs
 		 * @return the pattern-matching computation
 		 */
 		public static PatternMatchingComputation mk(List<Pair<Term, Term>> clauses) {
@@ -293,8 +289,7 @@ public class PatternMatchTree {
 		 * Create an edge corresponding to the pattern matching logic for the first step
 		 * in processing a deque of patterns. The provided deque is also updated.
 		 * 
-		 * @param d
-		 *            The deque of patterns
+		 * @param d The deque of patterns
 		 * @return The edge
 		 */
 		private static Edge<?> step(Deque<Term> d) {
@@ -403,7 +398,7 @@ public class PatternMatchTree {
 	public static class InternalNode implements Node {
 
 		private static AtomicInteger cnt = new AtomicInteger();
-		
+
 		private final SymbolicTerm symbolicTerm;
 		private final int id = cnt.getAndIncrement();
 
@@ -461,8 +456,7 @@ public class PatternMatchTree {
 	 * constructor), and this interface is parametric in the type of computation
 	 * that needs to be performed.
 	 *
-	 * @param <T>
-	 *            The type of the edge
+	 * @param <T> The type of the edge
 	 */
 	public static interface Edge<T> {
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/Relation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/Relation.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import java.util.List;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;
@@ -29,38 +28,38 @@ import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppStmt;
 
 public interface Relation extends CppExpr {
 
-    CppStmt mkDecl();
+	CppStmt mkDecl();
 
-    CppExpr mkContains(CppExpr expr, boolean useHints);
+	CppExpr mkContains(CppExpr expr, boolean useHints);
 
-    CppExpr mkContains(int idx, CppExpr expr, boolean useHints);
+	CppExpr mkContains(int idx, CppExpr expr, boolean useHints);
 
-    CppExpr mkInsert(CppExpr expr, boolean useHints);
+	CppExpr mkInsert(CppExpr expr, boolean useHints);
 
-    CppExpr mkInsertAll(CppExpr expr);
+	CppExpr mkInsertAll(CppExpr expr);
 
-    CppExpr mkIsEmpty();
+	CppExpr mkIsEmpty();
 
-    CppStmt mkDeclTuple(String name);
+	CppStmt mkDeclTuple(String name);
 
-    CppStmt mkDeclTuple(String name, List<CppExpr> exprs);
+	CppStmt mkDeclTuple(String name, List<CppExpr> exprs);
 
-    CppExpr mkTuple(List<CppExpr> exprs);
+	CppExpr mkTuple(List<CppExpr> exprs);
 
-    CppExpr mkTupleAccess(CppExpr tup, CppExpr idx);
+	CppExpr mkTupleAccess(CppExpr tup, CppExpr idx);
 
-    CppStmt mkPrint();
+	CppStmt mkPrint();
 
-    CppExpr mkPartition();
+	CppExpr mkPartition();
 
-    CppStmt mkPurge();
+	CppStmt mkPurge();
 
-    CppExpr mkLookup(int idx, BindingType[] pat, CppExpr key, boolean useHints);
+	CppExpr mkLookup(int idx, BindingType[] pat, CppExpr key, boolean useHints);
 
-    CppExpr mkSize();
+	CppExpr mkSize();
 
-    RelationStruct getStruct();
+	RelationStruct getStruct();
 
-    CppStmt mkDeclContext();
+	CppStmt mkDeclContext();
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/RelationStruct.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/RelationStruct.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
@@ -28,9 +27,9 @@ import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 public interface RelationStruct {
 
 	void declare(PrintWriter out);
-	
+
 	Relation mkRelation(RelationSymbol sym);
-	
+
 	String getName();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/RelsHpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/RelsHpp.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 
 import java.io.BufferedReader;
@@ -29,48 +28,36 @@ import java.io.PrintWriter;
 
 public class RelsHpp extends TemplateSrcFile {
 
-    public RelsHpp(CodeGenContext ctx) {
-        super("rels.hpp", ctx);
-    }
+	public RelsHpp(CodeGenContext ctx) {
+		super("rels.hpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        /*
-        Worker pr = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        pr.defineRelations();
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		/*
+		 * Worker pr = new Worker(out); CodeGenUtil.copyOver(br, out, 0);
+		 * pr.defineRelations();
+		 * 
+		 */
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-         */
-        CodeGenUtil.copyOver(br, out, -1);
-    }
-
-    /*
-    private class Worker {
-
-        private final PrintWriter out;
-
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
-
-        public void defineRelations() {
-            defineStructs();
-            defineRelations1();
-        }
-
-        private void defineStructs() {
-            for (RelationStruct struct : ctx.getRelationStructs()) {
-                struct.declare(out);
-                out.println();
-            }
-        }
-
-        private void defineRelations1() {
-            for (RelationSymbol sym : ctx.getRelationSymbols()) {
-                ctx.lookupRelation(sym).mkDecl().println(out, 0);
-            }
-        }
-
-    }
-     */
+	/*
+	 * private class Worker {
+	 * 
+	 * private final PrintWriter out;
+	 * 
+	 * public Worker(PrintWriter out) { this.out = out; }
+	 * 
+	 * public void defineRelations() { defineStructs(); defineRelations1(); }
+	 * 
+	 * private void defineStructs() { for (RelationStruct struct :
+	 * ctx.getRelationStructs()) { struct.declare(out); out.println(); } }
+	 * 
+	 * private void defineRelations1() { for (RelationSymbol sym :
+	 * ctx.getRelationSymbols()) { ctx.lookupRelation(sym).mkDecl().println(out, 0);
+	 * } }
+	 * 
+	 * }
+	 */
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/RuleTranslator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/RuleTranslator.java
@@ -37,254 +37,252 @@ import java.util.stream.Collectors;
 
 public class RuleTranslator {
 
-    private final CodeGenContext ctx;
-    private final QueryPlanner queryPlanner;
-    private static final String checkPred = "CODEGEN_CHECK";
+	private final CodeGenContext ctx;
+	private final QueryPlanner queryPlanner;
+	private static final String checkPred = "CODEGEN_CHECK";
 
-    public RuleTranslator(CodeGenContext ctx, QueryPlanner queryPlanner) {
-        this.ctx = ctx;
-        this.queryPlanner = queryPlanner;
-    }
+	public RuleTranslator(CodeGenContext ctx, QueryPlanner queryPlanner) {
+		this.ctx = ctx;
+		this.queryPlanner = queryPlanner;
+	}
 
-    public Pair<List<SRule>, List<Stratum>> translate(BasicProgram prog) throws CodeGenException {
-        var strats = checkStratification(prog);
-        List<SRule> l = new ArrayList<>();
-        Worker worker = new Worker(prog);
-        for (var stratum : strats) {
-            for (RelationSymbol sym : stratum.getPredicateSyms()) {
-                for (BasicRule r : prog.getRules(sym)) {
-                    var sr = worker.translate(r);
-                    sr.setQueryPlan(queryPlanner.genPlan(sr, stratum));
-                    l.add(sr);
-                }
-            }
-        }
-        l.addAll(worker.createProjectionRules());
-        l.add(worker.createCheckRule());
-        return new Pair<>(l, strats);
-    }
+	public Pair<List<SRule>, List<Stratum>> translate(BasicProgram prog) throws CodeGenException {
+		var strats = checkStratification(prog);
+		List<SRule> l = new ArrayList<>();
+		Worker worker = new Worker(prog);
+		for (var stratum : strats) {
+			for (RelationSymbol sym : stratum.getPredicateSyms()) {
+				for (BasicRule r : prog.getRules(sym)) {
+					var sr = worker.translate(r);
+					sr.setQueryPlan(queryPlanner.genPlan(sr, stratum));
+					l.add(sr);
+				}
+			}
+		}
+		l.addAll(worker.createProjectionRules());
+		l.add(worker.createCheckRule());
+		return new Pair<>(l, strats);
+	}
 
-    private List<Stratum> checkStratification(BasicProgram prog) throws CodeGenException {
-        Stratifier stratifier = new Stratifier(prog);
-        List<Stratum> strats;
-        try {
-            strats = stratifier.stratify();
-        } catch (InvalidProgramException e) {
-            throw new CodeGenException(e);
-        }
-        for (Stratum strat : strats) {
-            if (strat.hasRecursiveNegationOrAggregation()) {
-                throw new CodeGenException("Cannot handle recursive negation or aggregation: " + strat);
-            }
-        }
-        return strats;
-    }
+	private List<Stratum> checkStratification(BasicProgram prog) throws CodeGenException {
+		Stratifier stratifier = new Stratifier(prog);
+		List<Stratum> strats;
+		try {
+			strats = stratifier.stratify();
+		} catch (InvalidProgramException e) {
+			throw new CodeGenException(e);
+		}
+		for (Stratum strat : strats) {
+			if (strat.hasRecursiveNegationOrAggregation()) {
+				throw new CodeGenException("Cannot handle recursive negation or aggregation: " + strat);
+			}
+		}
+		return strats;
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final BasicProgram prog;
-        private Map<Var, Integer> varCount;
-        private final Set<Pair<RelationSymbol, List<Boolean>>> projections = new HashSet<>();
+		private final BasicProgram prog;
+		private Map<Var, Integer> varCount;
+		private final Set<Pair<RelationSymbol, List<Boolean>>> projections = new HashSet<>();
 
-        public Worker(BasicProgram prog) {
-            this.prog = prog;
-        }
+		public Worker(BasicProgram prog) {
+			this.prog = prog;
+		}
 
-        private SRule translate(BasicRule br) throws CodeGenException {
-            SimpleRule sr;
-            try {
-                ValidRule vr = ValidRule.make(br, (_lit, _vars) -> 1);
-                sr = SimpleRule.make(vr, prog.getFunctionCallFactory());
-                varCount = sr.countVariables();
-            } catch (InvalidProgramException e) {
-                throw new CodeGenException(e);
-            }
-            List<SLit> headTrans = translate(sr.getHead());
-            assert headTrans.size() == 1;
-            SLit head = headTrans.get(0);
-            List<SLit> body = new ArrayList<>();
-            for (int i = 0; i < sr.getBodySize(); ++i) {
-                body.addAll(translate(sr.getBody(i)));
-            }
-            return new SRule(head, body);
-        }
+		private SRule translate(BasicRule br) throws CodeGenException {
+			SimpleRule sr;
+			try {
+				ValidRule vr = ValidRule.make(br, (_lit, _vars) -> 1);
+				sr = SimpleRule.make(vr, prog.getFunctionCallFactory());
+				varCount = sr.countVariables();
+			} catch (InvalidProgramException e) {
+				throw new CodeGenException(e);
+			}
+			List<SLit> headTrans = translate(sr.getHead());
+			assert headTrans.size() == 1;
+			SLit head = headTrans.get(0);
+			List<SLit> body = new ArrayList<>();
+			for (int i = 0; i < sr.getBodySize(); ++i) {
+				body.addAll(translate(sr.getBody(i)));
+			}
+			return new SRule(head, body);
+		}
 
-        private List<SLit> translate(SimpleLiteral lit) {
-            return lit.accept(new SimpleLiteralVisitor<Void, List<SLit>>() {
-                @Override
-                public List<SLit> visit(Assignment assignment, Void input) {
-                    STerm lhs = translate(assignment.getDef());
-                    STerm rhs = translate(assignment.getVal());
-                    return Collections.singletonList(new SInfixBinaryOpAtom(lhs, "=", rhs));
-                }
+		private List<SLit> translate(SimpleLiteral lit) {
+			return lit.accept(new SimpleLiteralVisitor<Void, List<SLit>>() {
+				@Override
+				public List<SLit> visit(Assignment assignment, Void input) {
+					STerm lhs = translate(assignment.getDef());
+					STerm rhs = translate(assignment.getVal());
+					return Collections.singletonList(new SInfixBinaryOpAtom(lhs, "=", rhs));
+				}
 
-                @Override
-                public List<SLit> visit(Check check, Void input) {
-                    STerm lhs = translate(check.getLhs());
-                    STerm rhs = translate(check.getRhs());
-                    return Collections.singletonList(new SInfixBinaryOpAtom(lhs, check.isNegated() ? "!=" : "=", rhs));
-                }
+				@Override
+				public List<SLit> visit(Check check, Void input) {
+					STerm lhs = translate(check.getLhs());
+					STerm rhs = translate(check.getRhs());
+					return Collections.singletonList(new SInfixBinaryOpAtom(lhs, check.isNegated() ? "!=" : "=", rhs));
+				}
 
-                @Override
-                public List<SLit> visit(Destructor destructor, Void input) {
-                    /*
-                    A destructor of the form
+				@Override
+				public List<SLit> visit(Destructor destructor, Void input) {
+					/*
+					 * A destructor of the form
+					 * 
+					 * t -> c(X1, ..., Xn)
+					 * 
+					 * gets translated as
+					 * 
+					 * X0 = [[t]],
+					 * 
+					 * @dtor_c(X0) = B, CODEGEN_CHECK(B, B2), X1 = @nth(0, X0, B2), ..., Xn = @nth(n
+					 * - 1, X0, B2).
+					 * 
+					 * @dtor_c(...) returns 1 if the term has the symbol c and 0 otherwise.
+					 * CODEGEN_CHECK has a single tuple [1, 1]. It is there to make sure that the
+					 * destructor has been successful before nth is called.
+					 */
+					List<SLit> l = new ArrayList<>();
+					Term scrutinee = destructor.getScrutinee();
+					STerm translatedScrutineeExpr = translate(scrutinee);
+					Var scrutineeVar = Var.fresh();
+					STerm translatedScrutineeVar = new SVar(scrutineeVar);
+					l.add(new SInfixBinaryOpAtom(translatedScrutineeVar, "=", translatedScrutineeExpr));
+					List<Var> args = Collections.singletonList(scrutineeVar);
+					String functor = ctx.lookupOrCreateFunctorName(destructor.getSymbol());
+					var dtor = new SDestructorBody(args, scrutineeVar, destructor.getSymbol());
+					ctx.registerFunctorBody(functor, dtor);
+					List<STerm> translatedArgs = args.stream().map(Worker.this::translate).collect(Collectors.toList());
+					assert translatedArgs.size() == 1 && translatedArgs.get(0) instanceof SVar;
+					STerm lhs = new SFunctorCall(functor, translatedArgs);
+					SVar recRef = new SVar(Var.fresh());
+					l.add(new SInfixBinaryOpAtom(lhs, "=", recRef));
+					SVar checkOutput = new SVar(Var.fresh());
+					l.add(new SAtom(checkPred, Arrays.asList(recRef, checkOutput), false));
+					int arity = destructor.getSymbol().getArity();
+					Var[] bindings = destructor.getBindings();
+					for (int i = 0; i < arity; ++i) {
+						SFunctorCall call = new SFunctorCall("nth", new SInt(i), translatedArgs.get(0), checkOutput);
+						l.add(new SInfixBinaryOpAtom(translate(bindings[i]), "=", call));
+					}
+					return l;
+				}
 
-                        t -> c(X1, ..., Xn)
+				@Override
+				public List<SLit> visit(SimplePredicate predicate, Void input) {
+					List<STerm> args = Arrays.stream(predicate.getArgs()).map(Worker.this::translate)
+							.collect(Collectors.toList());
+					SLit lit;
+					if (predicate.isNegated()) {
+						lit = handleNegatedPredicate(predicate, args);
+					} else {
+						String symbol = ctx.lookupRepr(predicate.getSymbol());
+						lit = new SAtom(symbol, args, false);
+					}
+					return Collections.singletonList(lit);
+				}
+			}, null);
+		}
 
-                    gets translated as
+		private SLit handleNegatedPredicate(SimplePredicate predicate, List<STerm> souffleArgs) {
+			List<Boolean> projection = new ArrayList<>();
+			int ignoredCount = 0;
+			var args = predicate.getArgs();
+			for (Term arg : args) {
+				if (arg instanceof Var && varCount.get((Var) arg) == 1) {
+					ignoredCount++;
+					projection.add(false);
+				} else {
+					projection.add(true);
+				}
+			}
+			RelationSymbol sym = predicate.getSymbol();
+			if (ignoredCount == 0) {
+				return new SAtom(ctx.lookupRepr(sym), souffleArgs, true);
+			}
+			projections.add(new Pair<>(predicate.getSymbol(), projection));
+			List<STerm> newArgs = new ArrayList<>();
+			for (int i = 0; i < souffleArgs.size(); ++i) {
+				if (projection.get(i)) {
+					newArgs.add(souffleArgs.get(i));
+				}
+			}
+			return new SAtom(createProjectionSymbol(sym, projection), newArgs, true);
+		}
 
-                        X0 = [[t]],
-                        @dtor_c(X0) = B,
-                        CODEGEN_CHECK(B, B2),
-                        X1 = @nth(0, X0, B2),
-                        ...,
-                        Xn = @nth(n - 1, X0, B2).
+		private String createProjectionSymbol(RelationSymbol sym, List<Boolean> projection) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("CODEGEN_PROJECT_");
+			sb.append(ctx.lookupRepr(sym));
+			for (Boolean retain : projection) {
+				sb.append(retain ? "1" : "0");
+			}
+			return sb.toString();
+		}
 
-                    @dtor_c(...) returns 1 if the term has the symbol c and 0 otherwise.
-                    CODEGEN_CHECK has a single tuple [1, 1]. It is there to make sure that the destructor has been
-                    successful before nth is called.
-                     */
-                    List<SLit> l = new ArrayList<>();
-                    Term scrutinee = destructor.getScrutinee();
-                    STerm translatedScrutineeExpr = translate(scrutinee);
-                    Var scrutineeVar = Var.fresh();
-                    STerm translatedScrutineeVar = new SVar(scrutineeVar);
-                    l.add(new SInfixBinaryOpAtom(translatedScrutineeVar, "=", translatedScrutineeExpr));
-                    List<Var> args = Collections.singletonList(scrutineeVar);
-                    String functor = ctx.lookupOrCreateFunctorName(destructor.getSymbol());
-                    var dtor = new SDestructorBody(args, scrutineeVar, destructor.getSymbol());
-                    ctx.registerFunctorBody(functor, dtor);
-                    List<STerm> translatedArgs = args.stream().map(Worker.this::translate).collect(Collectors.toList());
-                    assert translatedArgs.size() == 1 && translatedArgs.get(0) instanceof SVar;
-                    STerm lhs = new SFunctorCall(functor, translatedArgs);
-                    SVar recRef = new SVar(Var.fresh());
-                    l.add(new SInfixBinaryOpAtom(lhs, "=", recRef));
-                    SVar checkOutput = new SVar(Var.fresh());
-                    l.add(new SAtom(checkPred, Arrays.asList(recRef, checkOutput), false));
-                    int arity = destructor.getSymbol().getArity();
-                    Var[] bindings = destructor.getBindings();
-                    for (int i = 0; i < arity; ++i) {
-                        SFunctorCall call = new SFunctorCall("nth", new SInt(i), translatedArgs.get(0), checkOutput);
-                        l.add(new SInfixBinaryOpAtom(translate(bindings[i]), "=", call));
-                    }
-                    return l;
-                }
+		private SFunctorCall liftToFunctor(Term t) {
+			String functor = ctx.lookupOrCreateFunctorName(t);
+			List<Var> args = new ArrayList<>(t.varSet());
+			ctx.registerFunctorBody(functor, new SExprBody(args, t));
+			List<STerm> translatedArgs = args.stream().map(this::translate).collect(Collectors.toList());
+			return new SFunctorCall(functor, translatedArgs);
+		}
 
-                @Override
-                public List<SLit> visit(SimplePredicate predicate, Void input) {
-                    List<STerm> args = Arrays.stream(predicate.getArgs()).map(Worker.this::translate).
-                            collect(Collectors.toList());
-                    SLit lit;
-                    if (predicate.isNegated()) {
-                        lit = handleNegatedPredicate(predicate, args);
-                    } else {
-                        String symbol = ctx.lookupRepr(predicate.getSymbol());
-                        lit = new SAtom(symbol, args, false);
-                    }
-                    return Collections.singletonList(lit);
-                }
-            }, null);
-        }
+		private STerm translate(Term t) {
+			return t.accept(new Terms.TermVisitor<Void, STerm>() {
+				@Override
+				public STerm visit(Var t, Void in) {
+					return new SVar(t);
+				}
 
-        private SLit handleNegatedPredicate(SimplePredicate predicate, List<STerm> souffleArgs) {
-            List<Boolean> projection = new ArrayList<>();
-            int ignoredCount = 0;
-            var args = predicate.getArgs();
-            for (Term arg : args) {
-                if (arg instanceof Var && varCount.get((Var) arg) == 1) {
-                    ignoredCount++;
-                    projection.add(false);
-                } else {
-                    projection.add(true);
-                }
-            }
-            RelationSymbol sym = predicate.getSymbol();
-            if (ignoredCount == 0) {
-                return new SAtom(ctx.lookupRepr(sym), souffleArgs, true);
-            }
-            projections.add(new Pair<>(predicate.getSymbol(), projection));
-            List<STerm> newArgs = new ArrayList<>();
-            for (int i = 0; i < souffleArgs.size(); ++i) {
-                if (projection.get(i)) {
-                    newArgs.add(souffleArgs.get(i));
-                }
-            }
-            return new SAtom(createProjectionSymbol(sym, projection), newArgs, true);
-        }
+				@Override
+				public STerm visit(Constructor c, Void in) {
+					return liftToFunctor(c);
+				}
 
-        private String createProjectionSymbol(RelationSymbol sym, List<Boolean> projection) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("CODEGEN_PROJECT_");
-            sb.append(ctx.lookupRepr(sym));
-            for (Boolean retain : projection) {
-                sb.append(retain ? "1" : "0");
-            }
-            return sb.toString();
-        }
+				@Override
+				public STerm visit(Primitive<?> p, Void in) {
+					return liftToFunctor(p);
+				}
 
-        private SFunctorCall liftToFunctor(Term t) {
-            String functor = ctx.lookupOrCreateFunctorName(t);
-            List<Var> args = new ArrayList<>(t.varSet());
-            ctx.registerFunctorBody(functor, new SExprBody(args, t));
-            List<STerm> translatedArgs = args.stream().map(this::translate).collect(Collectors.toList());
-            return new SFunctorCall(functor, translatedArgs);
-        }
+				@Override
+				public STerm visit(Expr e, Void in) {
+					return liftToFunctor(e);
+				}
+			}, null);
+		}
 
-        private STerm translate(Term t) {
-            return t.accept(new Terms.TermVisitor<Void, STerm>() {
-                @Override
-                public STerm visit(Var t, Void in) {
-                    return new SVar(t);
-                }
+		List<SRule> createProjectionRules() {
+			List<SRule> l = new ArrayList<>();
+			for (var p : projections) {
+				l.add(createProjection(p.fst(), p.snd()));
+			}
+			return l;
+		}
 
-                @Override
-                public STerm visit(Constructor c, Void in) {
-                    return liftToFunctor(c);
-                }
+		private SRule createProjection(RelationSymbol sym, List<Boolean> projection) {
+			List<STerm> headArgs = new ArrayList<>();
+			List<STerm> bodyArgs = new ArrayList<>();
+			for (int i = 0; i < sym.getArity(); ++i) {
+				STerm arg = new SVar(Var.fresh("x" + i));
+				bodyArgs.add(arg);
+				if (projection.get(i)) {
+					headArgs.add(arg);
+				}
+			}
+			String projSym = createProjectionSymbol(sym, projection);
+			SLit head = new SAtom(projSym, headArgs, false);
+			SLit bodyAtom = new SAtom(ctx.lookupRepr(sym), bodyArgs, false);
+			ctx.registerCustomRelation(projSym, headArgs.size(), SRuleMode.INTERMEDIATE);
+			return new SRule(head, bodyAtom);
+		}
 
-                @Override
-                public STerm visit(Primitive<?> p, Void in) {
-                    return liftToFunctor(p);
-                }
-
-                @Override
-                public STerm visit(Expr e, Void in) {
-                    return liftToFunctor(e);
-                }
-            }, null);
-        }
-
-        List<SRule> createProjectionRules() {
-            List<SRule> l = new ArrayList<>();
-            for (var p : projections) {
-                l.add(createProjection(p.fst(), p.snd()));
-            }
-            return l;
-        }
-
-        private SRule createProjection(RelationSymbol sym, List<Boolean> projection) {
-            List<STerm> headArgs = new ArrayList<>();
-            List<STerm> bodyArgs = new ArrayList<>();
-            for (int i = 0; i < sym.getArity(); ++i) {
-                STerm arg = new SVar(Var.fresh("x" + i));
-                bodyArgs.add(arg);
-                if (projection.get(i)) {
-                    headArgs.add(arg);
-                }
-            }
-            String projSym = createProjectionSymbol(sym, projection);
-            SLit head = new SAtom(projSym, headArgs, false);
-            SLit bodyAtom = new SAtom(ctx.lookupRepr(sym), bodyArgs, false);
-            ctx.registerCustomRelation(projSym, headArgs.size(), SRuleMode.INTERMEDIATE);
-            return new SRule(head, bodyAtom);
-        }
-
-        public SRule createCheckRule() {
-            ctx.registerCustomRelation(checkPred, 2, SRuleMode.INTERMEDIATE);
-            SLit head = new SAtom(checkPred, Arrays.asList(new SInt(1), new SInt(1)), false);
-            return new SRule(head);
-        }
-    }
+		public SRule createCheckRule() {
+			ctx.registerCustomRelation(checkPred, 2, SRuleMode.INTERMEDIATE);
+			SLit head = new SAtom(checkPred, Arrays.asList(new SInt(1), new SInt(1)), false);
+			return new SRule(head);
+		}
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtParserCpp.java
@@ -55,133 +55,133 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class SmtParserCpp extends TemplateSrcFile {
 
-    public SmtParserCpp(CodeGenContext ctx) {
-        super("smt_parser.cpp", ctx);
-    }
+	public SmtParserCpp(CodeGenContext ctx) {
+		super("smt_parser.cpp", ctx);
+	}
 
-    @Override
-    void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException {
-        Worker w = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        w.outputShouldRecord();
-        CodeGenUtil.copyOver(br, out, 1);
-        w.outputParseFuncs();
-        CodeGenUtil.copyOver(br, out, 2);
-        w.outputParseTerm();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	@Override
+	void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException {
+		Worker w = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		w.outputShouldRecord();
+		CodeGenUtil.copyOver(br, out, 1);
+		w.outputParseFuncs();
+		CodeGenUtil.copyOver(br, out, 2);
+		w.outputParseTerm();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final PrintWriter out;
-        private final Set<ConstructorSymbol> trackedSmtVars = new HashSet<>();
-        private final Map<Type, String> parseFuncs = new HashMap<>();
-        private final Map<String, CppStmt> parseFuncDefs = new HashMap<>();
+		private final PrintWriter out;
+		private final Set<ConstructorSymbol> trackedSmtVars = new HashSet<>();
+		private final Map<Type, String> parseFuncs = new HashMap<>();
+		private final Map<String, CppStmt> parseFuncDefs = new HashMap<>();
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-            parseFuncs.put(BuiltInTypes.string, "parse_string");
-            parseFuncs.put(BuiltInTypes.i32, "parse_i32");
-            parseFuncs.put(BuiltInTypes.i64, "parse_i64");
-            parseFuncs.put(BuiltInTypes.fp32, "parse_fp32");
-            parseFuncs.put(BuiltInTypes.fp64, "parse_fp64");
-            parseFuncs.put(BuiltInTypes.bool, "parse_bool");
+		public Worker(PrintWriter out) {
+			this.out = out;
+			parseFuncs.put(BuiltInTypes.string, "parse_string");
+			parseFuncs.put(BuiltInTypes.i32, "parse_i32");
+			parseFuncs.put(BuiltInTypes.i64, "parse_i64");
+			parseFuncs.put(BuiltInTypes.fp32, "parse_fp32");
+			parseFuncs.put(BuiltInTypes.fp64, "parse_fp64");
+			parseFuncs.put(BuiltInTypes.bool, "parse_bool");
 
-        }
+		}
 
-        private void outputShouldRecord() throws CodeGenException {
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                var ty = getSmtVarType(sym);
-                if (ty != null) {
-                    try {
-                        if (SmtLibParser.shouldRecord(ty)) {
-                            out.printf("    case %s: return true;\n", ctx.lookupRepr(sym));
-                            trackedSmtVars.add(sym);
-                        }
-                    } catch (SmtLibParseException e) {
-                        throw new CodeGenException(e);
-                    }
-                }
-            }
-        }
+		private void outputShouldRecord() throws CodeGenException {
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				var ty = getSmtVarType(sym);
+				if (ty != null) {
+					try {
+						if (SmtLibParser.shouldRecord(ty)) {
+							out.printf("    case %s: return true;\n", ctx.lookupRepr(sym));
+							trackedSmtVars.add(sym);
+						}
+					} catch (SmtLibParseException e) {
+						throw new CodeGenException(e);
+					}
+				}
+			}
+		}
 
-        private void outputParseFuncs() {
-            for (ConstructorSymbol sym : trackedSmtVars) {
-                genParseFunc(getSmtVarType(sym));
-            }
-            // Forward-declare functions to account for mutually recursive data types.
-            for (String name : parseFuncDefs.keySet()) {
-                out.println("struct " + name + ";");
-            }
-            out.println();
-            for (Map.Entry<String, CppStmt> e : parseFuncDefs.entrySet()) {
-                out.println("struct " + e.getKey() + " {");
-                out.println("  term_ptr operator()(SmtLibTokenizer &t) {");
-                e.getValue().println(out, 2);
-                out.println("  }\n};\n");
-            }
-        }
+		private void outputParseFuncs() {
+			for (ConstructorSymbol sym : trackedSmtVars) {
+				genParseFunc(getSmtVarType(sym));
+			}
+			// Forward-declare functions to account for mutually recursive data types.
+			for (String name : parseFuncDefs.keySet()) {
+				out.println("struct " + name + ";");
+			}
+			out.println();
+			for (Map.Entry<String, CppStmt> e : parseFuncDefs.entrySet()) {
+				out.println("struct " + e.getKey() + " {");
+				out.println("  term_ptr operator()(SmtLibTokenizer &t) {");
+				e.getValue().println(out, 2);
+				out.println("  }\n};\n");
+			}
+		}
 
-        private String genParseFunc(AlgebraicDataType ty) {
-            String name = parseFuncs.get(ty);
-            if (name != null) {
-                return name;
-            }
-            name = "parse_" + ctx.newId(CodeGenUtil.mkName(ty.getSymbol()));
-            var wrapped_name = "parse_adt<" + name + ">";
-            parseFuncs.put(ty, wrapped_name);
+		private String genParseFunc(AlgebraicDataType ty) {
+			String name = parseFuncs.get(ty);
+			if (name != null) {
+				return name;
+			}
+			name = "parse_" + ctx.newId(CodeGenUtil.mkName(ty.getSymbol()));
+			var wrapped_name = "parse_adt<" + name + ">";
+			parseFuncs.put(ty, wrapped_name);
 
-            List<CppStmt> body = new ArrayList<>();
-            String scrutinee = "x";
-            body.add(CppDecl.mk(scrutinee, CppFuncCall.mk("parse_identifier", CppVar.mk("t"))));
+			List<CppStmt> body = new ArrayList<>();
+			String scrutinee = "x";
+			body.add(CppDecl.mk(scrutinee, CppFuncCall.mk("parse_identifier", CppVar.mk("t"))));
 
-            List<Pair<CppExpr, CppStmt>> cases = new ArrayList<>();
-            for (var cs : ty.getConstructors()) {
-                cases.add(genConstructorCase(CppVar.mk(scrutinee), cs));
-            }
-            body.add(CppIf.mk(cases));
+			List<Pair<CppExpr, CppStmt>> cases = new ArrayList<>();
+			for (var cs : ty.getConstructors()) {
+				cases.add(genConstructorCase(CppVar.mk(scrutinee), cs));
+			}
+			body.add(CppIf.mk(cases));
 
-            body.add(CppExprFromString.mk("abort()").toStmt());
-            parseFuncDefs.put(name, CppSeq.mk(body));
-            return wrapped_name;
-        }
+			body.add(CppExprFromString.mk("abort()").toStmt());
+			parseFuncDefs.put(name, CppSeq.mk(body));
+			return wrapped_name;
+		}
 
-        private Pair<CppExpr, CppStmt> genConstructorCase(CppExpr scrutinee, ConstructorScheme cs) {
-            ConstructorSymbol sym = cs.getSymbol();
-            var check = CppBinop.mkEq(scrutinee, CppConst.mkString(sym.toString()));
-            List<CppExpr> args = new ArrayList<>();
-            List<CppStmt> stmts = new ArrayList<>();
-            int i = 0;
-            for (var ty : cs.getTypeArgs()) {
-                String arg = "a" + i;
-                CppStmt decl = CppDecl.mk(arg, CppFuncCall.mk(genParseFunc((AlgebraicDataType) ty), CppVar.mk("t")));
-                stmts.add(decl);
-                args.add(CppVar.mk(arg));
-                i++;
-            }
-            CppExpr term = CppFuncCall.mk("Term::make<" + ctx.lookupRepr(sym) + ">", args); 
-            stmts.add(CppReturn.mk(term));
-            return new Pair<>(check, CppSeq.mk(stmts));
-        }
+		private Pair<CppExpr, CppStmt> genConstructorCase(CppExpr scrutinee, ConstructorScheme cs) {
+			ConstructorSymbol sym = cs.getSymbol();
+			var check = CppBinop.mkEq(scrutinee, CppConst.mkString(sym.toString()));
+			List<CppExpr> args = new ArrayList<>();
+			List<CppStmt> stmts = new ArrayList<>();
+			int i = 0;
+			for (var ty : cs.getTypeArgs()) {
+				String arg = "a" + i;
+				CppStmt decl = CppDecl.mk(arg, CppFuncCall.mk(genParseFunc((AlgebraicDataType) ty), CppVar.mk("t")));
+				stmts.add(decl);
+				args.add(CppVar.mk(arg));
+				i++;
+			}
+			CppExpr term = CppFuncCall.mk("Term::make<" + ctx.lookupRepr(sym) + ">", args);
+			stmts.add(CppReturn.mk(term));
+			return new Pair<>(check, CppSeq.mk(stmts));
+		}
 
-        private void outputParseTerm() {
-            for (ConstructorSymbol sym : trackedSmtVars) {
-                var ty = getSmtVarType(sym);
-                var func = parseFuncs.get(ty);
-                out.printf("    case %s: return %s(t);\n", ctx.lookupRepr(sym), func);
-            }
-        }
+		private void outputParseTerm() {
+			for (ConstructorSymbol sym : trackedSmtVars) {
+				var ty = getSmtVarType(sym);
+				var func = parseFuncs.get(ty);
+				out.printf("    case %s: return %s(t);\n", ctx.lookupRepr(sym), func);
+			}
+		}
 
-        private AlgebraicDataType getSmtVarType(ConstructorSymbol sym) {
-            if (sym instanceof ParameterizedConstructorSymbol) {
-                var base = ((ParameterizedConstructorSymbol) sym).getBase();
-                if (base.equals(BuiltInConstructorSymbolBase.SMT_VAR)) {
-                    return SmtLibParser.stripSymType((AlgebraicDataType) sym.getCompileTimeType().getRetType());
-                }
-            }
-            return null;
-        }
+		private AlgebraicDataType getSmtVarType(ConstructorSymbol sym) {
+			if (sym instanceof ParameterizedConstructorSymbol) {
+				var base = ((ParameterizedConstructorSymbol) sym).getBase();
+				if (base.equals(BuiltInConstructorSymbolBase.SMT_VAR)) {
+					return SmtLibParser.stripSymType((AlgebraicDataType) sym.getCompileTimeType().getRetType());
+				}
+			}
+			return null;
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtShimCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SmtShimCpp.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.Configuration;
 import edu.harvard.seas.pl.formulog.codegen.ast.cpp.*;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -40,378 +39,378 @@ import java.util.Set;
 
 public class SmtShimCpp extends TemplateSrcFile {
 
-    public SmtShimCpp(CodeGenContext ctx) {
-        super("smt_shim.cpp", ctx);
-    }
+	public SmtShimCpp(CodeGenContext ctx) {
+		super("smt_shim.cpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker pr = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        pr.copyDeclarations();
-        CodeGenUtil.copyOver(br, out, 1);
-        pr.genSolverVarCases();
-        CodeGenUtil.copyOver(br, out, 2);
-        pr.genNeedsTypeAnnotationCases();
-        CodeGenUtil.copyOver(br, out, 3);
-        pr.genSerializationCases();
-        CodeGenUtil.copyOver(br, out, 4);
-        pr.genSymbolSerializationCases();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker pr = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		pr.copyDeclarations();
+		CodeGenUtil.copyOver(br, out, 1);
+		pr.genSolverVarCases();
+		CodeGenUtil.copyOver(br, out, 2);
+		pr.genNeedsTypeAnnotationCases();
+		CodeGenUtil.copyOver(br, out, 3);
+		pr.genSerializationCases();
+		CodeGenUtil.copyOver(br, out, 4);
+		pr.genSymbolSerializationCases();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final PrintWriter out;
-        private final Set<ConstructorSymbol> varSymbols = new HashSet<>();
+		private final PrintWriter out;
+		private final Set<ConstructorSymbol> varSymbols = new HashSet<>();
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                if (isVarSymbol(sym)) {
-                    varSymbols.add(sym);
-                }
-            }
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				if (isVarSymbol(sym)) {
+					varSymbols.add(sym);
+				}
+			}
+		}
 
-        private boolean isVarSymbol(ConstructorSymbol sym) {
-            return sym instanceof ParameterizedConstructorSymbol
-                    && ((ParameterizedConstructorSymbol) sym).getBase() == BuiltInConstructorSymbolBase.SMT_VAR;
-        }
+		private boolean isVarSymbol(ConstructorSymbol sym) {
+			return sym instanceof ParameterizedConstructorSymbol
+					&& ((ParameterizedConstructorSymbol) sym).getBase() == BuiltInConstructorSymbolBase.SMT_VAR;
+		}
 
-        public void copyDeclarations() {
-            SmtLibShim shim = new SmtLibShim(null, out);
-            shim.initialize(ctx.getProgram(), true);
-            try {
-                shim.setLogic(Configuration.smtLogic);
-                shim.makeDeclarations();
-            } catch (EvaluationException e) {
-                throw new AssertionError("impossible");
-            }
-        }
+		public void copyDeclarations() {
+			SmtLibShim shim = new SmtLibShim(null, out);
+			shim.initialize(ctx.getProgram(), true);
+			try {
+				shim.setLogic(Configuration.smtLogic);
+				shim.makeDeclarations();
+			} catch (EvaluationException e) {
+				throw new AssertionError("impossible");
+			}
+		}
 
-        public void genSolverVarCases() {
-            if (varSymbols.isEmpty()) {
-                return;
-            }
-            for (ConstructorSymbol sym : varSymbols) {
-                out.println("    case " + ctx.lookupRepr(sym) + ":");
-            }
-            CppReturn.mk(CppConst.mkTrue()).println(out, 3);
-        }
+		public void genSolverVarCases() {
+			if (varSymbols.isEmpty()) {
+				return;
+			}
+			for (ConstructorSymbol sym : varSymbols) {
+				out.println("    case " + ctx.lookupRepr(sym) + ":");
+			}
+			CppReturn.mk(CppConst.mkTrue()).println(out, 3);
+		}
 
-        public void genSerializationCases() {
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                genSerializationCase(sym);
-            }
-        }
+		public void genSerializationCases() {
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				genSerializationCase(sym);
+			}
+		}
 
-        private void genSerializationCase(ConstructorSymbol sym) {
-            CppStmt stmt = genSerializationCaseBody(sym);
-            if (stmt == null) {
-                return;
-            }
-            out.println("    case " + ctx.lookupRepr(sym) + ": {");
-            stmt.println(out, 3);
-            out.println("      break;");
-            out.println("    }");
-        }
+		private void genSerializationCase(ConstructorSymbol sym) {
+			CppStmt stmt = genSerializationCaseBody(sym);
+			if (stmt == null) {
+				return;
+			}
+			out.println("    case " + ctx.lookupRepr(sym) + ": {");
+			stmt.println(out, 3);
+			out.println("      break;");
+			out.println("    }");
+		}
 
-        private CppStmt genSerializationCaseBody(ConstructorSymbol sym) {
-            if (sym instanceof BuiltInConstructorSymbol) {
-                return genBuiltInConstructorSymbolCase((BuiltInConstructorSymbol) sym);
-            }
-            if (sym instanceof ParameterizedConstructorSymbol) {
-                return genParameterizedConstructorSymbolCase((ParameterizedConstructorSymbol) sym);
-            }
-            return null;
-        }
+		private CppStmt genSerializationCaseBody(ConstructorSymbol sym) {
+			if (sym instanceof BuiltInConstructorSymbol) {
+				return genBuiltInConstructorSymbolCase((BuiltInConstructorSymbol) sym);
+			}
+			if (sym instanceof ParameterizedConstructorSymbol) {
+				return genParameterizedConstructorSymbolCase((ParameterizedConstructorSymbol) sym);
+			}
+			return null;
+		}
 
-        private CppStmt genBuiltInConstructorSymbolCase(BuiltInConstructorSymbol sym) {
-            switch (sym) {
-                case ARRAY_CONST:
-                    return genSerializeOp("const");
-                case ARRAY_STORE:
-                    return genSerializeOp("store");
-                case BV_ADD:
-                    return genSerializeOp("bvadd");
-                case BV_AND:
-                    return genSerializeOp("bvand");
-                case BV_MUL:
-                    return genSerializeOp("bvmul");
-                case BV_NEG:
-                    return genSerializeOp("bvneg");
-                case BV_OR:
-                    return genSerializeOp("bvor");
-                case BV_SDIV:
-                    return genSerializeOp("bvsdiv");
-                case BV_SREM:
-                    return genSerializeOp("bvsrem");
-                case BV_SUB:
-                    return genSerializeOp("bvsub");
-                case BV_UDIV:
-                    return genSerializeOp("bvudiv");
-                case BV_UREM:
-                    return genSerializeOp("bvurem");
-                case BV_XOR:
-                    return genSerializeOp("bvxor");
-                // Normal constructors don't need special treatment
-                case CMP_EQ:
-                case CMP_GT:
-                case CMP_LT:
-                case CONS:
-                case NIL:
-                case NONE:
-                case SOME:
-                    break;
-                case ENTER_FORMULA:
-                case EXIT_FORMULA:
-                    return CppFuncCall.mk("abort").toStmt();
-                case FP_ADD:
-                    return genSerializeOp("fp.add");
-                case FP_DIV:
-                    return genSerializeOp("fp.div");
-                case FP_MUL:
-                    return genSerializeOp("fp.mul");
-                case FP_NEG:
-                    return genSerializeOp("fp.neg");
-                case FP_REM:
-                    return genSerializeOp("fp.rem");
-                case FP_SUB:
-                    return genSerializeOp("fp.sub");
-                case INT_ABS:
-                    return genSerializeOp("abs");
-                case INT_ADD:
-                    return genSerializeOp("+");
-                case INT_BIG_CONST:
-                    return genSerializeInt(true);
-                case INT_CONST:
-                    return genSerializeInt(false);
-                case INT_DIV:
-                    return genSerializeOp("div");
-                case INT_GE:
-                    return genSerializeOp(">=");
-                case INT_GT:
-                    return genSerializeOp(">");
-                case INT_LE:
-                    return genSerializeOp("<=");
-                case INT_LT:
-                    return genSerializeOp("<");
-                case INT_MOD:
-                    return genSerializeOp("mod");
-                case INT_MUL:
-                    return genSerializeOp("*");
-                case INT_NEG:
-                case INT_SUB:
-                    return genSerializeOp("-");
-                case SMT_AND:
-                    return genSerializeOp("and");
-                case SMT_EXISTS:
-                    return genSerializeQuantifier(true);
-                case SMT_FORALL:
-                    return genSerializeQuantifier(false);
-                case SMT_IMP:
-                    return genSerializeOp("=>");
-                case SMT_ITE:
-                    return genSerializeOp("ite");
-                case SMT_NOT:
-                    return genSerializeOp("not");
-                case SMT_OR:
-                    return genSerializeOp("or");
-                case STR_AT:
-                    return genSerializeOp("str.at");
-                case STR_CONCAT:
-                    return genSerializeOp("str.++");
-                case STR_CONTAINS:
-                    return genSerializeOp("str.contains");
-                case STR_INDEXOF:
-                    return genSerializeOp("str.indexof");
-                case STR_LEN:
-                    return genSerializeOp("str.len");
-                case STR_PREFIXOF:
-                    return genSerializeOp("str.prefixof");
-                case STR_REPLACE:
-                    return genSerializeOp("str.replace");
-                case STR_SUBSTR:
-                    return genSerializeOp("str.substr");
-                case STR_SUFFIXOF:
-                    return genSerializeOp("str.suffixof");
-            }
-            return null;
-        }
+		private CppStmt genBuiltInConstructorSymbolCase(BuiltInConstructorSymbol sym) {
+			switch (sym) {
+			case ARRAY_CONST:
+				return genSerializeOp("const");
+			case ARRAY_STORE:
+				return genSerializeOp("store");
+			case BV_ADD:
+				return genSerializeOp("bvadd");
+			case BV_AND:
+				return genSerializeOp("bvand");
+			case BV_MUL:
+				return genSerializeOp("bvmul");
+			case BV_NEG:
+				return genSerializeOp("bvneg");
+			case BV_OR:
+				return genSerializeOp("bvor");
+			case BV_SDIV:
+				return genSerializeOp("bvsdiv");
+			case BV_SREM:
+				return genSerializeOp("bvsrem");
+			case BV_SUB:
+				return genSerializeOp("bvsub");
+			case BV_UDIV:
+				return genSerializeOp("bvudiv");
+			case BV_UREM:
+				return genSerializeOp("bvurem");
+			case BV_XOR:
+				return genSerializeOp("bvxor");
+			// Normal constructors don't need special treatment
+			case CMP_EQ:
+			case CMP_GT:
+			case CMP_LT:
+			case CONS:
+			case NIL:
+			case NONE:
+			case SOME:
+				break;
+			case ENTER_FORMULA:
+			case EXIT_FORMULA:
+				return CppFuncCall.mk("abort").toStmt();
+			case FP_ADD:
+				return genSerializeOp("fp.add");
+			case FP_DIV:
+				return genSerializeOp("fp.div");
+			case FP_MUL:
+				return genSerializeOp("fp.mul");
+			case FP_NEG:
+				return genSerializeOp("fp.neg");
+			case FP_REM:
+				return genSerializeOp("fp.rem");
+			case FP_SUB:
+				return genSerializeOp("fp.sub");
+			case INT_ABS:
+				return genSerializeOp("abs");
+			case INT_ADD:
+				return genSerializeOp("+");
+			case INT_BIG_CONST:
+				return genSerializeInt(true);
+			case INT_CONST:
+				return genSerializeInt(false);
+			case INT_DIV:
+				return genSerializeOp("div");
+			case INT_GE:
+				return genSerializeOp(">=");
+			case INT_GT:
+				return genSerializeOp(">");
+			case INT_LE:
+				return genSerializeOp("<=");
+			case INT_LT:
+				return genSerializeOp("<");
+			case INT_MOD:
+				return genSerializeOp("mod");
+			case INT_MUL:
+				return genSerializeOp("*");
+			case INT_NEG:
+			case INT_SUB:
+				return genSerializeOp("-");
+			case SMT_AND:
+				return genSerializeOp("and");
+			case SMT_EXISTS:
+				return genSerializeQuantifier(true);
+			case SMT_FORALL:
+				return genSerializeQuantifier(false);
+			case SMT_IMP:
+				return genSerializeOp("=>");
+			case SMT_ITE:
+				return genSerializeOp("ite");
+			case SMT_NOT:
+				return genSerializeOp("not");
+			case SMT_OR:
+				return genSerializeOp("or");
+			case STR_AT:
+				return genSerializeOp("str.at");
+			case STR_CONCAT:
+				return genSerializeOp("str.++");
+			case STR_CONTAINS:
+				return genSerializeOp("str.contains");
+			case STR_INDEXOF:
+				return genSerializeOp("str.indexof");
+			case STR_LEN:
+				return genSerializeOp("str.len");
+			case STR_PREFIXOF:
+				return genSerializeOp("str.prefixof");
+			case STR_REPLACE:
+				return genSerializeOp("str.replace");
+			case STR_SUBSTR:
+				return genSerializeOp("str.substr");
+			case STR_SUFFIXOF:
+				return genSerializeOp("str.suffixof");
+			}
+			return null;
+		}
 
-        private int index(ParameterizedConstructorSymbol sym, int i) {
-            return ((TypeIndex) sym.getArgs().get(i).getType()).getIndex();
-        }
+		private int index(ParameterizedConstructorSymbol sym, int i) {
+			return ((TypeIndex) sym.getArgs().get(i).getType()).getIndex();
+		}
 
-        private CppStmt mkCall(String func) {
-            return CppFuncCall.mk(func, CppVar.mk("t")).toStmt();
-        }
+		private CppStmt mkCall(String func) {
+			return CppFuncCall.mk(func, CppVar.mk("t")).toStmt();
+		}
 
-        private CppStmt genParameterizedConstructorSymbolCase(ParameterizedConstructorSymbol sym) {
-            switch (sym.getBase()) {
-                case ARRAY_DEFAULT:
-                    return genSerializeOp("default");
-                case ARRAY_SELECT:
-                    return genSerializeOp("select");
-                case BV_BIG_CONST:
-                    return genSerializeBitString(index(sym, 0), true);
-                case BV_CONST:
-                    return genSerializeBitString(index(sym, 0), false);
-                case BV_SGE:
-                    return genSerializeOp("bvsge");
-                case BV_SGT:
-                    return genSerializeOp("bvsgt");
-                case BV_SLE:
-                    return genSerializeOp("bvsle");
-                case BV_SLT:
-                    return genSerializeOp("bvslt");
-                case BV_TO_BV_SIGNED:
-                    return genSerializeBvToBv(index(sym, 0), index(sym, 1), true);
-                case BV_TO_BV_UNSIGNED:
-                    return genSerializeBvToBv(index(sym, 0), index(sym, 1), false);
-                case BV_EXTRACT:
-                    return mkCall("serialize_bv_extract");
-                case BV_CONCAT:
-                    return genSerializeOp("concat");
-                case BV_TO_FP: {
-                    int exp = index(sym, 1);
-                    int sig = index(sym, 2);
-                    String func = "serialize_bv_to_fp<" + exp + ", " + sig + ">";
-                    return mkCall(func);
-                }
-                case BV_UGE:
-                    return genSerializeOp("bvuge");
-                case BV_UGT:
-                    return genSerializeOp("bvugt");
-                case BV_ULE:
-                    return genSerializeOp("bvule");
-                case BV_ULT:
-                    return genSerializeOp("bvult");
-                case FP_BIG_CONST: {
-                    int exp = index(sym, 0);
-                    int sig = index(sym, 1);
-                    return genSerializeFp(exp, sig, true);
-                }
-                case FP_CONST: {
-                    int exp = index(sym, 0);
-                    int sig = index(sym, 1);
-                    return genSerializeFp(exp, sig, false);
-                }
-                case FP_EQ:
-                    return genSerializeOp("fp.eq");
-                case FP_GE:
-                    return genSerializeOp("fp.geq");
-                case FP_GT:
-                    return genSerializeOp("fp.gt");
-                case FP_IS_NAN:
-                    return genSerializeOp("fp.isNaN");
-                case FP_LE:
-                    return genSerializeOp("fp.leq");
-                case FP_LT:
-                    return genSerializeOp("fp.lt");
-                case FP_TO_SBV:
-                    return genSerializeFpToBv(index(sym, 2), true);
-                case FP_TO_UBV:
-                    return genSerializeFpToBv(index(sym, 2), false);
-                case FP_TO_FP: {
-                    int exp = index(sym, 2);
-                    int sig = index(sym, 3);
-                    String func = "serialize_fp_to_fp<" + exp + ", " + sig + ">";
-                    return mkCall(func);
-                }
-                case SMT_EQ:
-                    return genSerializeOp("=");
-                case SMT_LET:
-                    return mkCall("serialize_let");
-                case SMT_VAR: {
-                    CppExpr call = CppFuncCall.mk("lookup_var", CppVar.mk("t"));
-                    return CppBinop.mkShiftLeft(CppVar.mk("m_in"), call).toStmt();
-                }
-                case SMT_PAT:
-                case SMT_WRAP_VAR:
-                    return CppFuncCall.mk("abort").toStmt();
-                case BV_TO_INT:
-                    return genSerializeOp("bv2int");
-                case INT_TO_BV: {
-                    int width = index(sym, 0);
-                    String func = "serialize_int2bv<" + width + ">";
-                    return mkCall(func);
-                }
-                    
-            }
-            return null;
-        }
+		private CppStmt genParameterizedConstructorSymbolCase(ParameterizedConstructorSymbol sym) {
+			switch (sym.getBase()) {
+			case ARRAY_DEFAULT:
+				return genSerializeOp("default");
+			case ARRAY_SELECT:
+				return genSerializeOp("select");
+			case BV_BIG_CONST:
+				return genSerializeBitString(index(sym, 0), true);
+			case BV_CONST:
+				return genSerializeBitString(index(sym, 0), false);
+			case BV_SGE:
+				return genSerializeOp("bvsge");
+			case BV_SGT:
+				return genSerializeOp("bvsgt");
+			case BV_SLE:
+				return genSerializeOp("bvsle");
+			case BV_SLT:
+				return genSerializeOp("bvslt");
+			case BV_TO_BV_SIGNED:
+				return genSerializeBvToBv(index(sym, 0), index(sym, 1), true);
+			case BV_TO_BV_UNSIGNED:
+				return genSerializeBvToBv(index(sym, 0), index(sym, 1), false);
+			case BV_EXTRACT:
+				return mkCall("serialize_bv_extract");
+			case BV_CONCAT:
+				return genSerializeOp("concat");
+			case BV_TO_FP: {
+				int exp = index(sym, 1);
+				int sig = index(sym, 2);
+				String func = "serialize_bv_to_fp<" + exp + ", " + sig + ">";
+				return mkCall(func);
+			}
+			case BV_UGE:
+				return genSerializeOp("bvuge");
+			case BV_UGT:
+				return genSerializeOp("bvugt");
+			case BV_ULE:
+				return genSerializeOp("bvule");
+			case BV_ULT:
+				return genSerializeOp("bvult");
+			case FP_BIG_CONST: {
+				int exp = index(sym, 0);
+				int sig = index(sym, 1);
+				return genSerializeFp(exp, sig, true);
+			}
+			case FP_CONST: {
+				int exp = index(sym, 0);
+				int sig = index(sym, 1);
+				return genSerializeFp(exp, sig, false);
+			}
+			case FP_EQ:
+				return genSerializeOp("fp.eq");
+			case FP_GE:
+				return genSerializeOp("fp.geq");
+			case FP_GT:
+				return genSerializeOp("fp.gt");
+			case FP_IS_NAN:
+				return genSerializeOp("fp.isNaN");
+			case FP_LE:
+				return genSerializeOp("fp.leq");
+			case FP_LT:
+				return genSerializeOp("fp.lt");
+			case FP_TO_SBV:
+				return genSerializeFpToBv(index(sym, 2), true);
+			case FP_TO_UBV:
+				return genSerializeFpToBv(index(sym, 2), false);
+			case FP_TO_FP: {
+				int exp = index(sym, 2);
+				int sig = index(sym, 3);
+				String func = "serialize_fp_to_fp<" + exp + ", " + sig + ">";
+				return mkCall(func);
+			}
+			case SMT_EQ:
+				return genSerializeOp("=");
+			case SMT_LET:
+				return mkCall("serialize_let");
+			case SMT_VAR: {
+				CppExpr call = CppFuncCall.mk("lookup_var", CppVar.mk("t"));
+				return CppBinop.mkShiftLeft(CppVar.mk("m_in"), call).toStmt();
+			}
+			case SMT_PAT:
+			case SMT_WRAP_VAR:
+				return CppFuncCall.mk("abort").toStmt();
+			case BV_TO_INT:
+				return genSerializeOp("bv2int");
+			case INT_TO_BV: {
+				int width = index(sym, 0);
+				String func = "serialize_int2bv<" + width + ">";
+				return mkCall(func);
+			}
 
-        private CppStmt genSerializeOp(String op) {
-            CppExpr s = CppConst.mkString(op);
-            CppExpr t = CppMethodCall.mkThruPtr(CppVar.mk("t"), "as_complex");
-            return CppFuncCall.mk("serialize", s, t).toStmt();
-        }
+			}
+			return null;
+		}
 
-        private CppStmt genSerializeBitString(int n, boolean big) {
-            CppExpr array = CppAccess.mk(CppMethodCall.mkThruPtr(CppVar.mk("t"), "as_complex"), "val");
-            CppExpr base = CppSubscript.mk(array, CppConst.mkInt(0));
-            String type = big ? "int64_t" : "int32_t";
-            String func = "serialize_bit_string<" + type + ", " + n + ">";
-            CppExpr arg = CppAccess.mk(CppMethodCall.mkThruPtr(base, "as_base<" + type + ">"), "val");
-            return CppFuncCall.mk(func, arg).toStmt();
-        }
+		private CppStmt genSerializeOp(String op) {
+			CppExpr s = CppConst.mkString(op);
+			CppExpr t = CppMethodCall.mkThruPtr(CppVar.mk("t"), "as_complex");
+			return CppFuncCall.mk("serialize", s, t).toStmt();
+		}
 
-        private CppStmt genSerializeBvToBv(int from, int to, boolean signed) {
-            String func = "serialize_bv_to_bv<" + from + ", " + to + ", " + signed + ">";
-            return mkCall(func);
-        }
+		private CppStmt genSerializeBitString(int n, boolean big) {
+			CppExpr array = CppAccess.mk(CppMethodCall.mkThruPtr(CppVar.mk("t"), "as_complex"), "val");
+			CppExpr base = CppSubscript.mk(array, CppConst.mkInt(0));
+			String type = big ? "int64_t" : "int32_t";
+			String func = "serialize_bit_string<" + type + ", " + n + ">";
+			CppExpr arg = CppAccess.mk(CppMethodCall.mkThruPtr(base, "as_base<" + type + ">"), "val");
+			return CppFuncCall.mk(func, arg).toStmt();
+		}
 
-        private CppStmt genSerializeFpToBv(int width, boolean signed) {
-            String func = "serialize_fp_to_bv<" + width + ", " + signed + ">";
-            return mkCall(func);
-        }
+		private CppStmt genSerializeBvToBv(int from, int to, boolean signed) {
+			String func = "serialize_bv_to_bv<" + from + ", " + to + ", " + signed + ">";
+			return mkCall(func);
+		}
 
-        private CppStmt genSerializeFp(int e, int s, boolean big) {
-            String type = big ? "double" : "float";
-            String func = "serialize_fp<" + type + ", " + e + ", " + s + ">";
-            CppExpr arg = CppFuncCall.mk("arg0", CppVar.mk("t"));
-            return CppFuncCall.mk(func, arg).toStmt();
-        }
+		private CppStmt genSerializeFpToBv(int width, boolean signed) {
+			String func = "serialize_fp_to_bv<" + width + ", " + signed + ">";
+			return mkCall(func);
+		}
 
-        private CppStmt genSerializeInt(boolean big) {
-            String type = big ? "int64_t" : "int32_t";
-            String func = "serialize_int<" + type + ">";
-            return mkCall(func);
-        }
+		private CppStmt genSerializeFp(int e, int s, boolean big) {
+			String type = big ? "double" : "float";
+			String func = "serialize_fp<" + type + ", " + e + ", " + s + ">";
+			CppExpr arg = CppFuncCall.mk("arg0", CppVar.mk("t"));
+			return CppFuncCall.mk(func, arg).toStmt();
+		}
 
-        private CppStmt genSerializeQuantifier(boolean exists) {
-            String func = "serialize_quantifier<" + exists + ">";
-            return mkCall(func);
-        }
+		private CppStmt genSerializeInt(boolean big) {
+			String type = big ? "int64_t" : "int32_t";
+			String func = "serialize_int<" + type + ">";
+			return mkCall(func);
+		}
 
-        public void genNeedsTypeAnnotationCases() {
-            boolean foundOne = false;
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                if (SmtLibShim.needsTypeAnnotation(sym)) {
-                    out.println("    case " + ctx.lookupRepr(sym) + ":");
-                    foundOne = true;
-                }
-            }
-            if (foundOne) {
-                CppReturn.mk(CppConst.mkTrue()).println(out, 3);
-            }
-        }
+		private CppStmt genSerializeQuantifier(boolean exists) {
+			String func = "serialize_quantifier<" + exists + ">";
+			return mkCall(func);
+		}
 
-        public void genSymbolSerializationCases() {
-            boolean foundOne = false;
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                if (sym.getConstructorSymbolType().equals(ConstructorSymbolType.SOLVER_CONSTRUCTOR_TESTER)) {
-                    out.println("    case " + ctx.lookupRepr(sym) + ":");
-                    foundOne = true;
-                }
-            }
-            if (foundOne) {
-                CppExpr call = CppFuncCall.mk("serialize_tester", CppVar.mk("sym"));
-                CppReturn.mk(call).println(out, 3);
-            }
-        }
+		public void genNeedsTypeAnnotationCases() {
+			boolean foundOne = false;
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				if (SmtLibShim.needsTypeAnnotation(sym)) {
+					out.println("    case " + ctx.lookupRepr(sym) + ":");
+					foundOne = true;
+				}
+			}
+			if (foundOne) {
+				CppReturn.mk(CppConst.mkTrue()).println(out, 3);
+			}
+		}
 
-    }
+		public void genSymbolSerializationCases() {
+			boolean foundOne = false;
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				if (sym.getConstructorSymbolType().equals(ConstructorSymbolType.SOLVER_CONSTRUCTOR_TESTER)) {
+					out.println("    case " + ctx.lookupRepr(sym) + ":");
+					foundOne = true;
+				}
+			}
+			if (foundOne) {
+				CppExpr call = CppFuncCall.mk("serialize_tester", CppVar.mk("sym"));
+				CppReturn.mk(call).println(out, 3);
+			}
+		}
+
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SouffleCodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SouffleCodeGen.java
@@ -38,182 +38,182 @@ import java.util.List;
 
 public class SouffleCodeGen {
 
-    private final CodeGenContext ctx;
-    private static final String non_existent_input = "CODEGEN_IMPOSSIBLE_IN";
-    private static final String non_existent_output = "CODEGEN_IMPOSSIBLE_OUT";
-    private static final SAtom non_existent_input_atom = new SAtom(non_existent_input, Collections.emptyList(), false);
+	private final CodeGenContext ctx;
+	private static final String non_existent_input = "CODEGEN_IMPOSSIBLE_IN";
+	private static final String non_existent_output = "CODEGEN_IMPOSSIBLE_OUT";
+	private static final SAtom non_existent_input_atom = new SAtom(non_existent_input, Collections.emptyList(), false);
 
-    public SouffleCodeGen(CodeGenContext ctx) {
-        this.ctx = ctx;
-    }
+	public SouffleCodeGen(CodeGenContext ctx) {
+		this.ctx = ctx;
+	}
 
-    public void gen(File directory) throws CodeGenException, IOException {
-        QueryPlanner qp = chooseQueryPlanner();
-        Pair<List<SRule>, List<Stratum>> p = new RuleTranslator(ctx, qp).translate(ctx.getProgram());
-        var rules = p.fst();
-        ctx.registerCustomRelation(non_existent_input, 0, SRuleMode.INPUT);
-        ctx.registerCustomRelation(non_existent_output, 0, SRuleMode.OUTPUT);
-        rules.add(genRuleForRetainingInputRelations());
-        rules.addAll(genRulesForEnforcingStratification(p.snd()));
-        File dlFile = directory.toPath().resolve(Path.of("src", "formulog.dl")).toFile();
-        emitDlFile(dlFile, rules);
-        new FunctorCodeGen(ctx).emitFunctors(directory);
-    }
+	public void gen(File directory) throws CodeGenException, IOException {
+		QueryPlanner qp = chooseQueryPlanner();
+		Pair<List<SRule>, List<Stratum>> p = new RuleTranslator(ctx, qp).translate(ctx.getProgram());
+		var rules = p.fst();
+		ctx.registerCustomRelation(non_existent_input, 0, SRuleMode.INPUT);
+		ctx.registerCustomRelation(non_existent_output, 0, SRuleMode.OUTPUT);
+		rules.add(genRuleForRetainingInputRelations());
+		rules.addAll(genRulesForEnforcingStratification(p.snd()));
+		File dlFile = directory.toPath().resolve(Path.of("src", "formulog.dl")).toFile();
+		emitDlFile(dlFile, rules);
+		new FunctorCodeGen(ctx).emitFunctors(directory);
+	}
 
-    private QueryPlanner chooseQueryPlanner() throws CodeGenException {
-        switch (Configuration.optimizationSetting) {
-        case 0:
-            return new NopQueryPlanner();
-        case 5:
-            return new DeltaFirstQueryPlanner(ctx);
-        default:
-            throw new CodeGenException(
-                    "Unsupported optimization setting for codegen: " + Configuration.optimizationSetting);
-        }
-    }
+	private QueryPlanner chooseQueryPlanner() throws CodeGenException {
+		switch (Configuration.optimizationSetting) {
+		case 0:
+			return new NopQueryPlanner();
+		case 5:
+			return new DeltaFirstQueryPlanner(ctx);
+		default:
+			throw new CodeGenException(
+					"Unsupported optimization setting for codegen: " + Configuration.optimizationSetting);
+		}
+	}
 
-    private void emitDlFile(File dlFile, List<SRule> rules) throws CodeGenException {
-        PrintWriter writer;
-        try {
-            writer = new PrintWriter(dlFile);
-        } catch (FileNotFoundException e) {
-            throw new CodeGenException(e);
-        }
-        Worker worker = new Worker(writer);
-        worker.declareTypes();
-        writer.println();
-        worker.declareRelations();
-        writer.println();
-        worker.declareFunctors();
-        writer.println();
-        for (SRule rule : rules) {
-            writer.println(rule);
-        }
-        writer.close();
-    }
+	private void emitDlFile(File dlFile, List<SRule> rules) throws CodeGenException {
+		PrintWriter writer;
+		try {
+			writer = new PrintWriter(dlFile);
+		} catch (FileNotFoundException e) {
+			throw new CodeGenException(e);
+		}
+		Worker worker = new Worker(writer);
+		worker.declareTypes();
+		writer.println();
+		worker.declareRelations();
+		writer.println();
+		worker.declareFunctors();
+		writer.println();
+		for (SRule rule : rules) {
+			writer.println(rule);
+		}
+		writer.close();
+	}
 
-    SRule genRuleForRetainingInputRelations() {
-        SAtom head = new SAtom(non_existent_output, Collections.emptyList(), false);
-        List<SLit> body = new ArrayList<>();
-        body.add(non_existent_input_atom);
-        for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
-            body.add(makeAtomWithDummyArgs(sym, false));
-        }
-        return new SRule(head, body);
-    }
+	SRule genRuleForRetainingInputRelations() {
+		SAtom head = new SAtom(non_existent_output, Collections.emptyList(), false);
+		List<SLit> body = new ArrayList<>();
+		body.add(non_existent_input_atom);
+		for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
+			body.add(makeAtomWithDummyArgs(sym, false));
+		}
+		return new SRule(head, body);
+	}
 
-    private List<SRule> genRulesForEnforcingStratification(List<Stratum> strats) {
-        if (strats.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<SRule> l = new ArrayList<>();
-        RelationSymbol firstRepr = strats.get(0).getPredicateSyms().iterator().next();
-        var prevAtom = makeAtomWithDummyArgs(firstRepr, true);
-        for (int i = 1; i < strats.size(); ++i) {
-            RelationSymbol currRepr = strats.get(i).getPredicateSyms().iterator().next();
-            var currAtom = makeAtomWithDummyArgs(currRepr, false);
-            l.add(new SRule(currAtom, non_existent_input_atom, prevAtom));
-            prevAtom = currAtom;
-        }
-        return l;
-    }
+	private List<SRule> genRulesForEnforcingStratification(List<Stratum> strats) {
+		if (strats.isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<SRule> l = new ArrayList<>();
+		RelationSymbol firstRepr = strats.get(0).getPredicateSyms().iterator().next();
+		var prevAtom = makeAtomWithDummyArgs(firstRepr, true);
+		for (int i = 1; i < strats.size(); ++i) {
+			RelationSymbol currRepr = strats.get(i).getPredicateSyms().iterator().next();
+			var currAtom = makeAtomWithDummyArgs(currRepr, false);
+			l.add(new SRule(currAtom, non_existent_input_atom, prevAtom));
+			prevAtom = currAtom;
+		}
+		return l;
+	}
 
-    private SAtom makeAtomWithDummyArgs(RelationSymbol sym, boolean negated) {
-        List<STerm> args = new ArrayList<>();
-        for (int i = 0; i < sym.getArity(); ++i) {
-            args.add(new SInt(0));
-        }
-        return new SAtom(ctx.lookupRepr(sym), args, negated);
-    }
+	private SAtom makeAtomWithDummyArgs(RelationSymbol sym, boolean negated) {
+		List<STerm> args = new ArrayList<>();
+		for (int i = 0; i < sym.getArity(); ++i) {
+			args.add(new SInt(0));
+		}
+		return new SAtom(ctx.lookupRepr(sym), args, negated);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final PrintWriter writer;
+		private final PrintWriter writer;
 
-        public Worker(PrintWriter writer) {
-            this.writer = writer;
-        }
+		public Worker(PrintWriter writer) {
+			this.writer = writer;
+		}
 
-        public void declareTypes() {
-            for (SIntListType ty : ctx.getSouffleTypes()) {
-                writer.print(".type ");
-                writer.print(ty.getName());
-                writer.print(" = ");
-                writer.println(ty.getDef());
-            }
-        }
+		public void declareTypes() {
+			for (SIntListType ty : ctx.getSouffleTypes()) {
+				writer.print(".type ");
+				writer.print(ty.getName());
+				writer.print(" = ");
+				writer.println(ty.getDef());
+			}
+		}
 
-        public void declareRelations() {
-            for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
-                declareRelation(sym, SRuleMode.INPUT);
-            }
-            for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
-                declareRelation(sym, SRuleMode.OUTPUT);
-            }
-            for (Pair<String, Pair<Integer, SRuleMode>> e : ctx.getCustomRelations()) {
-                declareRelation(e.fst(), e.snd().fst(), e.snd().snd());
-            }
-        }
+		public void declareRelations() {
+			for (RelationSymbol sym : ctx.getProgram().getFactSymbols()) {
+				declareRelation(sym, SRuleMode.INPUT);
+			}
+			for (RelationSymbol sym : ctx.getProgram().getRuleSymbols()) {
+				declareRelation(sym, SRuleMode.OUTPUT);
+			}
+			for (Pair<String, Pair<Integer, SRuleMode>> e : ctx.getCustomRelations()) {
+				declareRelation(e.fst(), e.snd().fst(), e.snd().snd());
+			}
+		}
 
-        private void declareRelation(String name, int arity, SRuleMode mode) {
-            writer.print(".decl ");
-            writer.print(name);
-            writer.print("(");
-            for (int i = 0; i < arity; ++i) {
-                writer.print("x");
-                writer.print(i);
-                writer.print(":number");
-                if (i < arity - 1) {
-                    writer.print(", ");
-                }
-            }
-            writer.println(")");
-            switch (mode) {
-            case INPUT:
-                writer.print(".input ");
-                break;
-            case OUTPUT:
-                writer.print(".output ");
-                break;
-            case INTERMEDIATE:
-                return;
-            }
-            writer.println(name);
-        }
+		private void declareRelation(String name, int arity, SRuleMode mode) {
+			writer.print(".decl ");
+			writer.print(name);
+			writer.print("(");
+			for (int i = 0; i < arity; ++i) {
+				writer.print("x");
+				writer.print(i);
+				writer.print(":number");
+				if (i < arity - 1) {
+					writer.print(", ");
+				}
+			}
+			writer.println(")");
+			switch (mode) {
+			case INPUT:
+				writer.print(".input ");
+				break;
+			case OUTPUT:
+				writer.print(".output ");
+				break;
+			case INTERMEDIATE:
+				return;
+			}
+			writer.println(name);
+		}
 
-        private void declareRelation(RelationSymbol sym, SRuleMode mode) {
-            declareRelation(ctx.lookupRepr(sym), sym.getArity(), mode);
-        }
+		private void declareRelation(RelationSymbol sym, SRuleMode mode) {
+			declareRelation(ctx.lookupRepr(sym), sym.getArity(), mode);
+		}
 
-        public void declareFunctors() {
-            writer.println(".functor nth(n:number, ref:number, check:number):number");
-            for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
-                String name = p.fst();
-                SFunctorBody body = p.snd();
-                declareFunctor(name, body);
-            }
-        }
+		public void declareFunctors() {
+			writer.println(".functor nth(n:number, ref:number, check:number):number");
+			for (Pair<String, SFunctorBody> p : ctx.getFunctors()) {
+				String name = p.fst();
+				SFunctorBody body = p.snd();
+				declareFunctor(name, body);
+			}
+		}
 
-        private void declareFunctor(String name, SFunctorBody body) {
-            writer.print(".functor ");
-            writer.print(name);
-            writer.print("(");
-            for (int i = 0; i < body.getArity(); ++i) {
-                writer.print("x");
-                writer.print(i);
-                writer.print(":number");
-                if (i < body.getArity() - 1) {
-                    writer.print(", ");
-                }
-            }
-            writer.print("):");
-            writer.print(body.getRetType());
-            if (body.isStateful()) {
-                writer.print(" stateful");
-            }
-            writer.println();
-        }
+		private void declareFunctor(String name, SFunctorBody body) {
+			writer.print(".functor ");
+			writer.print(name);
+			writer.print("(");
+			for (int i = 0; i < body.getArity(); ++i) {
+				writer.print("x");
+				writer.print(i);
+				writer.print(":number");
+				if (i < body.getArity() - 1) {
+					writer.print(", ");
+				}
+			}
+			writer.print("):");
+			writer.print(body.getRetType());
+			if (body.isStateful()) {
+				writer.print(" stateful");
+			}
+			writer.println();
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SymbolCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SymbolCpp.java
@@ -31,58 +31,58 @@ import java.util.Set;
 
 public class SymbolCpp extends TemplateSrcFile {
 
-    public SymbolCpp(CodeGenContext ctx) {
-        super("Symbol.cpp", ctx);
-    }
+	public SymbolCpp(CodeGenContext ctx) {
+		super("Symbol.cpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker w = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        w.defineSerialization();
-        CodeGenUtil.copyOver(br, out, 1);
-        w.initializeSymbolTable();
-        CodeGenUtil.copyOver(br, out, 2);
-        w.defineTupleLookup();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker w = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		w.defineSerialization();
+		CodeGenUtil.copyOver(br, out, 1);
+		w.initializeSymbolTable();
+		CodeGenUtil.copyOver(br, out, 2);
+		w.defineTupleLookup();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
-        private final PrintWriter out;
+		private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
+		private final PrintWriter out;
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        void defineSerialization() {
-            for (ConstructorSymbol sym : symbols) {
-                out.print("    case ");
-                out.print(ctx.lookupRepr(sym));
-                out.print(": return out << \"");
-                out.print(sym);
-                out.println("\";");
-            }
-        }
+		void defineSerialization() {
+			for (ConstructorSymbol sym : symbols) {
+				out.print("    case ");
+				out.print(ctx.lookupRepr(sym));
+				out.print(": return out << \"");
+				out.print(sym);
+				out.println("\";");
+			}
+		}
 
-        void initializeSymbolTable() {
-            for (ConstructorSymbol sym : symbols) {
-                CppExpr access = CppSubscript.mk(CppVar.mk("symbol_table"), CppConst.mkString(CodeGenUtil.mkName(sym)));
-                CppExpr assign = CppBinop.mkAssign(access, CppVar.mk(ctx.lookupRepr(sym)));
-                assign.toStmt().println(out, 1);
-            }
-        }
+		void initializeSymbolTable() {
+			for (ConstructorSymbol sym : symbols) {
+				CppExpr access = CppSubscript.mk(CppVar.mk("symbol_table"), CppConst.mkString(CodeGenUtil.mkName(sym)));
+				CppExpr assign = CppBinop.mkAssign(access, CppVar.mk(ctx.lookupRepr(sym)));
+				assign.toStmt().println(out, 1);
+			}
+		}
 
-        void defineTupleLookup() {
-            for (ConstructorSymbol sym : symbols) {
-                if (sym instanceof TupleSymbol) {
-                    out.print("    case " + sym.getArity() + ": return ");
-                    out.print(ctx.lookupRepr(sym));
-                    out.println(";");
-                }
-            }
-        }
+		void defineTupleLookup() {
+			for (ConstructorSymbol sym : symbols) {
+				if (sym instanceof TupleSymbol) {
+					out.print("    case " + sym.getArity() + ": return ");
+					out.print(ctx.lookupRepr(sym));
+					out.println(";");
+				}
+			}
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/SymbolHpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/SymbolHpp.java
@@ -29,43 +29,43 @@ import java.util.Set;
 
 public class SymbolHpp extends TemplateSrcFile {
 
-    public SymbolHpp(CodeGenContext ctx) {
-        super("Symbol.hpp", ctx);
-    }
+	public SymbolHpp(CodeGenContext ctx) {
+		super("Symbol.hpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker w = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        w.declareSymbols();
-        CodeGenUtil.copyOver(br, out, 1);
-        w.defineArity();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker w = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		w.declareSymbols();
+		CodeGenUtil.copyOver(br, out, 1);
+		w.defineArity();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
-        private final PrintWriter out;
+		private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
+		private final PrintWriter out;
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        void declareSymbols() {
-            for (ConstructorSymbol sym : symbols) {
-                out.print("  ");
-                out.println(ctx.lookupUnqualifiedRepr(sym) + ",");
-            }
-        }
+		void declareSymbols() {
+			for (ConstructorSymbol sym : symbols) {
+				out.print("  ");
+				out.println(ctx.lookupUnqualifiedRepr(sym) + ",");
+			}
+		}
 
-        void defineArity() {
-            for (ConstructorSymbol sym : symbols) {
-                out.print("    case ");
-                out.print(ctx.lookupRepr(sym));
-                out.println(": return " + sym.getArity() + ";");
-            }
-        }
+		void defineArity() {
+			for (ConstructorSymbol sym : symbols) {
+				out.print("    case ");
+				out.print(ctx.lookupRepr(sym));
+				out.println(": return " + sym.getArity() + ";");
+			}
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/TemplateSrcFile.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/TemplateSrcFile.java
@@ -24,24 +24,24 @@ import java.io.*;
 
 public abstract class TemplateSrcFile {
 
-    private final String name;
-    protected final CodeGenContext ctx;
+	private final String name;
+	protected final CodeGenContext ctx;
 
-    public TemplateSrcFile(String name, CodeGenContext ctx) {
-        this.name = name;
-        this.ctx = ctx;
-    }
+	public TemplateSrcFile(String name, CodeGenContext ctx) {
+		this.name = name;
+		this.ctx = ctx;
+	}
 
-    void gen(File outDir) throws IOException, CodeGenException {
-        try (InputStream is = CodeGenUtil.inputSrcFile(name);
-             InputStreamReader isr = new InputStreamReader(is);
-             BufferedReader br = new BufferedReader(isr);
-             PrintWriter out = new PrintWriter(CodeGenUtil.outputSrcFile(outDir, name))) {
-            gen(br, out);
-            out.flush();
-        }
-    }
+	void gen(File outDir) throws IOException, CodeGenException {
+		try (InputStream is = CodeGenUtil.inputSrcFile(name);
+				InputStreamReader isr = new InputStreamReader(is);
+				BufferedReader br = new BufferedReader(isr);
+				PrintWriter out = new PrintWriter(CodeGenUtil.outputSrcFile(outDir, name))) {
+			gen(br, out);
+			out.flush();
+		}
+	}
 
-    abstract void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException;
+	abstract void gen(BufferedReader br, PrintWriter out) throws IOException, CodeGenException;
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/TermCodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/TermCodeGen.java
@@ -46,243 +46,243 @@ import edu.harvard.seas.pl.formulog.util.Pair;
  */
 public class TermCodeGen {
 
-    private final CodeGenContext ctx;
+	private final CodeGenContext ctx;
 
-    public TermCodeGen(CodeGenContext ctx) {
-        this.ctx = ctx;
-    }
+	public TermCodeGen(CodeGenContext ctx) {
+		this.ctx = ctx;
+	}
 
-    public CppExpr mkBool(CppExpr bool) {
-        return CppFuncCall.mk("Term::make<bool>", bool);
-    }
+	public CppExpr mkBool(CppExpr bool) {
+		return CppFuncCall.mk("Term::make<bool>", bool);
+	}
 
-    /*
-     * EZ: mkComplex no longer requires supporting statements, but these methods
-     * still exist in order to not break the rest of the code.
-     *
-     * AB: Probably makes sense to keep the current signature - I don't think it
-     * causes any significant harm, and it gives us some future flexibility.
-     */
+	/*
+	 * EZ: mkComplex no longer requires supporting statements, but these methods
+	 * still exist in order to not break the rest of the code.
+	 *
+	 * AB: Probably makes sense to keep the current signature - I don't think it
+	 * causes any significant harm, and it gives us some future flexibility.
+	 */
 
-    /**
-     * Generate the C++ representation of a complex term given the symbol of a
-     * constructor and its arguments.
-     *
-     * @param sym
-     * @param args
-     * @return A pair of a C++ statement and a C++ expression representing the
-     * complex term; the statement should be executed before the expression
-     * is used.
-     */
-    public Pair<CppStmt, CppExpr> mkComplex(ConstructorSymbol sym, List<CppExpr> args) {
-        assert sym.getArity() == args.size();
-        CppVar symbol = CppVar.mk(ctx.lookupRepr(sym));
-        CppExpr val = CppFuncCall.mk("Term::make<" + symbol + ">", args);
-        return new Pair<>(CppSeq.mk(), val);
-    }
+	/**
+	 * Generate the C++ representation of a complex term given the symbol of a
+	 * constructor and its arguments.
+	 *
+	 * @param sym
+	 * @param args
+	 * @return A pair of a C++ statement and a C++ expression representing the
+	 *         complex term; the statement should be executed before the expression
+	 *         is used.
+	 */
+	public Pair<CppStmt, CppExpr> mkComplex(ConstructorSymbol sym, List<CppExpr> args) {
+		assert sym.getArity() == args.size();
+		CppVar symbol = CppVar.mk(ctx.lookupRepr(sym));
+		CppExpr val = CppFuncCall.mk("Term::make<" + symbol + ">", args);
+		return new Pair<>(CppSeq.mk(), val);
+	}
 
-    /**
-     * Generate the C++ representation of a complex term given the symbol of a
-     * constructor and its arguments.
-     *
-     * @param sym
-     * @param args
-     * @return A pair of a C++ statement and a C++ expression representing the
-     * complex term; the statement should be executed before the expression
-     * is used.
-     */
-    public Pair<CppStmt, CppExpr> mkComplex(ConstructorSymbol sym, CppExpr... args) {
-        return mkComplex(sym, Arrays.asList(args));
-    }
+	/**
+	 * Generate the C++ representation of a complex term given the symbol of a
+	 * constructor and its arguments.
+	 *
+	 * @param sym
+	 * @param args
+	 * @return A pair of a C++ statement and a C++ expression representing the
+	 *         complex term; the statement should be executed before the expression
+	 *         is used.
+	 */
+	public Pair<CppStmt, CppExpr> mkComplex(ConstructorSymbol sym, CppExpr... args) {
+		return mkComplex(sym, Arrays.asList(args));
+	}
 
-    /**
-     * Generate the C++ representation of a complex term given the symbol of a
-     * constructor and its arguments.
-     *
-     * @param acc  An accumulator list of statements; these should be executed before
-     *             the returned expression is used
-     * @param sym
-     * @param args
-     * @return A C++ expression representing the complex term
-     */
-    public CppExpr mkComplex(List<CppStmt> acc, ConstructorSymbol sym, CppExpr... args) {
-        Pair<CppStmt, CppExpr> p = mkComplex(sym, args);
-        acc.add(p.fst());
-        return p.snd();
-    }
+	/**
+	 * Generate the C++ representation of a complex term given the symbol of a
+	 * constructor and its arguments.
+	 *
+	 * @param acc  An accumulator list of statements; these should be executed
+	 *             before the returned expression is used
+	 * @param sym
+	 * @param args
+	 * @return A C++ expression representing the complex term
+	 */
+	public CppExpr mkComplex(List<CppStmt> acc, ConstructorSymbol sym, CppExpr... args) {
+		Pair<CppStmt, CppExpr> p = mkComplex(sym, args);
+		acc.add(p.fst());
+		return p.snd();
+	}
 
-    /**
-     * Generate the C++ representation of a complex term given the symbol of a
-     * constructor and its arguments.
-     *
-     * @param acc  An accumulator list of statements; these should be executed before
-     *             the returned expression is used
-     * @param sym
-     * @param args
-     * @return A C++ expression representing the complex term
-     */
-    public CppExpr mkComplex(List<CppStmt> acc, ConstructorSymbol sym, List<CppExpr> args) {
-        Pair<CppStmt, CppExpr> p = mkComplex(sym, args);
-        acc.add(p.fst());
-        return p.snd();
-    }
+	/**
+	 * Generate the C++ representation of a complex term given the symbol of a
+	 * constructor and its arguments.
+	 *
+	 * @param acc  An accumulator list of statements; these should be executed
+	 *             before the returned expression is used
+	 * @param sym
+	 * @param args
+	 * @return A C++ expression representing the complex term
+	 */
+	public CppExpr mkComplex(List<CppStmt> acc, ConstructorSymbol sym, List<CppExpr> args) {
+		Pair<CppStmt, CppExpr> p = mkComplex(sym, args);
+		acc.add(p.fst());
+		return p.snd();
+	}
 
-    /**
-     * Generate the C++ representation of a term, given an environment mapping
-     * Formulog variables to C++ expressions.
-     *
-     * @param t
-     * @param env
-     * @return A pair of a C++ statement and a C++ expression representing the term;
-     * the statement should be executed before the expression is used.
-     */
-    public Pair<CppStmt, CppExpr> gen(Term t, Map<Var, CppExpr> env) {
-        List<CppStmt> acc = new ArrayList<>();
-        CppExpr e = gen(acc, t, env);
-        return new Pair<>(CppSeq.mk(acc), e);
-    }
+	/**
+	 * Generate the C++ representation of a term, given an environment mapping
+	 * Formulog variables to C++ expressions.
+	 *
+	 * @param t
+	 * @param env
+	 * @return A pair of a C++ statement and a C++ expression representing the term;
+	 *         the statement should be executed before the expression is used.
+	 */
+	public Pair<CppStmt, CppExpr> gen(Term t, Map<Var, CppExpr> env) {
+		List<CppStmt> acc = new ArrayList<>();
+		CppExpr e = gen(acc, t, env);
+		return new Pair<>(CppSeq.mk(acc), e);
+	}
 
-    /**
-     * Generate the C++ representation of a term, given an environement mapping
-     * Formulog variables to C++ expressions.
-     *
-     * @param acc  An accumulator list of statements; these should be executed before
-     *             the returned expression is used
-     * @param sym
-     * @param args
-     * @return A C++ expression representing the term
-     */
-    public CppExpr gen(List<CppStmt> acc, Term t, Map<Var, CppExpr> env) {
-        return new Worker(acc, env).go(t);
-    }
+	/**
+	 * Generate the C++ representation of a term, given an environement mapping
+	 * Formulog variables to C++ expressions.
+	 *
+	 * @param acc  An accumulator list of statements; these should be executed
+	 *             before the returned expression is used
+	 * @param sym
+	 * @param args
+	 * @return A C++ expression representing the term
+	 */
+	public CppExpr gen(List<CppStmt> acc, Term t, Map<Var, CppExpr> env) {
+		return new Worker(acc, env).go(t);
+	}
 
-    /**
-     * Generate the C++ representation of a term, given an environement mapping
-     * Formulog variables to C++ expressions.
-     *
-     * @param acc  An accumulator list of statements; these should be executed before
-     *             the returned expression is used
-     * @param sym
-     * @param args
-     * @return C++ expressions representing the terms (in order)
-     */
-    public List<CppExpr> gen(List<CppStmt> acc, List<Term> ts, Map<Var, CppExpr> env) {
-        List<CppExpr> exprs = new ArrayList<>();
-        for (Term t : ts) {
-            exprs.add(gen(acc, t, env));
-        }
-        return exprs;
-    }
+	/**
+	 * Generate the C++ representation of a term, given an environement mapping
+	 * Formulog variables to C++ expressions.
+	 *
+	 * @param acc  An accumulator list of statements; these should be executed
+	 *             before the returned expression is used
+	 * @param sym
+	 * @param args
+	 * @return C++ expressions representing the terms (in order)
+	 */
+	public List<CppExpr> gen(List<CppStmt> acc, List<Term> ts, Map<Var, CppExpr> env) {
+		List<CppExpr> exprs = new ArrayList<>();
+		for (Term t : ts) {
+			exprs.add(gen(acc, t, env));
+		}
+		return exprs;
+	}
 
-    /**
-     * Generate the C++ representation of some terms, given an environment mapping
-     * Formulog variables to C++ expressions.
-     *
-     * @param ts
-     * @param env
-     * @return A pair of a C++ statement and a list of C++ expressions representing
-     * the terms (in order); the statement should be executed before the
-     * expressions are used.
-     */
-    public Pair<CppStmt, List<CppExpr>> gen(List<Term> ts, Map<Var, CppExpr> env) {
-        List<CppStmt> acc = new ArrayList<>();
-        List<CppExpr> es = gen(acc, ts, env);
-        return new Pair<>(CppSeq.mk(acc), es);
-    }
+	/**
+	 * Generate the C++ representation of some terms, given an environment mapping
+	 * Formulog variables to C++ expressions.
+	 *
+	 * @param ts
+	 * @param env
+	 * @return A pair of a C++ statement and a list of C++ expressions representing
+	 *         the terms (in order); the statement should be executed before the
+	 *         expressions are used.
+	 */
+	public Pair<CppStmt, List<CppExpr>> gen(List<Term> ts, Map<Var, CppExpr> env) {
+		List<CppStmt> acc = new ArrayList<>();
+		List<CppExpr> es = gen(acc, ts, env);
+		return new Pair<>(CppSeq.mk(acc), es);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final Map<Var, CppExpr> env;
-        private final List<CppStmt> acc;
-        private final MatchCodeGen mcg = new MatchCodeGen(ctx);
+		private final Map<Var, CppExpr> env;
+		private final List<CppStmt> acc;
+		private final MatchCodeGen mcg = new MatchCodeGen(ctx);
 
-        public Worker(List<CppStmt> acc, Map<Var, CppExpr> env) {
-            this.acc = acc;
-            this.env = env;
-        }
+		public Worker(List<CppStmt> acc, Map<Var, CppExpr> env) {
+			this.acc = acc;
+			this.env = env;
+		}
 
-        public CppExpr go(Term t) {
-            return t.accept(tv, null);
-        }
+		public CppExpr go(Term t) {
+			return t.accept(tv, null);
+		}
 
-        private final TermVisitor<Void, CppExpr> tv = new TermVisitor<Void, CppExpr>() {
+		private final TermVisitor<Void, CppExpr> tv = new TermVisitor<Void, CppExpr>() {
 
-            @Override
-            public CppExpr visit(Var x, Void in) {
-                assert env.containsKey(x);
-                return env.get(x);
-            }
+			@Override
+			public CppExpr visit(Var x, Void in) {
+				assert env.containsKey(x);
+				return env.get(x);
+			}
 
-            @Override
-            public CppExpr visit(Constructor c, Void in) {
-                ConstructorSymbol sym = c.getSymbol();
-                Term[] args = c.getArgs();
-                List<CppExpr> cppArgs = new ArrayList<>();
-                for (Term arg : args) {
-                    cppArgs.add(arg.accept(this, in));
-                }
-                CppExpr term = mkComplex(acc, sym, cppArgs);
-                String tId = ctx.newId("t");
-                acc.add(CppDecl.mk(tId, term));
-                return CppVar.mk(tId);
-            }
+			@Override
+			public CppExpr visit(Constructor c, Void in) {
+				ConstructorSymbol sym = c.getSymbol();
+				Term[] args = c.getArgs();
+				List<CppExpr> cppArgs = new ArrayList<>();
+				for (Term arg : args) {
+					cppArgs.add(arg.accept(this, in));
+				}
+				CppExpr term = mkComplex(acc, sym, cppArgs);
+				String tId = ctx.newId("t");
+				acc.add(CppDecl.mk(tId, term));
+				return CppVar.mk(tId);
+			}
 
-            @Override
-            public CppExpr visit(Primitive<?> p, Void in) {
-                return CppBaseTerm.mk(p);
-            }
+			@Override
+			public CppExpr visit(Primitive<?> p, Void in) {
+				return CppBaseTerm.mk(p);
+			}
 
-            @Override
-            public CppExpr visit(Expr e, Void in) {
-                return e.accept(ev, in);
-            }
+			@Override
+			public CppExpr visit(Expr e, Void in) {
+				return e.accept(ev, in);
+			}
 
-        };
+		};
 
-        private final ExprVisitor<Void, CppExpr> ev = new ExprVisitor<Void, CppExpr>() {
+		private final ExprVisitor<Void, CppExpr> ev = new ExprVisitor<Void, CppExpr>() {
 
-            @Override
-            public CppExpr visit(MatchExpr matchExpr, Void in) {
-                Pair<CppStmt, CppExpr> p = mcg.gen(matchExpr, env);
-                acc.add(p.fst());
-                return p.snd();
-            }
+			@Override
+			public CppExpr visit(MatchExpr matchExpr, Void in) {
+				Pair<CppStmt, CppExpr> p = mcg.gen(matchExpr, env);
+				acc.add(p.fst());
+				return p.snd();
+			}
 
-            @Override
-            public CppExpr visit(FunctionCall funcCall, Void in) {
-                List<CppExpr> args = new ArrayList<>();
-                for (Term arg : funcCall.getArgs()) {
-                    args.add(arg.accept(tv, in));
-                }
-                return CppFuncCall.mk(ctx.lookupRepr(funcCall.getSymbol()), args);
-            }
+			@Override
+			public CppExpr visit(FunctionCall funcCall, Void in) {
+				List<CppExpr> args = new ArrayList<>();
+				for (Term arg : funcCall.getArgs()) {
+					args.add(arg.accept(tv, in));
+				}
+				return CppFuncCall.mk(ctx.lookupRepr(funcCall.getSymbol()), args);
+			}
 
-            @Override
-            public CppExpr visit(LetFunExpr funcDefs, Void in) {
-                throw new AssertionError("impossible");
-            }
+			@Override
+			public CppExpr visit(LetFunExpr funcDefs, Void in) {
+				throw new AssertionError("impossible");
+			}
 
-            @Override
-            public CppExpr visit(Fold fold, Void in) {
-                List<CppExpr> args = new ArrayList<>();
-                var f = ctx.lookupRepr(fold.getFunction());
-                args.add(CppExprFromString.mk(f));
-                for (Term arg : fold.getArgs()) {
-                    args.add(arg.accept(tv, in));
-                }
-                return CppFuncCall.mk("funcs::fold", args);
-            }
+			@Override
+			public CppExpr visit(Fold fold, Void in) {
+				List<CppExpr> args = new ArrayList<>();
+				var f = ctx.lookupRepr(fold.getFunction());
+				args.add(CppExprFromString.mk(f));
+				for (Term arg : fold.getArgs()) {
+					args.add(arg.accept(tv, in));
+				}
+				return CppFuncCall.mk("funcs::fold", args);
+			}
 
-        };
+		};
 
-    }
+	}
 
-    public static CppExpr genIntizeTerm(CppExpr term) {
-        return CppMethodCall.mkThruPtr(term, "intize");
-    }
+	public static CppExpr genIntizeTerm(CppExpr term) {
+		return CppMethodCall.mkThruPtr(term, "intize");
+	}
 
-    public static CppExpr genUnintizeTerm(CppExpr id) {
-        return CppFuncCall.mk("Term::unintize", id);
-    }
+	public static CppExpr genUnintizeTerm(CppExpr id) {
+		return CppFuncCall.mk("Term::unintize", id);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/TermCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/TermCpp.java
@@ -30,52 +30,52 @@ import java.util.Set;
 
 public class TermCpp extends TemplateSrcFile {
 
-    public TermCpp(CodeGenContext ctx) {
-        super("Term.cpp", ctx);
-    }
+	public TermCpp(CodeGenContext ctx) {
+		super("Term.cpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker w = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        w.declareExplicitTemplateInstantiations();
-        CodeGenUtil.copyOver(br, out, 1);
-        w.declareMakeGenericCases();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker w = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		w.declareExplicitTemplateInstantiations();
+		CodeGenUtil.copyOver(br, out, 1);
+		w.declareMakeGenericCases();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
-        private final PrintWriter out;
+		private final Set<ConstructorSymbol> symbols = ctx.getConstructorSymbols();
+		private final PrintWriter out;
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        void declareExplicitTemplateInstantiations() {
-            for (ConstructorSymbol sym : symbols) {
-                String args = String.join(", ", Collections.nCopies(sym.getArity(), "term_ptr"));
-                out.print("template term_ptr Term::make<");
-                out.print(ctx.lookupRepr(sym));
-                if (sym.getArity() != 0) {
-                    out.print(", " + args);
-                }
-                out.println(">(" + args + ");");
-            }
-        }
+		void declareExplicitTemplateInstantiations() {
+			for (ConstructorSymbol sym : symbols) {
+				String args = String.join(", ", Collections.nCopies(sym.getArity(), "term_ptr"));
+				out.print("template term_ptr Term::make<");
+				out.print(ctx.lookupRepr(sym));
+				if (sym.getArity() != 0) {
+					out.print(", " + args);
+				}
+				out.println(">(" + args + ");");
+			}
+		}
 
-        void declareMakeGenericCases() {
-            for (ConstructorSymbol sym : symbols) {
-                String symName = ctx.lookupRepr(sym);
-                int arity = sym.getArity();
-                String[] args = new String[arity];
-                for (int i = 0; i < arity; i++)
-                    args[i] = "terms[" + i + "]";
-                out.printf("    case %s:\n", symName);
-                out.printf("      return Term::make<%s>(%s);\n", symName, String.join(", ", args));
-            }
-        }
+		void declareMakeGenericCases() {
+			for (ConstructorSymbol sym : symbols) {
+				String symName = ctx.lookupRepr(sym);
+				int arity = sym.getArity();
+				String[] args = new String[arity];
+				for (int i = 0; i < arity; i++)
+					args[i] = "terms[" + i + "]";
+				out.printf("    case %s:\n", symName);
+				out.printf("      return Term::make<%s>(%s);\n", symName, String.join(", ", args));
+			}
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/TypeCodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/TypeCodeGen.java
@@ -44,198 +44,197 @@ import edu.harvard.seas.pl.formulog.util.Pair;
  */
 public class TypeCodeGen {
 
-    private final CodeGenContext ctx;
+	private final CodeGenContext ctx;
 
-    public TypeCodeGen(CodeGenContext ctx) {
-        this.ctx = ctx;
-    }
+	public TypeCodeGen(CodeGenContext ctx) {
+		this.ctx = ctx;
+	}
 
-    /**
-     * Take a Formulog type and generate its C++ representation.
-     *
-     * @param type The Formulog type that needs to be represented in C++
-     * @return A pair of a C++ statement and an C++ expression. The expression is
-     * the C++ representation of the provided type; the statement is code
-     * that should be evaluated before that expression is used.
-     */
-    public Pair<CppStmt, CppExpr> gen(Type type) {
-        List<CppStmt> acc = new ArrayList<>();
-        CppExpr e = gen(acc, type);
-        return new Pair<>(CppSeq.mk(acc), e);
-    }
+	/**
+	 * Take a Formulog type and generate its C++ representation.
+	 *
+	 * @param type The Formulog type that needs to be represented in C++
+	 * @return A pair of a C++ statement and an C++ expression. The expression is
+	 *         the C++ representation of the provided type; the statement is code
+	 *         that should be evaluated before that expression is used.
+	 */
+	public Pair<CppStmt, CppExpr> gen(Type type) {
+		List<CppStmt> acc = new ArrayList<>();
+		CppExpr e = gen(acc, type);
+		return new Pair<>(CppSeq.mk(acc), e);
+	}
 
-    /**
-     * Take a Formulog type and generate its C++ representation. Any C++ statements
-     * that need to be run before the expression (representing that type) is used
-     * are appended to the given accumulator list.
-     *
-     * @param acc  An accumulator list of statements
-     * @param type The Formulog type that needs to be represented in C++
-     * @return The C++ expression representing the given Formulog type
-     */
-    public CppExpr gen(List<CppStmt> acc, Type type) {
-        return new Worker(acc, new HashMap<>()).go(type);
-    }
+	/**
+	 * Take a Formulog type and generate its C++ representation. Any C++ statements
+	 * that need to be run before the expression (representing that type) is used
+	 * are appended to the given accumulator list.
+	 *
+	 * @param acc  An accumulator list of statements
+	 * @param type The Formulog type that needs to be represented in C++
+	 * @return The C++ expression representing the given Formulog type
+	 */
+	public CppExpr gen(List<CppStmt> acc, Type type) {
+		return new Worker(acc, new HashMap<>()).go(type);
+	}
 
-    /**
-     * Take a list of Formulog types and generate their C++ representation. Any C++
-     * statements that need to be run before the expressions (representing those
-     * types) are used are appended to the given accumulator list.
-     *
-     * @param acc   An accumulator list of statements
-     * @param types The Formulog types that need to be represented in C++
-     * @return The C++ expressions representing the given Formulog types (and in the
-     * same order)
-     */
-    public List<CppExpr> gen(List<CppStmt> acc, List<Type> types) {
-        List<CppExpr> es = new ArrayList<>();
-        for (Type ty : types) {
-            gen(acc, ty);
-        }
-        return es;
-    }
+	/**
+	 * Take a list of Formulog types and generate their C++ representation. Any C++
+	 * statements that need to be run before the expressions (representing those
+	 * types) are used are appended to the given accumulator list.
+	 *
+	 * @param acc   An accumulator list of statements
+	 * @param types The Formulog types that need to be represented in C++
+	 * @return The C++ expressions representing the given Formulog types (and in the
+	 *         same order)
+	 */
+	public List<CppExpr> gen(List<CppStmt> acc, List<Type> types) {
+		List<CppExpr> es = new ArrayList<>();
+		for (Type ty : types) {
+			gen(acc, ty);
+		}
+		return es;
+	}
 
-    /**
-     * Take a list of Formulog types and generate their C++ representations.
-     *
-     * @param types The Formulog types that need to be represented in C++
-     * @return A pair of a C++ statement and a list of C++ expression. The
-     * expressions are the C++ representations of the provided types (in the
-     * same order); the statement is code that should be evaluated before
-     * those expressions are used.
-     */
-    public Pair<CppStmt, List<CppExpr>> gen(List<Type> types) {
-        List<CppStmt> acc = new ArrayList<>();
-        List<CppExpr> es = gen(acc, types);
-        return new Pair<>(CppSeq.mk(acc), es);
-    }
+	/**
+	 * Take a list of Formulog types and generate their C++ representations.
+	 *
+	 * @param types The Formulog types that need to be represented in C++
+	 * @return A pair of a C++ statement and a list of C++ expression. The
+	 *         expressions are the C++ representations of the provided types (in the
+	 *         same order); the statement is code that should be evaluated before
+	 *         those expressions are used.
+	 */
+	public Pair<CppStmt, List<CppExpr>> gen(List<Type> types) {
+		List<CppStmt> acc = new ArrayList<>();
+		List<CppExpr> es = gen(acc, types);
+		return new Pair<>(CppSeq.mk(acc), es);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        // Keep track of which type variables have already been generated
-        private final Map<TypeVar, CppExpr> env;
-        private final List<CppStmt> acc;
+		// Keep track of which type variables have already been generated
+		private final Map<TypeVar, CppExpr> env;
+		private final List<CppStmt> acc;
 
-        public Worker(List<CppStmt> acc, Map<TypeVar, CppExpr> env) {
-            this.acc = acc;
-            this.env = env;
-        }
+		public Worker(List<CppStmt> acc, Map<TypeVar, CppExpr> env) {
+			this.acc = acc;
+			this.env = env;
+		}
 
-        public CppExpr go(Type type) {
-            if (type instanceof FunctorType) {
-                return go1((FunctorType) type);
-            }
-            return type.accept(visitor, null);
-        }
+		public CppExpr go(Type type) {
+			if (type instanceof FunctorType) {
+				return go1((FunctorType) type);
+			}
+			return type.accept(visitor, null);
+		}
 
+		private List<CppExpr> go(List<Type> types) {
+			List<CppExpr> l = new ArrayList<>();
+			for (Type ty : types) {
+				l.add(go(ty));
+			}
+			return l;
+		}
 
-        private List<CppExpr> go(List<Type> types) {
-            List<CppExpr> l = new ArrayList<>();
-            for (Type ty : types) {
-                l.add(go(ty));
-            }
-            return l;
-        }
+		private CppExpr go1(FunctorType type) {
+			CppExpr ret = go(type.getRetType());
+			// A FunctorType is represented in C++ by a pair of the argument types and the
+			// return type.
+			return CppFuncCall.mk("make_pair", mkVec(type.getArgTypes()), ret);
+		}
 
-        private CppExpr go1(FunctorType type) {
-            CppExpr ret = go(type.getRetType());
-            // A FunctorType is represented in C++ by a pair of the argument types and the
-            // return type.
-            return CppFuncCall.mk("make_pair", mkVec(type.getArgTypes()), ret);
-        }
+		TypeVisitor<Void, CppExpr> visitor = new TypeVisitor<Void, CppExpr>() {
 
-        TypeVisitor<Void, CppExpr> visitor = new TypeVisitor<Void, CppExpr>() {
+			@Override
+			public CppExpr visit(TypeVar typeVar, Void in) {
+				CppExpr e = env.get(typeVar);
+				if (e == null) {
+					// Tell the C++ code to generate a fresh type variable
+					String id = ctx.newId("ty");
+					acc.add(CppDecl.mk(id, CppFuncCall.mk("new_var")));
+					e = CppVar.mk(id);
+					env.put(typeVar, e);
+				}
+				return e;
+			}
 
-            @Override
-            public CppExpr visit(TypeVar typeVar, Void in) {
-                CppExpr e = env.get(typeVar);
-                if (e == null) {
-                    // Tell the C++ code to generate a fresh type variable
-                    String id = ctx.newId("ty");
-                    acc.add(CppDecl.mk(id, CppFuncCall.mk("new_var")));
-                    e = CppVar.mk(id);
-                    env.put(typeVar, e);
-                }
-                return e;
-            }
+			@Override
+			public CppExpr visit(AlgebraicDataType algebraicType, Void in) {
+				TypeSymbol sym = algebraicType.getSymbol();
+				CppExpr e = null;
+				if (sym instanceof BuiltInTypeSymbol) {
+					e = handleBuiltInType(algebraicType);
+				}
+				if (e != null) {
+					return e;
+				}
+				// XXX Need to make sure this matches SMT declarations
+				return mkType("|" + sym + "|", algebraicType.getTypeArgs());
+			}
 
-            @Override
-            public CppExpr visit(AlgebraicDataType algebraicType, Void in) {
-                TypeSymbol sym = algebraicType.getSymbol();
-                CppExpr e = null;
-                if (sym instanceof BuiltInTypeSymbol) {
-                    e = handleBuiltInType(algebraicType);
-                }
-                if (e != null) {
-                    return e;
-                }
-                // XXX Need to make sure this matches SMT declarations
-                return mkType("|" + sym + "|", algebraicType.getTypeArgs());
-            }
+			@Override
+			public CppExpr visit(OpaqueType opaqueType, Void in) {
+				throw new AssertionError("impossible");
+			}
 
-            @Override
-            public CppExpr visit(OpaqueType opaqueType, Void in) {
-                throw new AssertionError("impossible");
-            }
+			@Override
+			public CppExpr visit(TypeIndex typeIndex, Void in) {
+				return mkType(Integer.toString(typeIndex.getIndex()));
+			}
 
-            @Override
-            public CppExpr visit(TypeIndex typeIndex, Void in) {
-                return mkType(Integer.toString(typeIndex.getIndex()));
-            }
+		};
 
-        };
+		private CppExpr handleBuiltInType(AlgebraicDataType type) {
+			BuiltInTypeSymbol sym = (BuiltInTypeSymbol) type.getSymbol();
+			List<Type> args = type.getTypeArgs();
+			switch (sym) {
+			case ARRAY_TYPE:
+				return mkType("Array", args);
+			case BOOL_TYPE:
+				return mkType("Bool", args);
+			case BV:
+				return mkType("_ BitVec", args);
+			case STRING_TYPE:
+				return mkType("String", args);
+			case FP:
+				return mkType("_ FloatingPoint", args);
+			case INT_TYPE:
+				return mkType("Int", args);
+			// The rest of the built-in types can be treated as normal (i.e., user-defined)
+			// types
+			case LIST_TYPE:
+			case OPTION_TYPE:
+			case CMP_TYPE:
+			case MODEL_TYPE:
+			case SMT_PATTERN_TYPE:
+			case SMT_TYPE:
+			case SMT_WRAPPED_VAR_TYPE:
+			case SYM_TYPE:
+				break;
+			}
+			return null;
+		}
 
-        private CppExpr handleBuiltInType(AlgebraicDataType type) {
-            BuiltInTypeSymbol sym = (BuiltInTypeSymbol) type.getSymbol();
-            List<Type> args = type.getTypeArgs();
-            switch (sym) {
-                case ARRAY_TYPE:
-                    return mkType("Array", args);
-                case BOOL_TYPE:
-                    return mkType("Bool", args);
-                case BV:
-                    return mkType("_ BitVec", args);
-                case STRING_TYPE:
-                    return mkType("String", args);
-                case FP:
-                    return mkType("_ FloatingPoint", args);
-                case INT_TYPE:
-                    return mkType("Int", args);
-                // The rest of the built-in types can be treated as normal (i.e., user-defined)
-                // types
-                case LIST_TYPE:
-                case OPTION_TYPE:
-                case CMP_TYPE:
-                case MODEL_TYPE:
-                case SMT_PATTERN_TYPE:
-                case SMT_TYPE:
-                case SMT_WRAPPED_VAR_TYPE:
-                case SYM_TYPE:
-                    break;
-            }
-            return null;
-        }
+		private CppExpr mkType(String name) {
+			return mkType(name, Collections.emptyList());
+		}
 
-        private CppExpr mkType(String name) {
-            return mkType(name, Collections.emptyList());
-        }
+		private CppExpr mkType(String name, List<Type> args) {
+			CppExpr cppName = CppConst.mkString(name);
+			CppExpr vec = mkVec(args);
+			String tyId = ctx.newId("ty");
+			// Create a new variable and initialize it. The initializer has the signature
+			// (type_name, is_var, type_args).
+			acc.add(CppCtor.mkInitializer("Type", tyId, cppName, CppConst.mkFalse(), vec));
+			return CppVar.mk(tyId);
+		}
 
-        private CppExpr mkType(String name, List<Type> args) {
-            CppExpr cppName = CppConst.mkString(name);
-            CppExpr vec = mkVec(args);
-            String tyId = ctx.newId("ty");
-            // Create a new variable and initialize it. The initializer has the signature
-            // (type_name, is_var, type_args).
-            acc.add(CppCtor.mkInitializer("Type", tyId, cppName, CppConst.mkFalse(), vec));
-            return CppVar.mk(tyId);
-        }
+		private CppExpr mkVec(List<Type> args) {
+			String vId = ctx.newId("v");
+			acc.add(CppCtor.mkInitializer("vector<Type>", vId, go(args)));
+			return CppVar.mk(vId);
+		}
 
-        private CppExpr mkVec(List<Type> args) {
-            String vId = ctx.newId("v");
-            acc.add(CppCtor.mkInitializer("vector<Type>", vId, go(args)));
-            return CppVar.mk(vId);
-        }
-
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/TypeCpp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/TypeCpp.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppExpr;
 import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppReturn;
 import edu.harvard.seas.pl.formulog.codegen.ast.cpp.CppSeq;
@@ -38,54 +37,54 @@ import java.util.List;
 
 public class TypeCpp extends TemplateSrcFile {
 
-    public TypeCpp(CodeGenContext ctx) {
-        super("Type.cpp", ctx);
-    }
+	public TypeCpp(CodeGenContext ctx) {
+		super("Type.cpp", ctx);
+	}
 
-    public void gen(BufferedReader br, PrintWriter out) throws IOException {
-        Worker pr = new Worker(out);
-        CodeGenUtil.copyOver(br, out, 0);
-        pr.defineSymbolTypes();
-        CodeGenUtil.copyOver(br, out, -1);
-    }
+	public void gen(BufferedReader br, PrintWriter out) throws IOException {
+		Worker pr = new Worker(out);
+		CodeGenUtil.copyOver(br, out, 0);
+		pr.defineSymbolTypes();
+		CodeGenUtil.copyOver(br, out, -1);
+	}
 
-    private class Worker {
+	private class Worker {
 
-        private final PrintWriter out;
-        private final TypeCodeGen tcg = new TypeCodeGen(ctx);
+		private final PrintWriter out;
+		private final TypeCodeGen tcg = new TypeCodeGen(ctx);
 
-        public Worker(PrintWriter out) {
-            this.out = out;
-        }
+		public Worker(PrintWriter out) {
+			this.out = out;
+		}
 
-        public void defineSymbolTypes() {
-            for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
-                defineSymbolType(sym);
-            }
-        }
+		public void defineSymbolTypes() {
+			for (ConstructorSymbol sym : ctx.getConstructorSymbols()) {
+				defineSymbolType(sym);
+			}
+		}
 
-        private void defineSymbolType(ConstructorSymbol sym) {
-            out.println("    case " + ctx.lookupRepr(sym) + ": {");
-            genCaseBody(sym).println(out, 3);
-            out.println("    }");
-        }
+		private void defineSymbolType(ConstructorSymbol sym) {
+			out.println("    case " + ctx.lookupRepr(sym) + ": {");
+			genCaseBody(sym).println(out, 3);
+			out.println("    }");
+		}
 
-        private CppStmt genCaseBody(ConstructorSymbol sym) {
-            List<CppStmt> acc = new ArrayList<>();
-            FunctorType ft = simplify(sym.getCompileTimeType());
-            CppExpr typeCode = tcg.gen(acc, ft);
-            acc.add(CppReturn.mk(typeCode));
-            return CppSeq.mk(acc);
-        }
+		private CppStmt genCaseBody(ConstructorSymbol sym) {
+			List<CppStmt> acc = new ArrayList<>();
+			FunctorType ft = simplify(sym.getCompileTimeType());
+			CppExpr typeCode = tcg.gen(acc, ft);
+			acc.add(CppReturn.mk(typeCode));
+			return CppSeq.mk(acc);
+		}
 
-        private FunctorType simplify(FunctorType ft) {
-            List<Type> args = new ArrayList<>();
-            for (Type ty : ft.getArgTypes()) {
-                args.add(TypeChecker.simplify(ty));
-            }
-            return new FunctorType(args, TypeChecker.simplify(ft.getRetType()));
-        }
+		private FunctorType simplify(FunctorType ft) {
+			List<Type> args = new ArrayList<>();
+			for (Type ty : ft.getArgTypes()) {
+				args.add(TypeChecker.simplify(ty));
+			}
+			return new FunctorType(args, TypeChecker.simplify(ft.getRetType()));
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppAccess.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppAccess.java
@@ -20,34 +20,33 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppAccess implements CppExpr {
 
-    private final CppExpr val;
-    private final String field;
-    private final boolean thruPtr;
+	private final CppExpr val;
+	private final String field;
+	private final boolean thruPtr;
 
-    private CppAccess(CppExpr val, String field, boolean thruPtr) {
-        this.val = val;
-        this.field = field;
-        this.thruPtr = thruPtr;
-    }
+	private CppAccess(CppExpr val, String field, boolean thruPtr) {
+		this.val = val;
+		this.field = field;
+		this.thruPtr = thruPtr;
+	}
 
-    public static CppAccess mk(CppExpr val, String field) {
-        return new CppAccess(val, field, false);
-    }
+	public static CppAccess mk(CppExpr val, String field) {
+		return new CppAccess(val, field, false);
+	}
 
-    public static CppAccess mkThruPtr(CppExpr val, String field) {
-        return new CppAccess(val, field, true);
-    }
+	public static CppAccess mkThruPtr(CppExpr val, String field) {
+		return new CppAccess(val, field, true);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        val.print(out);
-        out.print(thruPtr ? "->" : ".");
-        out.print(field);
-    }
+	@Override
+	public void print(PrintWriter out) {
+		val.print(out);
+		out.print(thruPtr ? "->" : ".");
+		out.print(field);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBaseTerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBaseTerm.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 import edu.harvard.seas.pl.formulog.ast.BoolTerm;
@@ -33,70 +32,70 @@ import edu.harvard.seas.pl.formulog.ast.StringTerm;
 
 public class CppBaseTerm implements CppExpr {
 
-    private final Primitive<?> p;
+	private final Primitive<?> p;
 
-    public static CppBaseTerm mk(Primitive<?> p) {
-        return new CppBaseTerm(p);
-    }
+	public static CppBaseTerm mk(Primitive<?> p) {
+		return new CppBaseTerm(p);
+	}
 
-    private CppBaseTerm(Primitive<?> p) {
-        this.p = p;
-    }
+	private CppBaseTerm(Primitive<?> p) {
+		this.p = p;
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        String type;
-        String val = p.toString();
-        if (p instanceof I32) {
-            type = "int32_t";
-        } else if (p instanceof I64) {
-            type = "int64_t";
-        } else if (p instanceof FP32) {
-            type = "float";
-            val = handleFloat(((FP32) p).getVal());
-        } else if (p instanceof FP64) {
-            type = "double";
-            val = handleDouble(((FP64) p).getVal());
-        } else if (p instanceof BoolTerm) {
-            type = "bool";
-        } else if (p instanceof StringTerm) {
-            type = "string";
-        } else {
-            throw new UnsupportedOperationException("Unsupported primitive: " + p);
-        }
-        printMakeTerm(type, val, out);
-    }
+	@Override
+	public void print(PrintWriter out) {
+		String type;
+		String val = p.toString();
+		if (p instanceof I32) {
+			type = "int32_t";
+		} else if (p instanceof I64) {
+			type = "int64_t";
+		} else if (p instanceof FP32) {
+			type = "float";
+			val = handleFloat(((FP32) p).getVal());
+		} else if (p instanceof FP64) {
+			type = "double";
+			val = handleDouble(((FP64) p).getVal());
+		} else if (p instanceof BoolTerm) {
+			type = "bool";
+		} else if (p instanceof StringTerm) {
+			type = "string";
+		} else {
+			throw new UnsupportedOperationException("Unsupported primitive: " + p);
+		}
+		printMakeTerm(type, val, out);
+	}
 
-    void printMakeTerm(String type, String val, PrintWriter out) {
-        out.print("Term::make<");
-        out.print(type);
-        out.print(">(");
-        out.print(val);
-        out.print(")");
-    }
+	void printMakeTerm(String type, String val, PrintWriter out) {
+		out.print("Term::make<");
+		out.print(type);
+		out.print(">(");
+		out.print(val);
+		out.print(")");
+	}
 
-    public static String handleDouble(double d) {
-        if (d == Double.NEGATIVE_INFINITY) {
-            return "-numeric_limits<double>::infinity()";
-        } else if (d == Double.POSITIVE_INFINITY) {
-            return "numeric_limits<double>::infinity()";
-        } else if (Double.isNaN(d)) {
-            return "nan(\"\")";
-        } else {
-            return Double.toString(d);
-        }
-    }
+	public static String handleDouble(double d) {
+		if (d == Double.NEGATIVE_INFINITY) {
+			return "-numeric_limits<double>::infinity()";
+		} else if (d == Double.POSITIVE_INFINITY) {
+			return "numeric_limits<double>::infinity()";
+		} else if (Double.isNaN(d)) {
+			return "nan(\"\")";
+		} else {
+			return Double.toString(d);
+		}
+	}
 
-    public static String handleFloat(float d) {
-        if (d == Float.NEGATIVE_INFINITY) {
-            return "-numeric_limits<float>::infinity()";
-        } else if (d == Float.POSITIVE_INFINITY) {
-            return "numeric_limits<float>::infinity()";
-        } else if (Float.isNaN(d)) {
-            return "nanf(\"\")";
-        } else {
-            return Float.toString(d);
-        }
-    }
+	public static String handleFloat(float d) {
+		if (d == Float.NEGATIVE_INFINITY) {
+			return "-numeric_limits<float>::infinity()";
+		} else if (d == Float.POSITIVE_INFINITY) {
+			return "numeric_limits<float>::infinity()";
+		} else if (Float.isNaN(d)) {
+			return "nanf(\"\")";
+		} else {
+			return Float.toString(d);
+		}
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBinop.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBinop.java
@@ -20,62 +20,61 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppBinop implements CppExpr {
 
-    private final CppExpr lhs;
-    private final String op;
-    private final CppExpr rhs;
+	private final CppExpr lhs;
+	private final String op;
+	private final CppExpr rhs;
 
-    private CppBinop(CppExpr lhs, String op, CppExpr rhs) {
-        this.lhs = lhs;
-        this.op = op;
-        this.rhs = rhs;
-    }
+	private CppBinop(CppExpr lhs, String op, CppExpr rhs) {
+		this.lhs = lhs;
+		this.op = op;
+		this.rhs = rhs;
+	}
 
-    private static CppBinop mk(CppExpr lhs, String op, CppExpr rhs) {
-        return new CppBinop(lhs, op, rhs);
-    }
+	private static CppBinop mk(CppExpr lhs, String op, CppExpr rhs) {
+		return new CppBinop(lhs, op, rhs);
+	}
 
-    public static CppBinop mkOrUpdate(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "|=", rhs);
-    }
+	public static CppBinop mkOrUpdate(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "|=", rhs);
+	}
 
-    public static CppBinop mkLogAnd(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "&&", rhs);
-    }
+	public static CppBinop mkLogAnd(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "&&", rhs);
+	}
 
-    public static CppBinop mkNotEq(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "!=", rhs);
-    }
+	public static CppBinop mkNotEq(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "!=", rhs);
+	}
 
-    public static CppBinop mkLt(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "<", rhs);
-    }
+	public static CppBinop mkLt(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "<", rhs);
+	}
 
-    public static CppBinop mkAssign(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "=", rhs);
-    }
+	public static CppBinop mkAssign(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "=", rhs);
+	}
 
-    public static CppExpr mkEq(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "==", rhs);
-    }
+	public static CppExpr mkEq(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "==", rhs);
+	}
 
-    public static CppExpr mkShiftLeft(CppExpr lhs, CppExpr rhs) {
-        return mk(lhs, "<<", rhs);
-    }
+	public static CppExpr mkShiftLeft(CppExpr lhs, CppExpr rhs) {
+		return mk(lhs, "<<", rhs);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print("(");
-        lhs.print(out);
-        out.print(" ");
-        out.print(op);
-        out.print(" ");
-        rhs.print(out);
-        out.print(")");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print("(");
+		lhs.print(out);
+		out.print(" ");
+		out.print(op);
+		out.print(" ");
+		rhs.print(out);
+		out.print(")");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBlock.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppBlock.java
@@ -29,23 +29,23 @@ import java.io.PrintWriter;
  */
 public class CppBlock implements CppStmt {
 
-    private final CppStmt stmt;
+	private final CppStmt stmt;
 
-    private CppBlock(CppStmt stmt) {
-        this.stmt = stmt;
-    }
+	private CppBlock(CppStmt stmt) {
+		this.stmt = stmt;
+	}
 
-    public static CppBlock mk(CppStmt stmt) {
-        return new CppBlock(stmt);
-    }
+	public static CppBlock mk(CppStmt stmt) {
+		return new CppBlock(stmt);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.println("{");
-        stmt.println(out, indent + 1);
-        CodeGenUtil.printIndent(out, indent);
-        out.println("}");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.println("{");
+		stmt.println(out, indent + 1);
+		CodeGenUtil.printIndent(out, indent);
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppCast.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppCast.java
@@ -20,34 +20,33 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppCast implements CppExpr {
 
-    private final String type;
-    private final CppExpr expr;
-    private final String castName;
+	private final String type;
+	private final CppExpr expr;
+	private final String castName;
 
-    private CppCast(String castName, String type, CppExpr expr) {
-        this.type = type;
-        this.expr = expr;
-        this.castName = castName;
-    }
+	private CppCast(String castName, String type, CppExpr expr) {
+		this.type = type;
+		this.expr = expr;
+		this.castName = castName;
+	}
 
-    public static CppCast mkReinterpret(String type, CppExpr expr) {
-        return new CppCast("reinterpret_cast", type, expr);
-    }
+	public static CppCast mkReinterpret(String type, CppExpr expr) {
+		return new CppCast("reinterpret_cast", type, expr);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print(castName);
-        out.print("<");
-        out.print(type);
-        out.print(">");
-        out.print("(");
-        expr.print(out);
-        out.print(")");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print(castName);
+		out.print("<");
+		out.print(type);
+		out.print(">");
+		out.print("(");
+		expr.print(out);
+		out.print(")");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppConst.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppConst.java
@@ -20,43 +20,42 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppConst<T> implements CppExpr {
 
-    private final T val;
+	private final T val;
 
-    private CppConst(T val) {
-        this.val = val;
-    }
+	private CppConst(T val) {
+		this.val = val;
+	}
 
-    public static CppConst<Boolean> mkTrue() {
-        return new CppConst<>(true);
-    }
+	public static CppConst<Boolean> mkTrue() {
+		return new CppConst<>(true);
+	}
 
-    public static CppConst<Boolean> mkFalse() {
-        return new CppConst<>(false);
-    }
+	public static CppConst<Boolean> mkFalse() {
+		return new CppConst<>(false);
+	}
 
-    public static CppConst<Integer> mkInt(int i) {
-        return new CppConst<>(i);
-    }
+	public static CppConst<Integer> mkInt(int i) {
+		return new CppConst<>(i);
+	}
 
-    public static CppConst<String> mkString(String s) {
-        return new CppConst<>(s);
-    }
+	public static CppConst<String> mkString(String s) {
+		return new CppConst<>(s);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        boolean isString = val instanceof String;
-        if (isString) {
-            out.print("\"");
-        }
-        out.print(val);
-        if (isString) {
-            out.print("\"");
-        }
-    }
+	@Override
+	public void print(PrintWriter out) {
+		boolean isString = val instanceof String;
+		if (isString) {
+			out.print("\"");
+		}
+		out.print(val);
+		if (isString) {
+			out.print("\"");
+		}
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppCtor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppCtor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
@@ -29,46 +28,46 @@ import java.util.List;
 
 public class CppCtor implements CppStmt {
 
-    private final String type;
-    private final String var;
-    private final List<CppExpr> args;
-    private final boolean initializer;
+	private final String type;
+	private final String var;
+	private final List<CppExpr> args;
+	private final boolean initializer;
 
-    private CppCtor(String type, String var, List<CppExpr> args, boolean initializer) {
-        this.type = type;
-        this.var = var;
-        this.args = args;
-        this.initializer = initializer;
-    }
+	private CppCtor(String type, String var, List<CppExpr> args, boolean initializer) {
+		this.type = type;
+		this.var = var;
+		this.args = args;
+		this.initializer = initializer;
+	}
 
-    public static CppCtor mk(String type, String var, List<CppExpr> args) {
-        return new CppCtor(type, var, args, false);
-    }
+	public static CppCtor mk(String type, String var, List<CppExpr> args) {
+		return new CppCtor(type, var, args, false);
+	}
 
-    public static CppCtor mk(String type, String var, CppExpr... args) {
-        return new CppCtor(type, var, Arrays.asList(args), false);
-    }
+	public static CppCtor mk(String type, String var, CppExpr... args) {
+		return new CppCtor(type, var, Arrays.asList(args), false);
+	}
 
-    public static CppCtor mkInitializer(String type, String var, List<CppExpr> args) {
-        return new CppCtor(type, var, args, true);
-    }
+	public static CppCtor mkInitializer(String type, String var, List<CppExpr> args) {
+		return new CppCtor(type, var, args, true);
+	}
 
-    public static CppCtor mkInitializer(String type, String var, CppExpr... args) {
-        return new CppCtor(type, var, Arrays.asList(args), true);
-    }
+	public static CppCtor mkInitializer(String type, String var, CppExpr... args) {
+		return new CppCtor(type, var, Arrays.asList(args), true);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.print(type);
-        out.print(" ");
-        out.print(var);
-        if (!args.isEmpty()) {
-            out.print(initializer ? "{" : "(");
-            CodeGenUtil.printSeparated(args, ", ", out);
-            out.print(initializer ? "}" : ")");
-        }
-        out.println(";");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.print(type);
+		out.print(" ");
+		out.print(var);
+		if (!args.isEmpty()) {
+			out.print(initializer ? "{" : "(");
+			CodeGenUtil.printSeparated(args, ", ", out);
+			out.print(initializer ? "}" : ")");
+		}
+		out.println(";");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppDecl.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppDecl.java
@@ -26,33 +26,33 @@ import java.io.PrintWriter;
 
 public class CppDecl implements CppStmt {
 
-    private final String type;
-    private final String var;
-    private final CppExpr val;
+	private final String type;
+	private final String var;
+	private final CppExpr val;
 
-    private CppDecl(String type, String var, CppExpr val) {
-        this.type = type;
-        this.var = var;
-        this.val = val;
-    }
+	private CppDecl(String type, String var, CppExpr val) {
+		this.type = type;
+		this.var = var;
+		this.val = val;
+	}
 
-    public static CppDecl mk(String var, CppExpr val) {
-        return new CppDecl("auto", var, val);
-    }
+	public static CppDecl mk(String var, CppExpr val) {
+		return new CppDecl("auto", var, val);
+	}
 
-    public static CppDecl mkRef(String var, CppExpr val) {
-        return new CppDecl("auto&", var, val);
-    }
+	public static CppDecl mkRef(String var, CppExpr val) {
+		return new CppDecl("auto&", var, val);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.print(type);
-        out.print(" ");
-        out.print(var);
-        out.print(" = ");
-        val.print(out);
-        out.println(";");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.print(type);
+		out.print(" ");
+		out.print(var);
+		out.print(" = ");
+		val.print(out);
+		out.println(";");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppExpr.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppExpr.java
@@ -20,26 +20,25 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public interface CppExpr {
 
-    void print(PrintWriter out);
+	void print(PrintWriter out);
 
-    default CppStmt toStmt() {
-        return new CppStmt() {
+	default CppStmt toStmt() {
+		return new CppStmt() {
 
-            @Override
-            public void println(PrintWriter out, int indent) {
-                CodeGenUtil.printIndent(out, indent);
-                CppExpr.this.print(out);
-                out.println(";");
-            }
+			@Override
+			public void println(PrintWriter out, int indent) {
+				CodeGenUtil.printIndent(out, indent);
+				CppExpr.this.print(out);
+				out.println(";");
+			}
 
-        };
-    }
+		};
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppExprFromString.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppExprFromString.java
@@ -20,24 +20,23 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppExprFromString implements CppExpr {
 
-    private final String s;
+	private final String s;
 
-    private CppExprFromString(String s) {
-        this.s = s;
-    }
+	private CppExprFromString(String s) {
+		this.s = s;
+	}
 
-    public static CppExprFromString mk(String s) {
-        return new CppExprFromString(s);
-    }
+	public static CppExprFromString mk(String s) {
+		return new CppExprFromString(s);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print(s);
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print(s);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppFor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppFor.java
@@ -20,53 +20,52 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppFor implements CppStmt {
 
-    private final String var;
-    private final CppExpr init;
-    private final CppExpr guard;
-    private final CppExpr update;
-    private final CppStmt body;
-    private final boolean parallel;
+	private final String var;
+	private final CppExpr init;
+	private final CppExpr guard;
+	private final CppExpr update;
+	private final CppStmt body;
+	private final boolean parallel;
 
-    private CppFor(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body, boolean parallel) {
-        this.var = var;
-        this.init = init;
-        this.guard = guard;
-        this.update = update;
-        this.body = body;
-        this.parallel = parallel;
-    }
+	private CppFor(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body, boolean parallel) {
+		this.var = var;
+		this.init = init;
+		this.guard = guard;
+		this.update = update;
+		this.body = body;
+		this.parallel = parallel;
+	}
 
-    public static CppFor mk(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body) {
-        return new CppFor(var, init, guard, update, body, false);
-    }
+	public static CppFor mk(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body) {
+		return new CppFor(var, init, guard, update, body, false);
+	}
 
-    public static CppFor mkParallel(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body) {
-        return new CppFor(var, init, guard, update, body, true);
-    }
+	public static CppFor mkParallel(String var, CppExpr init, CppExpr guard, CppExpr update, CppStmt body) {
+		return new CppFor(var, init, guard, update, body, true);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.print(parallel ? "pfor" : "for");
-        out.print(" (auto ");
-        out.print(var);
-        out.print(" = ");
-        init.print(out);
-        out.print("; ");
-        guard.print(out);
-        out.print("; ");
-        update.print(out);
-        out.println(") {");
-        body.println(out, indent + 1);
-        CodeGenUtil.printIndent(out, indent);
-        out.println("}");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.print(parallel ? "pfor" : "for");
+		out.print(" (auto ");
+		out.print(var);
+		out.print(" = ");
+		init.print(out);
+		out.print("; ");
+		guard.print(out);
+		out.print("; ");
+		update.print(out);
+		out.println(") {");
+		body.println(out, indent + 1);
+		CodeGenUtil.printIndent(out, indent);
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppForEach.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppForEach.java
@@ -20,38 +20,37 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppForEach implements CppStmt {
 
-    private final String var;
-    private final CppExpr val;
-    private final CppStmt body;
+	private final String var;
+	private final CppExpr val;
+	private final CppStmt body;
 
-    private CppForEach(String var, CppExpr val, CppStmt body) {
-        this.var = var;
-        this.val = val;
-        this.body = body;
-    }
+	private CppForEach(String var, CppExpr val, CppStmt body) {
+		this.var = var;
+		this.val = val;
+		this.body = body;
+	}
 
-    public static CppForEach mk(String var, CppExpr val, CppStmt body) {
-        return new CppForEach(var, val, body);
-    }
+	public static CppForEach mk(String var, CppExpr val, CppStmt body) {
+		return new CppForEach(var, val, body);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.print("for (const auto& ");
-        out.print(var);
-        out.print(" : ");
-        val.print(out);
-        out.println(") {");
-        body.println(out, indent + 1);
-        CodeGenUtil.printIndent(out, indent);
-        out.println("}");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.print("for (const auto& ");
+		out.print(var);
+		out.print(" : ");
+		val.print(out);
+		out.println(") {");
+		body.println(out, indent + 1);
+		CodeGenUtil.printIndent(out, indent);
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppFuncCall.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppFuncCall.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
@@ -29,28 +28,28 @@ import java.util.List;
 
 public class CppFuncCall implements CppExpr {
 
-    private final String func;
-    private final List<CppExpr> args;
+	private final String func;
+	private final List<CppExpr> args;
 
-    private CppFuncCall(String func, List<CppExpr> args) {
-        this.func = func;
-        this.args = args;
-    }
+	private CppFuncCall(String func, List<CppExpr> args) {
+		this.func = func;
+		this.args = args;
+	}
 
-    public static CppFuncCall mk(String func, List<CppExpr> args) {
-        return new CppFuncCall(func, args);
-    }
+	public static CppFuncCall mk(String func, List<CppExpr> args) {
+		return new CppFuncCall(func, args);
+	}
 
-    public static CppFuncCall mk(String func, CppExpr... args) {
-        return mk(func, Arrays.asList(args));
-    }
+	public static CppFuncCall mk(String func, CppExpr... args) {
+		return mk(func, Arrays.asList(args));
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print(func);
-        out.print("(");
-        CodeGenUtil.printSeparated(args, ", ", out);
-        out.print(")");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print(func);
+		out.print("(");
+		CodeGenUtil.printSeparated(args, ", ", out);
+		out.print(")");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppGoto.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppGoto.java
@@ -20,27 +20,26 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppGoto implements CppStmt {
 
-    private final String label;
+	private final String label;
 
-    private CppGoto(String label) {
-        this.label = label;
-    }
+	private CppGoto(String label) {
+		this.label = label;
+	}
 
-    public static CppGoto mk(String label) {
-        return new CppGoto(label);
-    }
+	public static CppGoto mk(String label) {
+		return new CppGoto(label);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.println("goto " + label + ";");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.println("goto " + label + ";");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppIf.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppIf.java
@@ -30,54 +30,54 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class CppIf implements CppStmt {
 
-    private final List<Pair<CppExpr, CppStmt>> cases;
-    private final CppStmt elseBranch;
+	private final List<Pair<CppExpr, CppStmt>> cases;
+	private final CppStmt elseBranch;
 
-    private CppIf(List<Pair<CppExpr, CppStmt>> cases, CppStmt elseBranch) {
-        if (cases.isEmpty()) {
-            throw new IllegalArgumentException("Need to have at least one case in an if statement");
-        }
-        this.cases = cases;
-        this.elseBranch = elseBranch;
-    }
+	private CppIf(List<Pair<CppExpr, CppStmt>> cases, CppStmt elseBranch) {
+		if (cases.isEmpty()) {
+			throw new IllegalArgumentException("Need to have at least one case in an if statement");
+		}
+		this.cases = cases;
+		this.elseBranch = elseBranch;
+	}
 
-    public static CppIf mk(CppExpr guard, CppStmt thenBranch) {
-        return mk(guard, thenBranch, null);
-    }
+	public static CppIf mk(CppExpr guard, CppStmt thenBranch) {
+		return mk(guard, thenBranch, null);
+	}
 
-    public static CppIf mk(CppExpr guard, CppStmt thenBranch, CppStmt elseBranch) {
-        return new CppIf(Collections.singletonList(new Pair<>(guard, thenBranch)), elseBranch);
-    }
+	public static CppIf mk(CppExpr guard, CppStmt thenBranch, CppStmt elseBranch) {
+		return new CppIf(Collections.singletonList(new Pair<>(guard, thenBranch)), elseBranch);
+	}
 
-    public static CppIf mk(List<Pair<CppExpr, CppStmt>> cases) {
-        return new CppIf(new ArrayList<>(cases), null);
-    }
+	public static CppIf mk(List<Pair<CppExpr, CppStmt>> cases) {
+		return new CppIf(new ArrayList<>(cases), null);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        boolean first = true;
-        for (Pair<CppExpr, CppStmt> p : cases) {
-            CppExpr guard = p.fst();
-            CppStmt code = p.snd();
-            CodeGenUtil.printIndent(out, indent);
-            if (!first) {
-                out.print("} else ");
-            }
-            out.print("if (");
-            guard.print(out);
-            out.println(") {");
-            code.println(out, indent + 1);
-            first = false;
-        }
-        CodeGenUtil.printIndent(out, indent);
-        if (elseBranch == null) {
-            out.println("}");
-            return;
-        }
-        out.println("} else {");
-        elseBranch.println(out, indent + 1);
-        CodeGenUtil.printIndent(out, indent);
-        out.println("}");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		boolean first = true;
+		for (Pair<CppExpr, CppStmt> p : cases) {
+			CppExpr guard = p.fst();
+			CppStmt code = p.snd();
+			CodeGenUtil.printIndent(out, indent);
+			if (!first) {
+				out.print("} else ");
+			}
+			out.print("if (");
+			guard.print(out);
+			out.println(") {");
+			code.println(out, indent + 1);
+			first = false;
+		}
+		CodeGenUtil.printIndent(out, indent);
+		if (elseBranch == null) {
+			out.println("}");
+			return;
+		}
+		out.println("} else {");
+		elseBranch.println(out, indent + 1);
+		CodeGenUtil.printIndent(out, indent);
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppLabel.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppLabel.java
@@ -20,27 +20,26 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppLabel implements CppStmt {
 
-    private final String label;
+	private final String label;
 
-    public CppLabel(String label) {
-        this.label = label;
-    }
+	public CppLabel(String label) {
+		this.label = label;
+	}
 
-    public static CppLabel mk(String label) {
-        return new CppLabel(label);
-    }
+	public static CppLabel mk(String label) {
+		return new CppLabel(label);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.println(label + ":");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.println(label + ":");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppMethodCall.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppMethodCall.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
@@ -29,42 +28,42 @@ import java.util.List;
 
 public class CppMethodCall implements CppExpr {
 
-    private final String func;
-    private final CppExpr rec;
-    private final List<CppExpr> args;
-    private final boolean thruPtr;
+	private final String func;
+	private final CppExpr rec;
+	private final List<CppExpr> args;
+	private final boolean thruPtr;
 
-    private CppMethodCall(CppExpr rec, String func, List<CppExpr> args, boolean thruPtr) {
-        this.func = func;
-        this.rec = rec;
-        this.args = args;
-        this.thruPtr = thruPtr;
-    }
+	private CppMethodCall(CppExpr rec, String func, List<CppExpr> args, boolean thruPtr) {
+		this.func = func;
+		this.rec = rec;
+		this.args = args;
+		this.thruPtr = thruPtr;
+	}
 
-    public static CppMethodCall mk(CppExpr rec, String func, List<CppExpr> args) {
-        return new CppMethodCall(rec, func, args, false);
-    }
+	public static CppMethodCall mk(CppExpr rec, String func, List<CppExpr> args) {
+		return new CppMethodCall(rec, func, args, false);
+	}
 
-    public static CppMethodCall mk(CppExpr rec, String func, CppExpr... args) {
-        return new CppMethodCall(rec, func, Arrays.asList(args), false);
-    }
+	public static CppMethodCall mk(CppExpr rec, String func, CppExpr... args) {
+		return new CppMethodCall(rec, func, Arrays.asList(args), false);
+	}
 
-    public static CppMethodCall mkThruPtr(CppExpr rec, String func, List<CppExpr> args) {
-        return new CppMethodCall(rec, func, args, true);
-    }
+	public static CppMethodCall mkThruPtr(CppExpr rec, String func, List<CppExpr> args) {
+		return new CppMethodCall(rec, func, args, true);
+	}
 
-    public static CppMethodCall mkThruPtr(CppExpr rec, String func, CppExpr... args) {
-        return new CppMethodCall(rec, func, Arrays.asList(args), true);
-    }
+	public static CppMethodCall mkThruPtr(CppExpr rec, String func, CppExpr... args) {
+		return new CppMethodCall(rec, func, Arrays.asList(args), true);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        rec.print(out);
-        out.print(thruPtr ? "->" : ".");
-        out.print(func);
-        out.print("(");
-        CodeGenUtil.printSeparated(args, ", ", out);
-        out.print(")");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		rec.print(out);
+		out.print(thruPtr ? "->" : ".");
+		out.print(func);
+		out.print("(");
+		CodeGenUtil.printSeparated(args, ", ", out);
+		out.print(")");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppNewArray.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppNewArray.java
@@ -20,30 +20,29 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppNewArray implements CppExpr {
 
-    private final String type;
-    private final CppExpr size;
+	private final String type;
+	private final CppExpr size;
 
-    private CppNewArray(String type, CppExpr size) {
-        this.type = type;
-        this.size = size;
-    }
+	private CppNewArray(String type, CppExpr size) {
+		this.type = type;
+		this.size = size;
+	}
 
-    public static CppNewArray mk(String type, CppExpr size) {
-        return new CppNewArray(type, size);
-    }
+	public static CppNewArray mk(String type, CppExpr size) {
+		return new CppNewArray(type, size);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print("new ");
-        out.print(type);
-        out.print("[");
-        size.print(out);
-        out.print("]");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print("new ");
+		out.print(type);
+		out.print("[");
+		size.print(out);
+		out.print("]");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppNullptr.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppNullptr.java
@@ -24,11 +24,11 @@ import java.io.PrintWriter;
 
 public enum CppNullptr implements CppExpr {
 
-    INSTANCE;
+	INSTANCE;
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print("nullptr");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print("nullptr");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppReturn.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppReturn.java
@@ -20,37 +20,36 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppReturn implements CppStmt {
 
-    private final CppExpr val;
+	private final CppExpr val;
 
-    private CppReturn(CppExpr val) {
-        this.val = val;
-    }
+	private CppReturn(CppExpr val) {
+		this.val = val;
+	}
 
-    public static CppReturn mk(CppExpr val) {
-        return new CppReturn(val);
-    }
+	public static CppReturn mk(CppExpr val) {
+		return new CppReturn(val);
+	}
 
-    public static CppReturn mk() {
-        return new CppReturn(null);
-    }
+	public static CppReturn mk() {
+		return new CppReturn(null);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        if (val == null) {
-            out.println("return;");
-            return;
-        }
-        out.print("return ");
-        val.print(out);
-        out.println(";");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		if (val == null) {
+			out.println("return;");
+			return;
+		}
+		out.print("return ");
+		val.print(out);
+		out.println(";");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppSeq.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppSeq.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
@@ -30,32 +29,32 @@ import java.util.List;
 
 public class CppSeq implements CppStmt {
 
-    private final List<CppStmt> stmts;
+	private final List<CppStmt> stmts;
 
-    private CppSeq(List<CppStmt> stmts) {
-        this.stmts = stmts;
-    }
+	private CppSeq(List<CppStmt> stmts) {
+		this.stmts = stmts;
+	}
 
-    public static CppSeq mk(List<CppStmt> stmts) {
-        if (stmts.isEmpty()) {
-            return skip;
-        }
-        return new CppSeq(stmts);
-    }
+	public static CppSeq mk(List<CppStmt> stmts) {
+		if (stmts.isEmpty()) {
+			return skip;
+		}
+		return new CppSeq(stmts);
+	}
 
-    public static CppSeq mk(CppStmt... stmts) {
-        return mk(Arrays.asList(stmts));
-    }
+	public static CppSeq mk(CppStmt... stmts) {
+		return mk(Arrays.asList(stmts));
+	}
 
-    public static CppSeq skip() {
-        return skip;
-    }
+	public static CppSeq skip() {
+		return skip;
+	}
 
-    private static final CppSeq skip = new CppSeq(Collections.emptyList());
+	private static final CppSeq skip = new CppSeq(Collections.emptyList());
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.print(stmts, out, indent);
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.print(stmts, out, indent);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppStmt.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppStmt.java
@@ -27,6 +27,6 @@ import java.io.PrintWriter;
  */
 public interface CppStmt {
 
-    void println(PrintWriter out, int indent);
+	void println(PrintWriter out, int indent);
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppSubscript.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppSubscript.java
@@ -20,29 +20,28 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppSubscript implements CppExpr {
 
-    private final CppExpr val;
-    private final CppExpr idx;
+	private final CppExpr val;
+	private final CppExpr idx;
 
-    private CppSubscript(CppExpr val, CppExpr idx) {
-        this.val = val;
-        this.idx = idx;
-    }
+	private CppSubscript(CppExpr val, CppExpr idx) {
+		this.val = val;
+		this.idx = idx;
+	}
 
-    public static CppSubscript mk(CppExpr val, CppExpr idx) {
-        return new CppSubscript(val, idx);
-    }
+	public static CppSubscript mk(CppExpr val, CppExpr idx) {
+		return new CppSubscript(val, idx);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        val.print(out);
-        out.print("[");
-        idx.print(out);
-        out.print("]");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		val.print(out);
+		out.print("[");
+		idx.print(out);
+		out.print("]");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppUnop.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppUnop.java
@@ -20,41 +20,40 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import java.io.PrintWriter;
 
 public class CppUnop implements CppExpr {
 
-    private final String op;
-    private final CppExpr expr;
+	private final String op;
+	private final CppExpr expr;
 
-    private CppUnop(String op, CppExpr expr) {
-        this.op = op;
-        this.expr = expr;
-    }
+	private CppUnop(String op, CppExpr expr) {
+		this.op = op;
+		this.expr = expr;
+	}
 
-    private static CppUnop mk(String op, CppExpr expr) {
-        return new CppUnop(op, expr);
-    }
+	private static CppUnop mk(String op, CppExpr expr) {
+		return new CppUnop(op, expr);
+	}
 
-    public static CppUnop mkNot(CppExpr expr) {
-        return mk("!", expr);
-    }
+	public static CppUnop mkNot(CppExpr expr) {
+		return mk("!", expr);
+	}
 
-    public static CppUnop mkPreIncr(CppExpr expr) {
-        return mk("++", expr);
-    }
+	public static CppUnop mkPreIncr(CppExpr expr) {
+		return mk("++", expr);
+	}
 
-    public static CppUnop mkDeref(CppExpr expr) {
-        return mk("*", expr);
-    }
+	public static CppUnop mkDeref(CppExpr expr) {
+		return mk("*", expr);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print("(");
-        out.print(op);
-        expr.print(out);
-        out.print(")");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print("(");
+		out.print(op);
+		expr.print(out);
+		out.print(")");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppVar.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppVar.java
@@ -24,24 +24,24 @@ import java.io.PrintWriter;
 
 public class CppVar implements CppExpr {
 
-    private final String var;
+	private final String var;
 
-    private CppVar(String var) {
-        this.var = var;
-    }
+	private CppVar(String var) {
+		this.var = var;
+	}
 
-    public static CppVar mk(String var) {
-        return new CppVar(var);
-    }
+	public static CppVar mk(String var) {
+		return new CppVar(var);
+	}
 
-    @Override
-    public String toString() {
-        return var;
-    }
+	@Override
+	public String toString() {
+		return var;
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print(var);
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print(var);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppVectorLiteral.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppVectorLiteral.java
@@ -25,26 +25,26 @@ import java.util.List;
 
 public class CppVectorLiteral implements CppExpr {
 
-    private final List<CppExpr> elts;
+	private final List<CppExpr> elts;
 
-    private CppVectorLiteral(List<CppExpr> elts) {
-        this.elts = elts;
-    }
+	private CppVectorLiteral(List<CppExpr> elts) {
+		this.elts = elts;
+	}
 
-    public static CppVectorLiteral mk(List<CppExpr> elts) {
-        return new CppVectorLiteral(elts);
-    }
+	public static CppVectorLiteral mk(List<CppExpr> elts) {
+		return new CppVectorLiteral(elts);
+	}
 
-    @Override
-    public void print(PrintWriter out) {
-        out.print("{");
-        for (int i = 0; i < elts.size(); ++i) {
-            elts.get(i).print(out);
-            if (i < elts.size() - 1) {
-                out.print(", ");
-            }
-        }
-        out.print("}");
-    }
+	@Override
+	public void print(PrintWriter out) {
+		out.print("{");
+		for (int i = 0; i < elts.size(); ++i) {
+			elts.get(i).print(out);
+			if (i < elts.size() - 1) {
+				out.print(", ");
+			}
+		}
+		out.print("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppWhile.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/cpp/CppWhile.java
@@ -20,34 +20,33 @@ package edu.harvard.seas.pl.formulog.codegen.ast.cpp;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.codegen.CodeGenUtil;
 
 import java.io.PrintWriter;
 
 public class CppWhile implements CppStmt {
 
-    private final CppExpr guard;
-    private final CppStmt body;
+	private final CppExpr guard;
+	private final CppStmt body;
 
-    private CppWhile(CppExpr guard, CppStmt body) {
-        this.guard = guard;
-        this.body = body;
-    }
+	private CppWhile(CppExpr guard, CppStmt body) {
+		this.guard = guard;
+		this.body = body;
+	}
 
-    public static CppWhile mk(CppExpr guard, CppStmt body) {
-        return new CppWhile(guard, body);
-    }
+	public static CppWhile mk(CppExpr guard, CppStmt body) {
+		return new CppWhile(guard, body);
+	}
 
-    @Override
-    public void println(PrintWriter out, int indent) {
-        CodeGenUtil.printIndent(out, indent);
-        out.print("while (");
-        guard.print(out);
-        out.println(") {");
-        body.println(out, indent + 1);
-        CodeGenUtil.printIndent(out, indent);
-        out.println("}");
-    }
+	@Override
+	public void println(PrintWriter out, int indent) {
+		CodeGenUtil.printIndent(out, indent);
+		out.print("while (");
+		guard.print(out);
+		out.println(") {");
+		body.println(out, indent + 1);
+		CodeGenUtil.printIndent(out, indent);
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
@@ -24,36 +24,36 @@ import java.util.List;
 
 public class SAtom implements SLit {
 
-    private final String pred;
-    private final List<STerm> args;
-    private final boolean isNegated;
+	private final String pred;
+	private final List<STerm> args;
+	private final boolean isNegated;
 
-    public SAtom(String symbol, List<STerm> args, boolean isNegated) {
-        pred = symbol;
-        this.args = args;
-        this.isNegated = isNegated;
-    }
+	public SAtom(String symbol, List<STerm> args, boolean isNegated) {
+		pred = symbol;
+		this.args = args;
+		this.isNegated = isNegated;
+	}
 
-    public String getSymbol() {
-        return pred;
-    }
+	public String getSymbol() {
+		return pred;
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        if (isNegated) {
-            sb.append("!");
-        }
-        sb.append(pred);
-        sb.append("(");
-        for (int i = 0; i < args.size(); ++i) {
-            sb.append(args.get(i));
-            if (i < args.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append(")");
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		if (isNegated) {
+			sb.append("!");
+		}
+		sb.append(pred);
+		sb.append("(");
+		for (int i = 0; i < args.size(); ++i) {
+			sb.append(args.get(i));
+			if (i < args.size() - 1) {
+				sb.append(", ");
+			}
+		}
+		sb.append(")");
+		return sb.toString();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SDestructorBody.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SDestructorBody.java
@@ -28,37 +28,37 @@ import java.util.List;
 
 public class SDestructorBody implements SFunctorBody {
 
-    private final List<Var> args;
-    private final Term scrutinee;
-    private final ConstructorSymbol symbol;
+	private final List<Var> args;
+	private final Term scrutinee;
+	private final ConstructorSymbol symbol;
 
-    public SDestructorBody(List<Var> args_, Term scrutinee_, ConstructorSymbol symbol_) {
-        args = args_;
-        scrutinee = scrutinee_;
-        symbol = symbol_;
-    }
+	public SDestructorBody(List<Var> args_, Term scrutinee_, ConstructorSymbol symbol_) {
+		args = args_;
+		scrutinee = scrutinee_;
+		symbol = symbol_;
+	}
 
-    @Override
-    public List<Var> getArgs() {
-        return args;
-    }
+	@Override
+	public List<Var> getArgs() {
+		return args;
+	}
 
-    @Override
-    public SType getRetType() {
-        return SIntType.INSTANCE;
-    }
+	@Override
+	public SType getRetType() {
+		return SIntType.INSTANCE;
+	}
 
-    @Override
-    public boolean isStateful() {
-        return false;
-    }
+	@Override
+	public boolean isStateful() {
+		return false;
+	}
 
-    public Term getScrutinee() {
-        return scrutinee;
-    }
+	public Term getScrutinee() {
+		return scrutinee;
+	}
 
-    public ConstructorSymbol getSymbol() {
-        return symbol;
-    }
+	public ConstructorSymbol getSymbol() {
+		return symbol;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SExprBody.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SExprBody.java
@@ -27,31 +27,31 @@ import java.util.List;
 
 public class SExprBody implements SFunctorBody {
 
-    private final List<Var> args;
-    private final Term body;
+	private final List<Var> args;
+	private final Term body;
 
-    public SExprBody(List<Var> args_, Term body_) {
-        args = args_;
-        body = body_;
-    }
+	public SExprBody(List<Var> args_, Term body_) {
+		args = args_;
+		body = body_;
+	}
 
-    public Term getBody() {
-        return body;
-    }
+	public Term getBody() {
+		return body;
+	}
 
-    @Override
-    public List<Var> getArgs() {
-        return args;
-    }
+	@Override
+	public List<Var> getArgs() {
+		return args;
+	}
 
-    @Override
-    public SType getRetType() {
-        return SIntType.INSTANCE;
-    }
+	@Override
+	public SType getRetType() {
+		return SIntType.INSTANCE;
+	}
 
-    @Override
-    public boolean isStateful() {
-        return false;
-    }
+	@Override
+	public boolean isStateful() {
+		return false;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorBody.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorBody.java
@@ -26,14 +26,14 @@ import java.util.List;
 
 public interface SFunctorBody {
 
-    default int getArity() {
-        return getArgs().size();
-    }
+	default int getArity() {
+		return getArgs().size();
+	}
 
-    List<Var> getArgs();
+	List<Var> getArgs();
 
-    SType getRetType();
+	SType getRetType();
 
-    boolean isStateful();
+	boolean isStateful();
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorCall.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorCall.java
@@ -25,32 +25,32 @@ import java.util.List;
 
 public class SFunctorCall implements STerm {
 
-    private final String func;
-    private final List<STerm> args;
+	private final String func;
+	private final List<STerm> args;
 
-    public SFunctorCall(String func, List<STerm> args) {
-        this.func = func;
-        this.args = args;
-    }
+	public SFunctorCall(String func, List<STerm> args) {
+		this.func = func;
+		this.args = args;
+	}
 
-    public SFunctorCall(String func, STerm... args) {
-        this(func, Arrays.asList(args));
-    }
+	public SFunctorCall(String func, STerm... args) {
+		this(func, Arrays.asList(args));
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("@");
-        sb.append(func);
-        sb.append("(");
-        for (int i = 0; i < args.size(); ++i) {
-            sb.append(args.get(i));
-            if (i < args.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append(")");
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("@");
+		sb.append(func);
+		sb.append("(");
+		for (int i = 0; i < args.size(); ++i) {
+			sb.append(args.get(i));
+			if (i < args.size() - 1) {
+				sb.append(", ");
+			}
+		}
+		sb.append(")");
+		return sb.toString();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInfixBinaryOpAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInfixBinaryOpAtom.java
@@ -22,19 +22,19 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
 public class SInfixBinaryOpAtom implements SLit {
 
-    private final STerm lhs;
-    private final String op;
-    private final STerm rhs;
+	private final STerm lhs;
+	private final String op;
+	private final STerm rhs;
 
-    public SInfixBinaryOpAtom(STerm lhs_, String op_, STerm rhs_) {
-        lhs = lhs_;
-        op = op_;
-        rhs = rhs_;
-    }
+	public SInfixBinaryOpAtom(STerm lhs_, String op_, STerm rhs_) {
+		lhs = lhs_;
+		op = op_;
+		rhs = rhs_;
+	}
 
-    @Override
-    public String toString() {
-        return lhs + " " + op + " " + rhs;
-    }
+	@Override
+	public String toString() {
+		return lhs + " " + op + " " + rhs;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInt.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInt.java
@@ -22,15 +22,15 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
 public class SInt implements STerm {
 
-    private final int val;
+	private final int val;
 
-    public SInt(int val_) {
-        val = val_;
-    }
+	public SInt(int val_) {
+		val = val_;
+	}
 
-    @Override
-    public String toString() {
-        return Integer.toString(val);
-    }
+	@Override
+	public String toString() {
+		return Integer.toString(val);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntList.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntList.java
@@ -24,24 +24,24 @@ import java.util.List;
 
 public class SIntList implements STerm {
 
-    private final List<STerm> ts;
+	private final List<STerm> ts;
 
-    public SIntList(List<STerm> ts_) {
-        ts = ts_;
-    }
+	public SIntList(List<STerm> ts_) {
+		ts = ts_;
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        for (int i = 0; i < ts.size(); ++i) {
-            sb.append(ts.get(i));
-            if (i < ts.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append("]");
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("[");
+		for (int i = 0; i < ts.size(); ++i) {
+			sb.append(ts.get(i));
+			if (i < ts.size() - 1) {
+				sb.append(", ");
+			}
+		}
+		sb.append("]");
+		return sb.toString();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntListType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntListType.java
@@ -24,47 +24,49 @@ import java.util.Objects;
 
 public class SIntListType implements SType {
 
-    private final int arity;
+	private final int arity;
 
-    public SIntListType(int arity) {
-        this.arity = arity;
-    }
+	public SIntListType(int arity) {
+		this.arity = arity;
+	}
 
-    public String getName() {
-        return "IntList" + arity;
-    }
+	public String getName() {
+		return "IntList" + arity;
+	}
 
-    public String getDef() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        for (int i = 0; i < arity; ++i) {
-            sb.append("x");
-            sb.append(i);
-            sb.append(":number");
-            if (i < arity - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append("]");
-        return sb.toString();
-    }
+	public String getDef() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("[");
+		for (int i = 0; i < arity; ++i) {
+			sb.append("x");
+			sb.append(i);
+			sb.append(":number");
+			if (i < arity - 1) {
+				sb.append(", ");
+			}
+		}
+		sb.append("]");
+		return sb.toString();
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SIntListType that = (SIntListType) o;
-        return arity == that.arity;
-    }
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SIntListType that = (SIntListType) o;
+		return arity == that.arity;
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(arity);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(arity);
+	}
 
-    @Override
-    public String toString() {
-        return getName();
-    }
+	@Override
+	public String toString() {
+		return getName();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntType.java
@@ -21,11 +21,11 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 public enum SIntType implements SType {
-    INSTANCE;
+	INSTANCE;
 
-    @Override
-    public String toString() {
-        return "number";
-    }
+	@Override
+	public String toString() {
+		return "number";
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRule.java
@@ -28,68 +28,68 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class SRule {
 
-    private final SLit head;
-    private final List<SLit> body;
-    private List<Pair<Integer, int[]>> queryPlan;
+	private final SLit head;
+	private final List<SLit> body;
+	private List<Pair<Integer, int[]>> queryPlan;
 
-    public SRule(SLit head, List<SLit> body) {
-        this.head = head;
-        this.body = body;
-    }
+	public SRule(SLit head, List<SLit> body) {
+		this.head = head;
+		this.body = body;
+	}
 
-    public SRule(SLit head, SLit... body) {
-        this(head, Arrays.asList(body));
-    }
+	public SRule(SLit head, SLit... body) {
+		this(head, Arrays.asList(body));
+	}
 
-    public List<SLit> getBody() {
-        return Collections.unmodifiableList(body);
-    }
+	public List<SLit> getBody() {
+		return Collections.unmodifiableList(body);
+	}
 
-    public void setQueryPlan(List<Pair<Integer, int[]>> queryPlan) {
-        this.queryPlan = queryPlan;
-    }
+	public void setQueryPlan(List<Pair<Integer, int[]>> queryPlan) {
+		this.queryPlan = queryPlan;
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(head);
-        if (!body.isEmpty()) {
-            sb.append(" :- ");
-            String sep = "";
-            if (body.size() > 1) {
-                sep = "\n\t";
-            }
-            for (int i = 0; i < body.size(); ++i) {
-                sb.append(sep);
-                sb.append(body.get(i));
-                if (i < body.size() - 1) {
-                    sb.append(", ");
-                }
-            }
-        }
-        sb.append(".");
-        if (queryPlan != null) {
-            sb.append("\n");
-            for (int i = 0; i < queryPlan.size(); ++i) {
-                if (i == 0) {
-                    sb.append(".plan ");
-                } else {
-                    sb.append(", ");
-                }
-                var p = queryPlan.get(i);
-                sb.append(p.fst());
-                sb.append(": (");
-                var plan = p.snd();
-                for (int j = 0; j < plan.length; ++j) {
-                    sb.append(plan[j]);
-                    if (j < plan.length - 1) {
-                        sb.append(",");
-                    }
-                }
-                sb.append(")");
-            }
-        }
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(head);
+		if (!body.isEmpty()) {
+			sb.append(" :- ");
+			String sep = "";
+			if (body.size() > 1) {
+				sep = "\n\t";
+			}
+			for (int i = 0; i < body.size(); ++i) {
+				sb.append(sep);
+				sb.append(body.get(i));
+				if (i < body.size() - 1) {
+					sb.append(", ");
+				}
+			}
+		}
+		sb.append(".");
+		if (queryPlan != null) {
+			sb.append("\n");
+			for (int i = 0; i < queryPlan.size(); ++i) {
+				if (i == 0) {
+					sb.append(".plan ");
+				} else {
+					sb.append(", ");
+				}
+				var p = queryPlan.get(i);
+				sb.append(p.fst());
+				sb.append(": (");
+				var plan = p.snd();
+				for (int j = 0; j < plan.length; ++j) {
+					sb.append(plan[j]);
+					if (j < plan.length - 1) {
+						sb.append(",");
+					}
+				}
+				sb.append(")");
+			}
+		}
+		return sb.toString();
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRuleMode.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SRuleMode.java
@@ -21,5 +21,5 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 public enum SRuleMode {
-    INPUT, OUTPUT, INTERMEDIATE;
+	INPUT, OUTPUT, INTERMEDIATE;
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SVar.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SVar.java
@@ -24,19 +24,19 @@ import edu.harvard.seas.pl.formulog.ast.Var;
 
 public class SVar implements STerm {
 
-    private final String name;
+	private final String name;
 
-    public SVar(Var var) {
-        String s = var.toString();
-        if (s.charAt(0) == '$') {
-            s = "x" + s.substring(1);
-        }
-        name = s;
-    }
+	public SVar(Var var) {
+		String s = var.toString();
+		if (s.charAt(0) == '$') {
+			s = "x" + s.substring(1);
+		}
+		name = s;
+	}
 
-    @Override
-    public String toString() {
-        return name;
-    }
+	@Override
+	public String toString() {
+		return name;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/BindingTypeArrayWrapper.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/BindingTypeArrayWrapper.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.db;
  * #L%
  */
 
-
 import java.util.Arrays;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/ExampleComparator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/ExampleComparator.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.db;
  * #L%
  */
 
-
 import java.util.Comparator;
 
 import edu.harvard.seas.pl.formulog.ast.Term;
@@ -36,7 +35,7 @@ public class ExampleComparator implements Comparator<Term[]> {
 		} else if (xid > yid) {
 			return 1;
 		}
-		
+
 		xid = xs[2].getId();
 		yid = ys[2].getId();
 		if (xid < yid) {
@@ -44,7 +43,7 @@ public class ExampleComparator implements Comparator<Term[]> {
 		} else if (xid > yid) {
 			return 1;
 		}
-		
+
 		xid = xs[1].getId();
 		yid = ys[1].getId();
 		if (xid < yid) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/IndexedFactDb.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/IndexedFactDb.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.db;
  * #L%
  */
 
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.Term;
@@ -29,23 +28,23 @@ import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 public interface IndexedFactDb {
 
 	Set<RelationSymbol> getSymbols();
-	
+
 	Iterable<Term[]> getAll(RelationSymbol sym);
-	
+
 	boolean isEmpty(RelationSymbol sym);
-	
+
 	int countDistinct(RelationSymbol sym);
-	
+
 	int numIndices(RelationSymbol sym);
-	
+
 	int countDuplicates(RelationSymbol sym);
-	
+
 	Iterable<Term[]> get(RelationSymbol sym, Term[] key, int index);
-	
+
 	boolean add(RelationSymbol sym, Term[] args);
-	
+
 	boolean addAll(RelationSymbol sym, Iterable<Term[]> tups);
-	
+
 	boolean hasFact(RelationSymbol sym, Term[] args);
 
 	void clear();

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/IndexedFactDbBuilder.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/IndexedFactDbBuilder.java
@@ -22,13 +22,12 @@ package edu.harvard.seas.pl.formulog.db;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;
 
-
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 
 public interface IndexedFactDbBuilder<T extends IndexedFactDb> {
 
 	int makeIndex(RelationSymbol sym, BindingType[] pat);
-	
+
 	T build();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/MinChainCover.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/MinChainCover.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.db;
 
 import java.util.ArrayList;
 
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -62,7 +61,7 @@ public class MinChainCover<T> {
 			}
 
 		};
-		
+
 		private final Node sink = new Node() {
 
 			@Override
@@ -71,7 +70,7 @@ public class MinChainCover<T> {
 			}
 
 		};
-		
+
 		@SuppressWarnings("unchecked")
 		public Worker(Set<T> s) {
 			int n = s.size();

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/MinIndex.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/MinIndex.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.db;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,10 +34,10 @@ public final class MinIndex {
 	private MinIndex() {
 		throw new AssertionError("impossible");
 	}
-	
+
 	public static <T> Map<Set<T>, Iterable<T>> compute(Set<T> domain, Set<Set<T>> searches) {
 		MinChainCover<Set<T>> mcc = new MinChainCover<>((x, y) -> y.containsAll(x));
-		Iterable<Iterable<Set<T>>> chains = mcc.compute(searches); 
+		Iterable<Iterable<Set<T>>> chains = mcc.compute(searches);
 		Map<Set<T>, Iterable<T>> idxs = new HashMap<>();
 		for (Iterable<Set<T>> chain : chains) {
 			List<T> idx = computeIndex(chain);
@@ -50,7 +49,7 @@ public final class MinIndex {
 		}
 		return idxs;
 	}
-	
+
 	private static <T> void padIndex(List<T> idx, Set<T> domain) {
 		Set<T> seen = new HashSet<>(idx);
 		for (T elt : domain) {
@@ -73,7 +72,7 @@ public final class MinIndex {
 		}
 		return index;
 	}
-	
+
 	public static void main(String[] args) {
 		Set<String> s1 = new HashSet<>(Arrays.asList("x"));
 		Set<String> s2 = new HashSet<>(Arrays.asList("x", "y"));

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/SortedIndexedFactDb.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/SortedIndexedFactDb.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,560 +48,560 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 public class SortedIndexedFactDb implements IndexedFactDb {
 
-    private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices;
-    private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex;
-
-    private SortedIndexedFactDb(Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices,
-                                Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex) {
-        this.indices = indices;
-        this.masterIndex = masterIndex;
-    }
-
-    @Override
-    public Set<RelationSymbol> getSymbols() {
-        return Collections.unmodifiableSet(masterIndex.keySet());
-    }
-
-    @Override
-    public Iterable<Term[]> getAll(RelationSymbol sym) {
-        return masterIndex.get(sym).fst().getAll();
-    }
-
-    @Override
-    public boolean isEmpty(RelationSymbol sym) {
-        return masterIndex.get(sym).fst().isEmpty();
-    }
-
-    @Override
-    public int countDistinct(RelationSymbol sym) {
-        return masterIndex.get(sym).fst().count();
-    }
-
-    @Override
-    public int countDuplicates(RelationSymbol sym) {
-        int count = 0;
-        for (IndexedFactSet idx : getUniqueIndices(sym)) {
-            count += idx.count();
-        }
-        return count;
-    }
-
-    private Set<IndexedFactSet> getUniqueIndices(RelationSymbol sym) {
-        Set<IndexedFactSet> s = new HashSet<>();
-        for (Pair<IndexedFactSet, ?> e : indices.get(sym)) {
-            s.add(e.fst());
-        }
-        return s;
-    }
-
-    @Override
-    public Iterable<Term[]> get(RelationSymbol sym, Term[] key, int index) {
-        Pair<IndexedFactSet, BindingType[]> p = indices.get(sym)[index];
-        return p.fst().lookup(key, p.snd());
-    }
-
-    @Override
-    public boolean add(RelationSymbol sym, Term[] tup) {
-        assert allNormal(tup);
-        IndexedFactSet master = masterIndex.get(sym).fst();
-        if (master.add(tup)) {
-            for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
-                IndexedFactSet idx = p.fst();
-                if (!idx.equals(master)) {
-                    idx.add(tup);
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean addAll(RelationSymbol sym, Iterable<Term[]> tups) {
-        IndexedFactSet master = masterIndex.get(sym).fst();
-        if (master.addAll(tups)) {
-            for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
-                IndexedFactSet idx = p.fst();
-                if (!idx.equals(master)) {
-                    idx.addAll(tups);
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-
-    private boolean allNormal(Term[] args) {
-        for (Term arg : args) {
-            if (!arg.isGround() || arg.containsUnevaluatedTerm()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean hasFact(RelationSymbol sym, Term[] args) {
-        assert allNormal(args);
-        return masterIndex.get(sym).fst().contains(args);
-    }
-
-    @Override
-    public void clear() {
-        for (Pair<IndexedFactSet, BindingType[]>[] idxs : indices.values()) {
-            for (Pair<IndexedFactSet, ?> p : idxs) {
-                p.fst().clear();
-            }
-        }
-    }
-
-    @Override
-    public String toString() {
-        String s = "{\n";
-        for (RelationSymbol sym : masterIndex.keySet()) {
-            s += "\t" + sym + " = {\n";
-            for (Pair<IndexedFactSet, BindingType[]> p : indices.get(sym)) {
-                s += "\t" + Arrays.toString(p.snd()) + "\n";
-                s += p.fst().toString() + "\n";
-            }
-            s += "\t}\n";
-        }
-        return s + "}";
-    }
-
-    public String toSimplifiedString() {
-        String s = "{\n";
-        for (RelationSymbol sym : masterIndex.keySet()) {
-            Pair<IndexedFactSet, BindingType[]> p = masterIndex.get(sym);
-            IndexedFactSet idx = p.fst();
-            if (!idx.isEmpty()) {
-                s += "\t" + sym + " = {\n";
-                s += "\t" + Arrays.toString(p.snd()) + "\n";
-                s += idx.toString() + "\n";
-                s += "\t}\n";
-            }
-        }
-        return s + "}";
-    }
-
-    @Override
-    public int numIndices(RelationSymbol sym) {
-        if (!indices.containsKey(sym)) {
-            throw new IllegalArgumentException("Unrecognized symbol: " + sym);
-        }
-        return getUniqueIndices(sym).size();
-    }
-
-    public IndexInfo getIndexInfo(RelationSymbol sym, int idx) {
-        if (idx < 0 || idx > numIndices(sym)) {
-            throw new IllegalArgumentException("Unrecognized index for symbol " + sym + ": " + idx);
-        }
-        Pair<IndexedFactSet, BindingType[]> p = indices.get(sym)[idx];
-        IndexedFactSet index = p.fst();
-        return new IndexInfo(index.getId(), index.comparatorOrder, p.snd());
-    }
-
-    public int getMasterIndex(RelationSymbol sym) {
-        if (!indices.containsKey(sym)) {
-            throw new IllegalArgumentException("Unrecognized symbol: " + sym);
-        }
-        int i = 0;
-        IndexedFactSet master = masterIndex.get(sym).fst();
-        for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
-            if (p.fst().equals(master)) {
-                break;
-            }
-            i++;
-        }
-        return i;
-    }
-
-    public static class SortedIndexedFactDbBuilder implements IndexedFactDbBuilder<SortedIndexedFactDb> {
-
-        private final Map<RelationSymbol, Integer> counts = new HashMap<>();
-        private final Map<RelationSymbol, Map<BindingTypeArrayWrapper, Integer>> pats = new LinkedHashMap<>();
-        private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex = new HashMap<>();
-
-        public SortedIndexedFactDbBuilder(Set<RelationSymbol> allSyms) {
-            List<RelationSymbol> sortedSyms = allSyms.stream().sorted(SymbolComparator.INSTANCE)
-                    .collect(Collectors.toList());
-            for (RelationSymbol sym : sortedSyms) {
-                pats.put(sym, new HashMap<>());
-                counts.put(sym, 0);
-            }
-        }
-
-        @Override
-        public synchronized int makeIndex(RelationSymbol sym, BindingType[] pat) {
-            assert sym.getArity() == pat.length;
-            Map<BindingTypeArrayWrapper, Integer> m = pats.get(sym);
-            BindingTypeArrayWrapper key = new BindingTypeArrayWrapper(pat);
-            assert m != null : "Symbol not registered with DB: " + sym;
-            Integer idx = m.get(key);
-            if (idx == null) {
-                idx = counts.get(sym);
-                counts.put(sym, idx + 1);
-                m.put(key, idx);
-            }
-            return idx;
-        }
-
-        @Override
-        public SortedIndexedFactDb build() {
-            Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices = new HashMap<>();
-            for (Map.Entry<RelationSymbol, Map<BindingTypeArrayWrapper, Integer>> e : pats.entrySet()) {
-                RelationSymbol sym = e.getKey();
-                indices.put(sym, mkIndices(sym, e.getValue()));
-            }
-
-            List<RelationSymbol> sortedSyms = counts.keySet().stream().sorted(SymbolComparator.INSTANCE)
-                    .collect(Collectors.toList());
-            HashMap<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> sorted = new LinkedHashMap<>();
-            for (RelationSymbol sym : sortedSyms) {
-                sorted.put(sym, masterIndex.get(sym));
-            }
-            return new SortedIndexedFactDb(indices, sorted);
-        }
-
-        @SuppressWarnings("unchecked")
-        private Pair<IndexedFactSet, BindingType[]>[] mkIndices(RelationSymbol sym,
-                                                                Map<BindingTypeArrayWrapper, Integer> m) {
-            List<Pair<IndexedFactSet, BindingType[]>> indices;
-            if (Configuration.minIndex) {
-                indices = mkMinIndices(sym, m);
-            } else {
-                indices = mkNaiveIndices(sym, m);
-            }
-            boolean ok = false;
-            for (Pair<IndexedFactSet, BindingType[]> p : indices) {
-                IndexedFactSet idx = p.fst();
-                if (idx.comparatorLength() == sym.getArity()) {
-                    masterIndex.put(sym, new Pair<>(idx, p.snd()));
-                    ok = true;
-                    break;
-                }
-            }
-            if (!ok) {
-                BindingType[] pat = new BindingType[sym.getArity()];
-                for (int i = 0; i < pat.length; ++i) {
-                    pat[i] = BindingType.FREE;
-                }
-                IndexedFactSet master = IndexedFactSet.make(pat);
-                Pair<IndexedFactSet, BindingType[]> p = new Pair<>(master, pat);
-                masterIndex.put(sym, p);
-                indices.add(p);
-            }
-            assert indicesWellFormed(indices) : "Bad index created for relation: " + sym;
-            return indices.toArray(new Pair[0]);
-        }
-
-        private static boolean indicesWellFormed(Iterable<Pair<IndexedFactSet, BindingType[]>> indices) {
-            boolean ok = true;
-            for (Pair<IndexedFactSet, BindingType[]> p : indices) {
-                ok &= p.fst().comparatorLength() == countNumNotIgnored(p.snd());
-            }
-            return ok;
-        }
-
-        private static int countNumNotIgnored(BindingType[] pat) {
-            int i = 0;
-            for (BindingType b : pat) {
-                if (!b.isIgnored()) {
-                    i++;
-                }
-            }
-            return i;
-        }
-
-        private List<Pair<IndexedFactSet, BindingType[]>> mkNaiveIndices(RelationSymbol sym,
-                                                                         Map<BindingTypeArrayWrapper, Integer> m) {
-            List<Pair<IndexedFactSet, BindingType[]>> idxs = new ArrayList<>();
-            List<Map.Entry<BindingTypeArrayWrapper, Integer>> sorted = m.entrySet().stream().sorted(cmp)
-                    .collect(Collectors.toList());
-            for (Map.Entry<BindingTypeArrayWrapper, Integer> e : sorted) {
-                BindingType[] pat = e.getKey().getArr();
-                IndexedFactSet idx = IndexedFactSet.make(pat);
-                idxs.add(new Pair<>(idx, pat));
-            }
-            return idxs;
-        }
-
-        private List<Pair<IndexedFactSet, BindingType[]>> mkMinIndices(RelationSymbol sym,
-                                                                       Map<BindingTypeArrayWrapper, Integer> m) {
-            List<Pair<IndexedFactSet, BindingType[]>> indices = new ArrayList<>(m.size());
-            for (int i = 0; i < m.size(); ++i) {
-                indices.add(null);
-            }
-            for (Map.Entry<Set<Integer>, Set<Pair<Integer, BindingType[]>>> e1 : partitionByIgnoredPositions(m)
-                    .entrySet()) {
-                for (Map.Entry<Integer, Pair<IndexedFactSet, BindingType[]>> e2 : mkMinIndices(sym, e1.getKey(),
-                        e1.getValue()).entrySet()) {
-                    assert indices.get(e2.getKey()) == null;
-                    indices.set(e2.getKey(), e2.getValue());
-                }
-            }
-            return indices;
-        }
-
-        private Map<Integer, Pair<IndexedFactSet, BindingType[]>> mkMinIndices(RelationSymbol sym, Set<Integer> ignored,
-                                                                               Set<Pair<Integer, BindingType[]>> s) {
-            Map<Integer, Set<Integer>> searchByNum = new HashMap<>();
-            Map<Integer, BindingType[]> bindingsByNum = new HashMap<>();
-            Set<Set<Integer>> searches = new HashSet<>();
-            for (Pair<Integer, BindingType[]> p : s) {
-                Set<Integer> search = new HashSet<>();
-                BindingType[] pat = p.snd();
-                for (int i = 0; i < pat.length; ++i) {
-                    if (pat[i].isBound()) {
-                        search.add(i);
-                    }
-                }
-                searches.add(search);
-                int i = p.fst();
-                searchByNum.put(i, search);
-                bindingsByNum.put(i, pat);
-            }
-            Set<Integer> domain = mkDomain(sym.getArity(), ignored);
-            Map<Set<Integer>, Iterable<Integer>> indexBySearch = MinIndex.compute(domain, searches);
-            Map<Iterable<Integer>, IndexedFactSet> factSetByIndex = new HashMap<>();
-            for (Iterable<Integer> idx : indexBySearch.values()) {
-                List<Integer> order = new ArrayList<>();
-                for (int i : idx) {
-                    order.add(i);
-                }
-                factSetByIndex.put(idx, IndexedFactSet.make(order));
-            }
-            Map<Integer, Pair<IndexedFactSet, BindingType[]>> indices = new HashMap<>();
-            for (int i : searchByNum.keySet()) {
-                Set<Integer> search = searchByNum.get(i);
-                BindingType[] pat = bindingsByNum.get(i);
-                Iterable<Integer> idx = indexBySearch.get(search);
-                indices.put(i, new Pair<>(factSetByIndex.get(idx), pat));
-            }
-            return indices;
-        }
-
-        private static Set<Integer> mkDomain(int arity, Set<Integer> ignored) {
-            Set<Integer> s = new HashSet<>();
-            for (int i = 0; i < arity; ++i) {
-                if (!ignored.contains(i)) {
-                    s.add(i);
-                }
-            }
-            return s;
-        }
-
-        private static Map<Set<Integer>, Set<Pair<Integer, BindingType[]>>> partitionByIgnoredPositions(
-                Map<BindingTypeArrayWrapper, Integer> m) {
-            Map<Set<Integer>, Set<Pair<Integer, BindingType[]>>> byIgnoredPos = new HashMap<>();
-            for (Map.Entry<BindingTypeArrayWrapper, Integer> e : m.entrySet()) {
-                BindingType[] pat = e.getKey().getArr();
-                Set<Integer> ignored = findIgnoredPositions(pat);
-                Pair<Integer, BindingType[]> p = new Pair<>(e.getValue(), pat);
-                Util.lookupOrCreate(byIgnoredPos, ignored, () -> new HashSet<>()).add(p);
-            }
-            return byIgnoredPos;
-        }
-
-        private static Set<Integer> findIgnoredPositions(BindingType[] pat) {
-            Set<Integer> ignored = new HashSet<>();
-            for (int i = 0; i < pat.length; ++i) {
-                if (pat[i].isIgnored()) {
-                    ignored.add(i);
-                }
-            }
-            return ignored;
-        }
-
-        private static final Comparator<Map.Entry<BindingTypeArrayWrapper, Integer>> cmp = new Comparator<Map.Entry<BindingTypeArrayWrapper, Integer>>() {
-
-            @Override
-            public int compare(Entry<BindingTypeArrayWrapper, Integer> o1, Entry<BindingTypeArrayWrapper, Integer> o2) {
-                return Integer.compare(o1.getValue(), o2.getValue());
-            }
-
-        };
-
-    }
-
-    private static class IndexedFactSet {
-
-        private static final AtomicInteger idCnt = new AtomicInteger();
-        private final int id;
-        private final NavigableSet<Term[]> s;
-        private final AtomicInteger cnt = new AtomicInteger();
-        private final List<Integer> comparatorOrder;
-
-        private final static TupleComparatorGenerator gen = new TupleComparatorGenerator();
-
-        public static IndexedFactSet make(BindingType[] pat) {
-            List<Integer> order = new ArrayList<>();
-            for (int i = 0; i < pat.length; ++i) {
-                if (pat[i].isBound()) {
-                    order.add(i);
-                }
-            }
-            for (int i = 0; i < pat.length; ++i) {
-                if (pat[i].isFree()) {
-                    order.add(i);
-                }
-            }
-            return make(order);
-        }
-
-        private static IndexedFactSet make(List<Integer> order) {
-            int[] a = new int[order.size()];
-            for (int i = 0; i < a.length; ++i) {
-                a[i] = order.get(i);
-            }
-            Comparator<Term[]> cmp;
-            if (Configuration.genComparators) {
-                try {
-                    cmp = gen.generate(a);
-                } catch (InstantiationException | IllegalAccessException e) {
-                    throw new AssertionError(e);
-                }
-            } else {
-                cmp = new TermArrayComparator(a);
-            }
-            return new IndexedFactSet(new ConcurrentSkipListSet<>(cmp), order);
-        }
-
-        public int comparatorLength() {
-            return comparatorOrder.size();
-        }
-
-        public Iterable<Term[]> getAll() {
-            return s;
-        }
-
-        public void clear() {
-            s.clear();
-            cnt.set(0);
-        }
-
-        public boolean isEmpty() {
-            return s.isEmpty();
-        }
-
-        private IndexedFactSet(NavigableSet<Term[]> s, List<Integer> comparatorOrder) {
-            this.s = s;
-            this.comparatorOrder = comparatorOrder;
-            this.id = idCnt.getAndIncrement();
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public boolean add(Term[] arr) {
-            boolean modified = s.add(arr);
-            if (modified) {
-                cnt.incrementAndGet();
-            }
-            return modified;
-        }
-
-        public boolean addAll(Iterable<Term[]> tups) {
-            boolean modified = false;
-            int delta = 0;
-            for (Term[] tup : tups) {
-                if (s.add(tup)) {
-                    modified = true;
-                    delta++;
-                }
-            }
-            if (modified) {
-                cnt.addAndGet(delta);
-            }
-            return modified;
-        }
-
-        public int count() {
-            return cnt.get();
-        }
-
-        public Iterable<Term[]> lookup(Term[] tup, BindingType[] pat) {
-            Term[] lower = new Term[tup.length];
-            Term[] upper = new Term[tup.length];
-            for (int i = 0; i < tup.length; ++i) {
-                if (pat[i].isBound()) {
-                    lower[i] = tup[i];
-                    upper[i] = tup[i];
-                } else {
-                    lower[i] = Terms.minTerm;
-                    upper[i] = Terms.maxTerm;
-                }
-            }
-            return s.subSet(lower, true, upper, true);
-        }
-
-        public boolean contains(Term[] tup) {
-            return s.contains(tup);
-        }
-
-        @Override
-        public String toString() {
-            String str = "[\n\t";
-            str += "\t#" + id + " " + comparatorOrder + "\n";
-            for (Term[] tup : s) {
-                str += "\n\t";
-                str += Arrays.toString(tup);
-            }
-            return str + "\n]";
-        }
-
-    }
-
-    private static class TermArrayComparator implements Comparator<Term[]> {
-
-        private final int[] pat;
-
-        public TermArrayComparator(int[] pat) {
-            this.pat = pat;
-        }
-
-        @Override
-        public int compare(Term[] o1, Term[] o2) {
-            for (int i = 0; i < pat.length; i++) {
-                int j = pat[i];
-                int x = o1[j].getId();
-                int y = o2[j].getId();
-                if (x < y) {
-                    return -1;
-                } else if (x > y) {
-                    return 1;
-                }
-            }
-            return 0;
-        }
-
-    }
-
-    public class IndexInfo {
-
-        private final int indexId;
-        private final List<Integer> comparatorOrder;
-        private final BindingType[] pat;
-
-        private IndexInfo(int indexId, List<Integer> comparatorOrder, BindingType[] pat) {
-            this.indexId = indexId;
-            this.comparatorOrder = Collections.unmodifiableList(comparatorOrder);
-            this.pat = pat;
-        }
-
-        public List<Integer> getComparatorOrder() {
-            return comparatorOrder;
-        }
-
-        public BindingType[] getPattern() {
-            return pat;
-        }
-
-        public int getIndexId() {
-            return indexId;
-        }
-
-    }
+	private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices;
+	private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex;
+
+	private SortedIndexedFactDb(Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices,
+			Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex) {
+		this.indices = indices;
+		this.masterIndex = masterIndex;
+	}
+
+	@Override
+	public Set<RelationSymbol> getSymbols() {
+		return Collections.unmodifiableSet(masterIndex.keySet());
+	}
+
+	@Override
+	public Iterable<Term[]> getAll(RelationSymbol sym) {
+		return masterIndex.get(sym).fst().getAll();
+	}
+
+	@Override
+	public boolean isEmpty(RelationSymbol sym) {
+		return masterIndex.get(sym).fst().isEmpty();
+	}
+
+	@Override
+	public int countDistinct(RelationSymbol sym) {
+		return masterIndex.get(sym).fst().count();
+	}
+
+	@Override
+	public int countDuplicates(RelationSymbol sym) {
+		int count = 0;
+		for (IndexedFactSet idx : getUniqueIndices(sym)) {
+			count += idx.count();
+		}
+		return count;
+	}
+
+	private Set<IndexedFactSet> getUniqueIndices(RelationSymbol sym) {
+		Set<IndexedFactSet> s = new HashSet<>();
+		for (Pair<IndexedFactSet, ?> e : indices.get(sym)) {
+			s.add(e.fst());
+		}
+		return s;
+	}
+
+	@Override
+	public Iterable<Term[]> get(RelationSymbol sym, Term[] key, int index) {
+		Pair<IndexedFactSet, BindingType[]> p = indices.get(sym)[index];
+		return p.fst().lookup(key, p.snd());
+	}
+
+	@Override
+	public boolean add(RelationSymbol sym, Term[] tup) {
+		assert allNormal(tup);
+		IndexedFactSet master = masterIndex.get(sym).fst();
+		if (master.add(tup)) {
+			for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
+				IndexedFactSet idx = p.fst();
+				if (!idx.equals(master)) {
+					idx.add(tup);
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean addAll(RelationSymbol sym, Iterable<Term[]> tups) {
+		IndexedFactSet master = masterIndex.get(sym).fst();
+		if (master.addAll(tups)) {
+			for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
+				IndexedFactSet idx = p.fst();
+				if (!idx.equals(master)) {
+					idx.addAll(tups);
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	private boolean allNormal(Term[] args) {
+		for (Term arg : args) {
+			if (!arg.isGround() || arg.containsUnevaluatedTerm()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean hasFact(RelationSymbol sym, Term[] args) {
+		assert allNormal(args);
+		return masterIndex.get(sym).fst().contains(args);
+	}
+
+	@Override
+	public void clear() {
+		for (Pair<IndexedFactSet, BindingType[]>[] idxs : indices.values()) {
+			for (Pair<IndexedFactSet, ?> p : idxs) {
+				p.fst().clear();
+			}
+		}
+	}
+
+	@Override
+	public String toString() {
+		String s = "{\n";
+		for (RelationSymbol sym : masterIndex.keySet()) {
+			s += "\t" + sym + " = {\n";
+			for (Pair<IndexedFactSet, BindingType[]> p : indices.get(sym)) {
+				s += "\t" + Arrays.toString(p.snd()) + "\n";
+				s += p.fst().toString() + "\n";
+			}
+			s += "\t}\n";
+		}
+		return s + "}";
+	}
+
+	public String toSimplifiedString() {
+		String s = "{\n";
+		for (RelationSymbol sym : masterIndex.keySet()) {
+			Pair<IndexedFactSet, BindingType[]> p = masterIndex.get(sym);
+			IndexedFactSet idx = p.fst();
+			if (!idx.isEmpty()) {
+				s += "\t" + sym + " = {\n";
+				s += "\t" + Arrays.toString(p.snd()) + "\n";
+				s += idx.toString() + "\n";
+				s += "\t}\n";
+			}
+		}
+		return s + "}";
+	}
+
+	@Override
+	public int numIndices(RelationSymbol sym) {
+		if (!indices.containsKey(sym)) {
+			throw new IllegalArgumentException("Unrecognized symbol: " + sym);
+		}
+		return getUniqueIndices(sym).size();
+	}
+
+	public IndexInfo getIndexInfo(RelationSymbol sym, int idx) {
+		if (idx < 0 || idx > numIndices(sym)) {
+			throw new IllegalArgumentException("Unrecognized index for symbol " + sym + ": " + idx);
+		}
+		Pair<IndexedFactSet, BindingType[]> p = indices.get(sym)[idx];
+		IndexedFactSet index = p.fst();
+		return new IndexInfo(index.getId(), index.comparatorOrder, p.snd());
+	}
+
+	public int getMasterIndex(RelationSymbol sym) {
+		if (!indices.containsKey(sym)) {
+			throw new IllegalArgumentException("Unrecognized symbol: " + sym);
+		}
+		int i = 0;
+		IndexedFactSet master = masterIndex.get(sym).fst();
+		for (Pair<IndexedFactSet, ?> p : indices.get(sym)) {
+			if (p.fst().equals(master)) {
+				break;
+			}
+			i++;
+		}
+		return i;
+	}
+
+	public static class SortedIndexedFactDbBuilder implements IndexedFactDbBuilder<SortedIndexedFactDb> {
+
+		private final Map<RelationSymbol, Integer> counts = new HashMap<>();
+		private final Map<RelationSymbol, Map<BindingTypeArrayWrapper, Integer>> pats = new LinkedHashMap<>();
+		private final Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> masterIndex = new HashMap<>();
+
+		public SortedIndexedFactDbBuilder(Set<RelationSymbol> allSyms) {
+			List<RelationSymbol> sortedSyms = allSyms.stream().sorted(SymbolComparator.INSTANCE)
+					.collect(Collectors.toList());
+			for (RelationSymbol sym : sortedSyms) {
+				pats.put(sym, new HashMap<>());
+				counts.put(sym, 0);
+			}
+		}
+
+		@Override
+		public synchronized int makeIndex(RelationSymbol sym, BindingType[] pat) {
+			assert sym.getArity() == pat.length;
+			Map<BindingTypeArrayWrapper, Integer> m = pats.get(sym);
+			BindingTypeArrayWrapper key = new BindingTypeArrayWrapper(pat);
+			assert m != null : "Symbol not registered with DB: " + sym;
+			Integer idx = m.get(key);
+			if (idx == null) {
+				idx = counts.get(sym);
+				counts.put(sym, idx + 1);
+				m.put(key, idx);
+			}
+			return idx;
+		}
+
+		@Override
+		public SortedIndexedFactDb build() {
+			Map<RelationSymbol, Pair<IndexedFactSet, BindingType[]>[]> indices = new HashMap<>();
+			for (Map.Entry<RelationSymbol, Map<BindingTypeArrayWrapper, Integer>> e : pats.entrySet()) {
+				RelationSymbol sym = e.getKey();
+				indices.put(sym, mkIndices(sym, e.getValue()));
+			}
+
+			List<RelationSymbol> sortedSyms = counts.keySet().stream().sorted(SymbolComparator.INSTANCE)
+					.collect(Collectors.toList());
+			HashMap<RelationSymbol, Pair<IndexedFactSet, BindingType[]>> sorted = new LinkedHashMap<>();
+			for (RelationSymbol sym : sortedSyms) {
+				sorted.put(sym, masterIndex.get(sym));
+			}
+			return new SortedIndexedFactDb(indices, sorted);
+		}
+
+		@SuppressWarnings("unchecked")
+		private Pair<IndexedFactSet, BindingType[]>[] mkIndices(RelationSymbol sym,
+				Map<BindingTypeArrayWrapper, Integer> m) {
+			List<Pair<IndexedFactSet, BindingType[]>> indices;
+			if (Configuration.minIndex) {
+				indices = mkMinIndices(sym, m);
+			} else {
+				indices = mkNaiveIndices(sym, m);
+			}
+			boolean ok = false;
+			for (Pair<IndexedFactSet, BindingType[]> p : indices) {
+				IndexedFactSet idx = p.fst();
+				if (idx.comparatorLength() == sym.getArity()) {
+					masterIndex.put(sym, new Pair<>(idx, p.snd()));
+					ok = true;
+					break;
+				}
+			}
+			if (!ok) {
+				BindingType[] pat = new BindingType[sym.getArity()];
+				for (int i = 0; i < pat.length; ++i) {
+					pat[i] = BindingType.FREE;
+				}
+				IndexedFactSet master = IndexedFactSet.make(pat);
+				Pair<IndexedFactSet, BindingType[]> p = new Pair<>(master, pat);
+				masterIndex.put(sym, p);
+				indices.add(p);
+			}
+			assert indicesWellFormed(indices) : "Bad index created for relation: " + sym;
+			return indices.toArray(new Pair[0]);
+		}
+
+		private static boolean indicesWellFormed(Iterable<Pair<IndexedFactSet, BindingType[]>> indices) {
+			boolean ok = true;
+			for (Pair<IndexedFactSet, BindingType[]> p : indices) {
+				ok &= p.fst().comparatorLength() == countNumNotIgnored(p.snd());
+			}
+			return ok;
+		}
+
+		private static int countNumNotIgnored(BindingType[] pat) {
+			int i = 0;
+			for (BindingType b : pat) {
+				if (!b.isIgnored()) {
+					i++;
+				}
+			}
+			return i;
+		}
+
+		private List<Pair<IndexedFactSet, BindingType[]>> mkNaiveIndices(RelationSymbol sym,
+				Map<BindingTypeArrayWrapper, Integer> m) {
+			List<Pair<IndexedFactSet, BindingType[]>> idxs = new ArrayList<>();
+			List<Map.Entry<BindingTypeArrayWrapper, Integer>> sorted = m.entrySet().stream().sorted(cmp)
+					.collect(Collectors.toList());
+			for (Map.Entry<BindingTypeArrayWrapper, Integer> e : sorted) {
+				BindingType[] pat = e.getKey().getArr();
+				IndexedFactSet idx = IndexedFactSet.make(pat);
+				idxs.add(new Pair<>(idx, pat));
+			}
+			return idxs;
+		}
+
+		private List<Pair<IndexedFactSet, BindingType[]>> mkMinIndices(RelationSymbol sym,
+				Map<BindingTypeArrayWrapper, Integer> m) {
+			List<Pair<IndexedFactSet, BindingType[]>> indices = new ArrayList<>(m.size());
+			for (int i = 0; i < m.size(); ++i) {
+				indices.add(null);
+			}
+			for (Map.Entry<Set<Integer>, Set<Pair<Integer, BindingType[]>>> e1 : partitionByIgnoredPositions(m)
+					.entrySet()) {
+				for (Map.Entry<Integer, Pair<IndexedFactSet, BindingType[]>> e2 : mkMinIndices(sym, e1.getKey(),
+						e1.getValue()).entrySet()) {
+					assert indices.get(e2.getKey()) == null;
+					indices.set(e2.getKey(), e2.getValue());
+				}
+			}
+			return indices;
+		}
+
+		private Map<Integer, Pair<IndexedFactSet, BindingType[]>> mkMinIndices(RelationSymbol sym, Set<Integer> ignored,
+				Set<Pair<Integer, BindingType[]>> s) {
+			Map<Integer, Set<Integer>> searchByNum = new HashMap<>();
+			Map<Integer, BindingType[]> bindingsByNum = new HashMap<>();
+			Set<Set<Integer>> searches = new HashSet<>();
+			for (Pair<Integer, BindingType[]> p : s) {
+				Set<Integer> search = new HashSet<>();
+				BindingType[] pat = p.snd();
+				for (int i = 0; i < pat.length; ++i) {
+					if (pat[i].isBound()) {
+						search.add(i);
+					}
+				}
+				searches.add(search);
+				int i = p.fst();
+				searchByNum.put(i, search);
+				bindingsByNum.put(i, pat);
+			}
+			Set<Integer> domain = mkDomain(sym.getArity(), ignored);
+			Map<Set<Integer>, Iterable<Integer>> indexBySearch = MinIndex.compute(domain, searches);
+			Map<Iterable<Integer>, IndexedFactSet> factSetByIndex = new HashMap<>();
+			for (Iterable<Integer> idx : indexBySearch.values()) {
+				List<Integer> order = new ArrayList<>();
+				for (int i : idx) {
+					order.add(i);
+				}
+				factSetByIndex.put(idx, IndexedFactSet.make(order));
+			}
+			Map<Integer, Pair<IndexedFactSet, BindingType[]>> indices = new HashMap<>();
+			for (int i : searchByNum.keySet()) {
+				Set<Integer> search = searchByNum.get(i);
+				BindingType[] pat = bindingsByNum.get(i);
+				Iterable<Integer> idx = indexBySearch.get(search);
+				indices.put(i, new Pair<>(factSetByIndex.get(idx), pat));
+			}
+			return indices;
+		}
+
+		private static Set<Integer> mkDomain(int arity, Set<Integer> ignored) {
+			Set<Integer> s = new HashSet<>();
+			for (int i = 0; i < arity; ++i) {
+				if (!ignored.contains(i)) {
+					s.add(i);
+				}
+			}
+			return s;
+		}
+
+		private static Map<Set<Integer>, Set<Pair<Integer, BindingType[]>>> partitionByIgnoredPositions(
+				Map<BindingTypeArrayWrapper, Integer> m) {
+			Map<Set<Integer>, Set<Pair<Integer, BindingType[]>>> byIgnoredPos = new HashMap<>();
+			for (Map.Entry<BindingTypeArrayWrapper, Integer> e : m.entrySet()) {
+				BindingType[] pat = e.getKey().getArr();
+				Set<Integer> ignored = findIgnoredPositions(pat);
+				Pair<Integer, BindingType[]> p = new Pair<>(e.getValue(), pat);
+				Util.lookupOrCreate(byIgnoredPos, ignored, () -> new HashSet<>()).add(p);
+			}
+			return byIgnoredPos;
+		}
+
+		private static Set<Integer> findIgnoredPositions(BindingType[] pat) {
+			Set<Integer> ignored = new HashSet<>();
+			for (int i = 0; i < pat.length; ++i) {
+				if (pat[i].isIgnored()) {
+					ignored.add(i);
+				}
+			}
+			return ignored;
+		}
+
+		private static final Comparator<Map.Entry<BindingTypeArrayWrapper, Integer>> cmp = new Comparator<Map.Entry<BindingTypeArrayWrapper, Integer>>() {
+
+			@Override
+			public int compare(Entry<BindingTypeArrayWrapper, Integer> o1, Entry<BindingTypeArrayWrapper, Integer> o2) {
+				return Integer.compare(o1.getValue(), o2.getValue());
+			}
+
+		};
+
+	}
+
+	private static class IndexedFactSet {
+
+		private static final AtomicInteger idCnt = new AtomicInteger();
+		private final int id;
+		private final NavigableSet<Term[]> s;
+		private final AtomicInteger cnt = new AtomicInteger();
+		private final List<Integer> comparatorOrder;
+
+		private final static TupleComparatorGenerator gen = new TupleComparatorGenerator();
+
+		public static IndexedFactSet make(BindingType[] pat) {
+			List<Integer> order = new ArrayList<>();
+			for (int i = 0; i < pat.length; ++i) {
+				if (pat[i].isBound()) {
+					order.add(i);
+				}
+			}
+			for (int i = 0; i < pat.length; ++i) {
+				if (pat[i].isFree()) {
+					order.add(i);
+				}
+			}
+			return make(order);
+		}
+
+		private static IndexedFactSet make(List<Integer> order) {
+			int[] a = new int[order.size()];
+			for (int i = 0; i < a.length; ++i) {
+				a[i] = order.get(i);
+			}
+			Comparator<Term[]> cmp;
+			if (Configuration.genComparators) {
+				try {
+					cmp = gen.generate(a);
+				} catch (InstantiationException | IllegalAccessException e) {
+					throw new AssertionError(e);
+				}
+			} else {
+				cmp = new TermArrayComparator(a);
+			}
+			return new IndexedFactSet(new ConcurrentSkipListSet<>(cmp), order);
+		}
+
+		public int comparatorLength() {
+			return comparatorOrder.size();
+		}
+
+		public Iterable<Term[]> getAll() {
+			return s;
+		}
+
+		public void clear() {
+			s.clear();
+			cnt.set(0);
+		}
+
+		public boolean isEmpty() {
+			return s.isEmpty();
+		}
+
+		private IndexedFactSet(NavigableSet<Term[]> s, List<Integer> comparatorOrder) {
+			this.s = s;
+			this.comparatorOrder = comparatorOrder;
+			this.id = idCnt.getAndIncrement();
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public boolean add(Term[] arr) {
+			boolean modified = s.add(arr);
+			if (modified) {
+				cnt.incrementAndGet();
+			}
+			return modified;
+		}
+
+		public boolean addAll(Iterable<Term[]> tups) {
+			boolean modified = false;
+			int delta = 0;
+			for (Term[] tup : tups) {
+				if (s.add(tup)) {
+					modified = true;
+					delta++;
+				}
+			}
+			if (modified) {
+				cnt.addAndGet(delta);
+			}
+			return modified;
+		}
+
+		public int count() {
+			return cnt.get();
+		}
+
+		public Iterable<Term[]> lookup(Term[] tup, BindingType[] pat) {
+			Term[] lower = new Term[tup.length];
+			Term[] upper = new Term[tup.length];
+			for (int i = 0; i < tup.length; ++i) {
+				if (pat[i].isBound()) {
+					lower[i] = tup[i];
+					upper[i] = tup[i];
+				} else {
+					lower[i] = Terms.minTerm;
+					upper[i] = Terms.maxTerm;
+				}
+			}
+			return s.subSet(lower, true, upper, true);
+		}
+
+		public boolean contains(Term[] tup) {
+			return s.contains(tup);
+		}
+
+		@Override
+		public String toString() {
+			String str = "[\n\t";
+			str += "\t#" + id + " " + comparatorOrder + "\n";
+			for (Term[] tup : s) {
+				str += "\n\t";
+				str += Arrays.toString(tup);
+			}
+			return str + "\n]";
+		}
+
+	}
+
+	private static class TermArrayComparator implements Comparator<Term[]> {
+
+		private final int[] pat;
+
+		public TermArrayComparator(int[] pat) {
+			this.pat = pat;
+		}
+
+		@Override
+		public int compare(Term[] o1, Term[] o2) {
+			for (int i = 0; i < pat.length; i++) {
+				int j = pat[i];
+				int x = o1[j].getId();
+				int y = o2[j].getId();
+				if (x < y) {
+					return -1;
+				} else if (x > y) {
+					return 1;
+				}
+			}
+			return 0;
+		}
+
+	}
+
+	public class IndexInfo {
+
+		private final int indexId;
+		private final List<Integer> comparatorOrder;
+		private final BindingType[] pat;
+
+		private IndexInfo(int indexId, List<Integer> comparatorOrder, BindingType[] pat) {
+			this.indexId = indexId;
+			this.comparatorOrder = Collections.unmodifiableList(comparatorOrder);
+			this.pat = pat;
+		}
+
+		public List<Integer> getComparatorOrder() {
+			return comparatorOrder;
+		}
+
+		public BindingType[] getPattern() {
+			return pat;
+		}
+
+		public int getIndexId() {
+			return indexId;
+		}
+
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/TupleComparatorGenerator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/TupleComparatorGenerator.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.db;
  * #L%
  */
 
-
 import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,7 +50,7 @@ public class TupleComparatorGenerator extends ClassLoader {
 	private static final Type objectType = new ObjectType("java.lang.Object");
 	private static final Type termType = new ObjectType("edu.harvard.seas.pl.formulog.ast.Term");
 	private static final Type termArrayType = new ArrayType(termType, 1);
-	
+
 	private final AtomicInteger cnt = new AtomicInteger();
 	private Map<IntArrayWrapper, Comparator<Term[]>> memo = new ConcurrentHashMap<>();
 
@@ -67,7 +66,7 @@ public class TupleComparatorGenerator extends ClassLoader {
 		}
 		return cmp;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public Comparator<Term[]> generate1(int[] accessPat) throws InstantiationException, IllegalAccessException {
 		String className = "edu.harvard.seas.pl.formulog.db.CustomComparator" + cnt.getAndIncrement();
@@ -129,7 +128,7 @@ public class TupleComparatorGenerator extends ClassLoader {
 		br.setTarget(il.append(p.fst()));
 		return new Pair<>(il, p.snd());
 	}
-	
+
 	private InstructionList genLoad(InstructionFactory f, int argn, int idx) {
 		assert argn == 1 || argn == 2;
 		InstructionList il = new InstructionList();
@@ -139,14 +138,15 @@ public class TupleComparatorGenerator extends ClassLoader {
 		il.append(f.createInvoke("edu.harvard.seas.pl.formulog.ast.Term", "getId", Type.INT, new Type[] {},
 				Const.INVOKEINTERFACE));
 		il.append(new ISTORE(argn + 2));
-		return il; 
+		return il;
 	}
-	
+
 	private Pair<InstructionList, BranchInstruction> genICmp(InstructionFactory f, boolean firstCmp) {
 		InstructionList il = new InstructionList();
 		il.append(new ILOAD(3));
 		il.append(new ILOAD(4));
-		BranchInstruction br = InstructionFactory.createBranchInstruction(firstCmp ? Const.IF_ICMPGE : Const.IF_ICMPLE, null);
+		BranchInstruction br = InstructionFactory.createBranchInstruction(firstCmp ? Const.IF_ICMPGE : Const.IF_ICMPLE,
+				null);
 		il.append(br);
 		il.append(new PUSH(f.getConstantPool(), firstCmp ? -1 : 1));
 		il.append(InstructionConst.IRETURN);

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -36,11 +35,11 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 	final Set<IndexedRule> firstRoundRules = new HashSet<>();
 	final Map<RelationSymbol, Set<IndexedRule>> laterRoundRules = new HashMap<>();
 	final Map<IndexedRule, boolean[]> splitPositions = new HashMap<>();
-	
+
 	public AbstractStratumEvaluator(Iterable<IndexedRule> rules) {
 		processRules(rules);
 	}
-	
+
 	private void processRules(Iterable<IndexedRule> rules) {
 		SmtCallFinder scf = new SmtCallFinder();
 		for (IndexedRule rule : rules) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EvalUtil.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EvalUtil.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveRule.DeltaSymbol;
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 import edu.harvard.seas.pl.formulog.validating.ast.Assignment;
@@ -35,7 +34,7 @@ public final class EvalUtil {
 	private EvalUtil() {
 		throw new AssertionError("impossible");
 	}
-	
+
 	public static RelationSymbol findDelta(IndexedRule rule) {
 		for (SimpleLiteral l : rule) {
 			RelationSymbol delta = l.accept(new SimpleLiteralVisitor<Void, RelationSymbol>() {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/Evaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/Evaluation.java
@@ -24,17 +24,16 @@ import edu.harvard.seas.pl.formulog.ast.BasicRule;
 import edu.harvard.seas.pl.formulog.ast.Program;
 import edu.harvard.seas.pl.formulog.ast.UserPredicate;
 
-
 public interface Evaluation {
 
 	void run() throws EvaluationException;
-	
+
 	EvaluationResult getResult();
 
 	boolean hasQuery();
-	
+
 	UserPredicate getQuery();
-	
+
 	Program<UserPredicate, BasicRule> getInputProgram();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EvaluationException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EvaluationException.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 public class EvaluationException extends Exception {
 
 	private static final long serialVersionUID = 1L;
 
 	public EvaluationException() {
-		
+
 	}
 
 	public EvaluationException(String message) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EvaluationResult.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EvaluationResult.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.UserPredicate;
@@ -29,11 +28,11 @@ import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 public interface EvaluationResult {
 
 	Iterable<UserPredicate> getAll(RelationSymbol sym);
-	
+
 	Iterable<UserPredicate> getQueryAnswer();
-	
+
 	Set<RelationSymbol> getSymbols();
-	
+
 	int getCount(RelationSymbol sym);
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/IndexedRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/IndexedRule.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/PredicateFunctionSetter.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/PredicateFunctionSetter.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -76,7 +75,7 @@ public class PredicateFunctionSetter {
 			}
 		}
 	}
-	
+
 	public void setDb(IndexedFactDb db) {
 		assert this.db == null;
 		this.db = db;
@@ -190,7 +189,7 @@ public class PredicateFunctionSetter {
 		}
 		def.setDef(innerDef);
 	}
-	
+
 	private static BindingType[] turnIgnoredToFree(BindingType[] bindings) {
 		BindingType[] bindings2 = new BindingType[bindings.length];
 		for (int i = 0; i < bindings.length; ++i) {
@@ -231,7 +230,8 @@ public class PredicateFunctionSetter {
 		};
 	}
 
-	private FunctionDef makeAggregate(PredicateFunctionSymbol funcSym, Term[] paddedArgs, int idx, BindingType[] bindingsUsedForIndex) {
+	private FunctionDef makeAggregate(PredicateFunctionSymbol funcSym, Term[] paddedArgs, int idx,
+			BindingType[] bindingsUsedForIndex) {
 		RelationSymbol predSym = funcSym.getPredicateSymbol();
 		int arity = 0;
 		BindingType[] bindings = funcSym.getBindings();
@@ -280,7 +280,7 @@ public class PredicateFunctionSetter {
 
 		};
 	}
-	
+
 	private Term[] padArgs(PredicateFunctionSymbol funcSym) {
 		RelationSymbol predSym = funcSym.getPredicateSymbol();
 		Term[] padded = new Term[predSym.getArity()];
@@ -289,7 +289,7 @@ public class PredicateFunctionSetter {
 		}
 		return padded;
 	}
-	
+
 	private Term[] fillInPaddedArgs(PredicateFunctionSymbol funcSym, Term[] paddedArgs, Term[] actualArgs) {
 		RelationSymbol predSym = funcSym.getPredicateSymbol();
 		Term[] newArgs = new Term[predSym.getArity()];
@@ -306,5 +306,5 @@ public class PredicateFunctionSetter {
 		}
 		return newArgs;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.Set;
@@ -48,430 +47,429 @@ import edu.harvard.seas.pl.formulog.validating.ast.SimplePredicate;
 
 public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 
-    final int stratumNum;
-    final SortedIndexedFactDb db;
-    SortedIndexedFactDb deltaDb;
-    SortedIndexedFactDb nextDeltaDb;
-    final CountingFJP exec;
-    final Set<RelationSymbol> trackedRelations;
-    volatile boolean changed;
+	final int stratumNum;
+	final SortedIndexedFactDb db;
+	SortedIndexedFactDb deltaDb;
+	SortedIndexedFactDb nextDeltaDb;
+	final CountingFJP exec;
+	final Set<RelationSymbol> trackedRelations;
+	volatile boolean changed;
 
-    static final int taskSize = Configuration.taskSize;
-    static final int smtTaskSize = Configuration.smtTaskSize;
+	static final int taskSize = Configuration.taskSize;
+	static final int smtTaskSize = Configuration.smtTaskSize;
 
-    public RoundBasedStratumEvaluator(int stratumNum, SortedIndexedFactDb db,
-                                      SortedIndexedFactDb deltaDb, SortedIndexedFactDb nextDeltaDb, Iterable<IndexedRule> rules, CountingFJP exec,
-                                      Set<RelationSymbol> trackedRelations) {
-        super(rules);
-        this.stratumNum = stratumNum;
-        this.db = db;
-        this.deltaDb = deltaDb;
-        this.nextDeltaDb = nextDeltaDb;
-        this.exec = exec;
-        this.trackedRelations = trackedRelations;
-    }
+	public RoundBasedStratumEvaluator(int stratumNum, SortedIndexedFactDb db, SortedIndexedFactDb deltaDb,
+			SortedIndexedFactDb nextDeltaDb, Iterable<IndexedRule> rules, CountingFJP exec,
+			Set<RelationSymbol> trackedRelations) {
+		super(rules);
+		this.stratumNum = stratumNum;
+		this.db = db;
+		this.deltaDb = deltaDb;
+		this.nextDeltaDb = nextDeltaDb;
+		this.exec = exec;
+		this.trackedRelations = trackedRelations;
+	}
 
-    @Override
-    public void evaluate() throws EvaluationException {
-        this.deltaDb.clear();
-        this.nextDeltaDb.clear();
-        final boolean oneRuleAtATime = Configuration.oneRuleAtATime;
-        int round = 0;
-        StopWatch watch = recordRoundStart(round);
-        for (IndexedRule r : firstRoundRules) {
-            exec.externallyAddTask(new RulePrefixEvaluator(r));
-            if (oneRuleAtATime) {
-                exec.blockUntilFinishedExn();
-            }
-        }
-        exec.blockUntilFinishedExn();
-        recordRoundEnd(round, watch);
-        updateDbs();
-        while (changed) {
-            round++;
-            watch = recordRoundStart(round);
-            changed = false;
-            for (RelationSymbol delta : laterRoundRules.keySet()) {
-                if (!deltaDb.isEmpty(delta)) {
-                    for (IndexedRule r : laterRoundRules.get(delta)) {
-                        exec.externallyAddTask(new RulePrefixEvaluator(r));
-                        if (oneRuleAtATime) {
-                            exec.blockUntilFinishedExn();
-                        }
-                    }
-                }
-            }
-            exec.blockUntilFinishedExn();
-            recordRoundEnd(round, watch);
-            updateDbs();
-        }
-    }
+	@Override
+	public void evaluate() throws EvaluationException {
+		this.deltaDb.clear();
+		this.nextDeltaDb.clear();
+		final boolean oneRuleAtATime = Configuration.oneRuleAtATime;
+		int round = 0;
+		StopWatch watch = recordRoundStart(round);
+		for (IndexedRule r : firstRoundRules) {
+			exec.externallyAddTask(new RulePrefixEvaluator(r));
+			if (oneRuleAtATime) {
+				exec.blockUntilFinishedExn();
+			}
+		}
+		exec.blockUntilFinishedExn();
+		recordRoundEnd(round, watch);
+		updateDbs();
+		while (changed) {
+			round++;
+			watch = recordRoundStart(round);
+			changed = false;
+			for (RelationSymbol delta : laterRoundRules.keySet()) {
+				if (!deltaDb.isEmpty(delta)) {
+					for (IndexedRule r : laterRoundRules.get(delta)) {
+						exec.externallyAddTask(new RulePrefixEvaluator(r));
+						if (oneRuleAtATime) {
+							exec.blockUntilFinishedExn();
+						}
+					}
+				}
+			}
+			exec.blockUntilFinishedExn();
+			recordRoundEnd(round, watch);
+			updateDbs();
+		}
+	}
 
-    void reportFact(RelationSymbol sym, Term[] args, Substitution s) throws EvaluationException {
-        Term[] newArgs = new Term[args.length];
-        for (int i = 0; i < args.length; ++i) {
-            newArgs[i] = args[i].normalize(s);
-        }
-        if (!db.hasFact(sym, newArgs) && nextDeltaDb.add(sym, newArgs)) {
-            changed = true;
-            if (trackedRelations.contains(sym)) {
-                System.err.println("[TRACKED] " + UserPredicate.make(sym, newArgs, false));
-            }
-        }
-    }
+	void reportFact(RelationSymbol sym, Term[] args, Substitution s) throws EvaluationException {
+		Term[] newArgs = new Term[args.length];
+		for (int i = 0; i < args.length; ++i) {
+			newArgs[i] = args[i].normalize(s);
+		}
+		if (!db.hasFact(sym, newArgs) && nextDeltaDb.add(sym, newArgs)) {
+			changed = true;
+			if (trackedRelations.contains(sym)) {
+				System.err.println("[TRACKED] " + UserPredicate.make(sym, newArgs, false));
+			}
+		}
+	}
 
-    void updateDbs() {
-        StopWatch watch = recordDbUpdateStart();
-        for (RelationSymbol sym : nextDeltaDb.getSymbols()) {
-            if (nextDeltaDb.isEmpty(sym)) {
-                continue;
-            }
-            Iterable<Iterable<Term[]>> answers = Util.splitIterable(nextDeltaDb.getAll(sym), taskSize);
-            exec.externallyAddTask(new UpdateDbTask(sym, answers.iterator()));
-        }
-        exec.blockUntilFinished();
-        SortedIndexedFactDb tmp = deltaDb;
-        deltaDb = nextDeltaDb;
-        nextDeltaDb = tmp;
-        nextDeltaDb.clear();
-        recordDbUpdateEnd(watch);
-    }
+	void updateDbs() {
+		StopWatch watch = recordDbUpdateStart();
+		for (RelationSymbol sym : nextDeltaDb.getSymbols()) {
+			if (nextDeltaDb.isEmpty(sym)) {
+				continue;
+			}
+			Iterable<Iterable<Term[]>> answers = Util.splitIterable(nextDeltaDb.getAll(sym), taskSize);
+			exec.externallyAddTask(new UpdateDbTask(sym, answers.iterator()));
+		}
+		exec.blockUntilFinished();
+		SortedIndexedFactDb tmp = deltaDb;
+		deltaDb = nextDeltaDb;
+		nextDeltaDb = tmp;
+		nextDeltaDb.clear();
+		recordDbUpdateEnd(watch);
+	}
 
-    @SuppressWarnings("serial")
-    class UpdateDbTask extends AbstractFJPTask {
+	@SuppressWarnings("serial")
+	class UpdateDbTask extends AbstractFJPTask {
 
-        final RelationSymbol sym;
-        final Iterator<Iterable<Term[]>> it;
+		final RelationSymbol sym;
+		final Iterator<Iterable<Term[]>> it;
 
-        protected UpdateDbTask(RelationSymbol sym, Iterator<Iterable<Term[]>> it) {
-            super(exec);
-            this.sym = sym;
-            this.it = it;
-        }
+		protected UpdateDbTask(RelationSymbol sym, Iterator<Iterable<Term[]>> it) {
+			super(exec);
+			this.sym = sym;
+			this.it = it;
+		}
 
-        @Override
-        public void doTask() throws EvaluationException {
-            Iterable<Term[]> tups = it.next();
-            if (it.hasNext()) {
-                exec.recursivelyAddTask(new UpdateDbTask(sym, it));
-            }
-            db.addAll(sym, tups);
-        }
+		@Override
+		public void doTask() throws EvaluationException {
+			Iterable<Term[]> tups = it.next();
+			if (it.hasNext()) {
+				exec.recursivelyAddTask(new UpdateDbTask(sym, it));
+			}
+			db.addAll(sym, tups);
+		}
 
-    }
+	}
 
-    Iterable<Iterable<Term[]>> lookup(IndexedRule r, int pos, OverwriteSubstitution s) throws EvaluationException {
-        SimplePredicate predicate = (SimplePredicate) r.getBody(pos);
-        int idx = r.getDbIndex(pos);
-        Term[] args = predicate.getArgs();
-        Term[] key = new Term[args.length];
-        BindingType[] pat = predicate.getBindingPattern();
-        for (int i = 0; i < args.length; ++i) {
-            if (pat[i].isBound()) {
-                key[i] = args[i].normalize(s);
-            } else {
-                key[i] = args[i];
-            }
-        }
-        RelationSymbol sym = predicate.getSymbol();
-        Iterable<Term[]> ans;
-        if (sym instanceof DeltaSymbol) {
-            ans = deltaDb.get(((DeltaSymbol) sym).getBaseSymbol(), key, idx);
-        } else {
-            ans = db.get(sym, key, idx);
-        }
-        boolean shouldSplit = splitPositions.get(r)[pos];
-        int targetSize = shouldSplit ? smtTaskSize : taskSize;
-        return Util.splitIterable(ans, targetSize);
-    }
+	Iterable<Iterable<Term[]>> lookup(IndexedRule r, int pos, OverwriteSubstitution s) throws EvaluationException {
+		SimplePredicate predicate = (SimplePredicate) r.getBody(pos);
+		int idx = r.getDbIndex(pos);
+		Term[] args = predicate.getArgs();
+		Term[] key = new Term[args.length];
+		BindingType[] pat = predicate.getBindingPattern();
+		for (int i = 0; i < args.length; ++i) {
+			if (pat[i].isBound()) {
+				key[i] = args[i].normalize(s);
+			} else {
+				key[i] = args[i];
+			}
+		}
+		RelationSymbol sym = predicate.getSymbol();
+		Iterable<Term[]> ans;
+		if (sym instanceof DeltaSymbol) {
+			ans = deltaDb.get(((DeltaSymbol) sym).getBaseSymbol(), key, idx);
+		} else {
+			ans = db.get(sym, key, idx);
+		}
+		boolean shouldSplit = splitPositions.get(r)[pos];
+		int targetSize = shouldSplit ? smtTaskSize : taskSize;
+		return Util.splitIterable(ans, targetSize);
+	}
 
-    static final boolean recordRuleDiagnostics = Configuration.recordRuleDiagnostics;
+	static final boolean recordRuleDiagnostics = Configuration.recordRuleDiagnostics;
 
-    @SuppressWarnings("serial")
-    class RuleSuffixEvaluator extends AbstractFJPTask {
+	@SuppressWarnings("serial")
+	class RuleSuffixEvaluator extends AbstractFJPTask {
 
-        final IndexedRule rule;
-        final SimplePredicate head;
-        final SimpleLiteral[] body;
-        final int startPos;
-        final OverwriteSubstitution s;
-        final Iterator<Iterable<Term[]>> it;
+		final IndexedRule rule;
+		final SimplePredicate head;
+		final SimpleLiteral[] body;
+		final int startPos;
+		final OverwriteSubstitution s;
+		final Iterator<Iterable<Term[]>> it;
 
-        protected RuleSuffixEvaluator(IndexedRule rule, SimplePredicate head, SimpleLiteral[] body, int pos,
-                                      OverwriteSubstitution s, Iterator<Iterable<Term[]>> it) {
-            super(exec);
-            this.rule = rule;
-            this.head = head;
-            this.body = body;
-            this.startPos = pos;
-            this.s = s;
-            this.it = it;
-        }
+		protected RuleSuffixEvaluator(IndexedRule rule, SimplePredicate head, SimpleLiteral[] body, int pos,
+				OverwriteSubstitution s, Iterator<Iterable<Term[]>> it) {
+			super(exec);
+			this.rule = rule;
+			this.head = head;
+			this.body = body;
+			this.startPos = pos;
+			this.s = s;
+			this.it = it;
+		}
 
-        protected RuleSuffixEvaluator(IndexedRule rule, int pos, OverwriteSubstitution s,
-                                      Iterator<Iterable<Term[]>> it) {
-            super(exec);
-            this.rule = rule;
-            this.head = rule.getHead();
-            SimpleLiteral[] bd = new SimpleLiteral[rule.getBodySize()];
-            for (int i = 0; i < bd.length; ++i) {
-                bd[i] = rule.getBody(i);
-            }
-            this.body = bd;
-            this.startPos = pos;
-            this.s = s;
-            this.it = it;
-        }
+		protected RuleSuffixEvaluator(IndexedRule rule, int pos, OverwriteSubstitution s,
+				Iterator<Iterable<Term[]>> it) {
+			super(exec);
+			this.rule = rule;
+			this.head = rule.getHead();
+			SimpleLiteral[] bd = new SimpleLiteral[rule.getBodySize()];
+			for (int i = 0; i < bd.length; ++i) {
+				bd[i] = rule.getBody(i);
+			}
+			this.body = bd;
+			this.startPos = pos;
+			this.s = s;
+			this.it = it;
+		}
 
-        @Override
-        public void doTask() throws EvaluationException {
-            long start = 0;
-            if (recordRuleDiagnostics) {
-                start = System.currentTimeMillis();
-            }
-            Iterable<Term[]> tups = it.next();
-            if (it.hasNext()) {
-                exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, head, body, startPos, s.copy(), it));
-            }
-            try {
-                for (Term[] tup : tups) {
-                    evaluate(tup);
-                }
-            } catch (UncheckedEvaluationException e) {
-                throw new EvaluationException(
-                        "Exception raised while evaluating the rule: " + rule + "\n\n" + e.getMessage());
-            }
-            if (recordRuleDiagnostics) {
-                long end = System.currentTimeMillis();
-                Configuration.recordRuleSuffixTime(rule, end - start);
-            }
-        }
+		@Override
+		public void doTask() throws EvaluationException {
+			long start = 0;
+			if (recordRuleDiagnostics) {
+				start = System.currentTimeMillis();
+			}
+			Iterable<Term[]> tups = it.next();
+			if (it.hasNext()) {
+				exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, head, body, startPos, s.copy(), it));
+			}
+			try {
+				for (Term[] tup : tups) {
+					evaluate(tup);
+				}
+			} catch (UncheckedEvaluationException e) {
+				throw new EvaluationException(
+						"Exception raised while evaluating the rule: " + rule + "\n\n" + e.getMessage());
+			}
+			if (recordRuleDiagnostics) {
+				long end = System.currentTimeMillis();
+				Configuration.recordRuleSuffixTime(rule, end - start);
+			}
+		}
 
-        void evaluate(Term[] ans) throws UncheckedEvaluationException {
-            SimplePredicate p = (SimplePredicate) body[startPos];
-            updateBinding(p, ans);
-            int pos = startPos + 1;
-            @SuppressWarnings("unchecked")
-            Iterator<Term[]>[] stack = new Iterator[rule.getBodySize()];
-            boolean movingRight = true;
-            while (pos > startPos) {
-                if (pos == body.length) {
-                    try {
-                        reportFact(head.getSymbol(), head.getArgs(), s);
-                    } catch (EvaluationException e) {
-                        throw new UncheckedEvaluationException(
-                                "Exception raised while evaluating the literal: " + head + "\n\n" + e.getMessage());
-                    }
-                    pos--;
-                    movingRight = false;
-                } else if (movingRight) {
-                    SimpleLiteral l = body[pos];
-                    try {
-                        switch (l.getTag()) {
-                            case ASSIGNMENT:
-                                ((Assignment) l).assign(s);
-                                pos++;
-                                break;
-                            case CHECK:
-                                if (((Check) l).check(s)) {
-                                    pos++;
-                                } else {
-                                    pos--;
-                                    movingRight = false;
-                                }
-                                break;
-                            case DESTRUCTOR:
-                                if (((Destructor) l).destruct(s)) {
-                                    pos++;
-                                } else {
-                                    pos--;
-                                    movingRight = false;
-                                }
-                                break;
-                            case PREDICATE:
-                                Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
-                                if (((SimplePredicate) l).isNegated()) {
-                                    if (!tups.hasNext()) {
-                                        pos++;
-                                    } else {
-                                        pos--;
-                                        movingRight = false;
-                                    }
-                                } else {
-                                    if (tups.hasNext()) {
-                                        stack[pos] = tups.next().iterator();
-                                        if (tups.hasNext()) {
-                                            exec.recursivelyAddTask(
-                                                    new RuleSuffixEvaluator(rule, head, body, pos, s.copy(), tups));
-                                        }
-                                        // No need to do anything else: we'll hit the right case on the next iteration.
-                                    } else {
-                                        pos--;
-                                    }
-                                    movingRight = false;
-                                }
-                                break;
-                        }
-                    } catch (EvaluationException e) {
-                        throw new UncheckedEvaluationException(
-                                "Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
-                    }
-                } else {
-                    Iterator<Term[]> it = stack[pos];
-                    if (it != null && it.hasNext()) {
-                        ans = it.next();
-                        updateBinding((SimplePredicate) rule.getBody(pos), ans);
-                        movingRight = true;
-                        pos++;
-                    } else {
-                        stack[pos] = null;
-                        pos--;
-                    }
-                }
-            }
-        }
+		void evaluate(Term[] ans) throws UncheckedEvaluationException {
+			SimplePredicate p = (SimplePredicate) body[startPos];
+			updateBinding(p, ans);
+			int pos = startPos + 1;
+			@SuppressWarnings("unchecked")
+			Iterator<Term[]>[] stack = new Iterator[rule.getBodySize()];
+			boolean movingRight = true;
+			while (pos > startPos) {
+				if (pos == body.length) {
+					try {
+						reportFact(head.getSymbol(), head.getArgs(), s);
+					} catch (EvaluationException e) {
+						throw new UncheckedEvaluationException(
+								"Exception raised while evaluating the literal: " + head + "\n\n" + e.getMessage());
+					}
+					pos--;
+					movingRight = false;
+				} else if (movingRight) {
+					SimpleLiteral l = body[pos];
+					try {
+						switch (l.getTag()) {
+						case ASSIGNMENT:
+							((Assignment) l).assign(s);
+							pos++;
+							break;
+						case CHECK:
+							if (((Check) l).check(s)) {
+								pos++;
+							} else {
+								pos--;
+								movingRight = false;
+							}
+							break;
+						case DESTRUCTOR:
+							if (((Destructor) l).destruct(s)) {
+								pos++;
+							} else {
+								pos--;
+								movingRight = false;
+							}
+							break;
+						case PREDICATE:
+							Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
+							if (((SimplePredicate) l).isNegated()) {
+								if (!tups.hasNext()) {
+									pos++;
+								} else {
+									pos--;
+									movingRight = false;
+								}
+							} else {
+								if (tups.hasNext()) {
+									stack[pos] = tups.next().iterator();
+									if (tups.hasNext()) {
+										exec.recursivelyAddTask(
+												new RuleSuffixEvaluator(rule, head, body, pos, s.copy(), tups));
+									}
+									// No need to do anything else: we'll hit the right case on the next iteration.
+								} else {
+									pos--;
+								}
+								movingRight = false;
+							}
+							break;
+						}
+					} catch (EvaluationException e) {
+						throw new UncheckedEvaluationException(
+								"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
+					}
+				} else {
+					Iterator<Term[]> it = stack[pos];
+					if (it != null && it.hasNext()) {
+						ans = it.next();
+						updateBinding((SimplePredicate) rule.getBody(pos), ans);
+						movingRight = true;
+						pos++;
+					} else {
+						stack[pos] = null;
+						pos--;
+					}
+				}
+			}
+		}
 
-        void updateBinding(SimplePredicate p, Term[] ans) {
-            if (Configuration.recordWork) {
-                Configuration.work.incrementAndGet();
-            }
-            Term[] args = p.getArgs();
-            BindingType[] pat = p.getBindingPattern();
-            for (int i = 0; i < pat.length; ++i) {
-                if (pat[i].isFree()) {
-                    s.put((Var) args[i], ans[i]);
-                }
-            }
-        }
+		void updateBinding(SimplePredicate p, Term[] ans) {
+			if (Configuration.recordWork) {
+				Configuration.work.incrementAndGet();
+			}
+			Term[] args = p.getArgs();
+			BindingType[] pat = p.getBindingPattern();
+			for (int i = 0; i < pat.length; ++i) {
+				if (pat[i].isFree()) {
+					s.put((Var) args[i], ans[i]);
+				}
+			}
+		}
 
-    }
+	}
 
-    @SuppressWarnings("serial")
-    class RulePrefixEvaluator extends AbstractFJPTask {
+	@SuppressWarnings("serial")
+	class RulePrefixEvaluator extends AbstractFJPTask {
 
-        final IndexedRule rule;
+		final IndexedRule rule;
 
-        protected RulePrefixEvaluator(IndexedRule rule) {
-            super(exec);
-            this.rule = rule;
-        }
+		protected RulePrefixEvaluator(IndexedRule rule) {
+			super(exec);
+			this.rule = rule;
+		}
 
-        @Override
-        public void doTask() throws EvaluationException {
-            long start = 0;
-            if (recordRuleDiagnostics) {
-                start = System.currentTimeMillis();
-            }
-            try {
-                evaluate();
-            } catch (EvaluationException e) {
-                throw new EvaluationException(
-                        "Exception raised while evaluating the rule:\n" + rule + "\n\n" + e.getMessage());
-            }
-            if (recordRuleDiagnostics) {
-                long end = System.currentTimeMillis();
-                Configuration.recordRulePrefixTime(rule, end - start);
-            }
-        }
+		@Override
+		public void doTask() throws EvaluationException {
+			long start = 0;
+			if (recordRuleDiagnostics) {
+				start = System.currentTimeMillis();
+			}
+			try {
+				evaluate();
+			} catch (EvaluationException e) {
+				throw new EvaluationException(
+						"Exception raised while evaluating the rule:\n" + rule + "\n\n" + e.getMessage());
+			}
+			if (recordRuleDiagnostics) {
+				long end = System.currentTimeMillis();
+				Configuration.recordRulePrefixTime(rule, end - start);
+			}
+		}
 
-        void evaluate() throws EvaluationException {
-            int len = rule.getBodySize();
-            int pos = 0;
-            OverwriteSubstitution s = new OverwriteSubstitution();
-            loop:
-            for (; pos < len; ++pos) {
-                SimpleLiteral l = rule.getBody(pos);
-                try {
-                    switch (l.getTag()) {
-                        case ASSIGNMENT:
-                            ((Assignment) l).assign(s);
-                            break;
-                        case CHECK:
-                            if (!((Check) l).check(s)) {
-                                return;
-                            }
-                            break;
-                        case DESTRUCTOR:
-                            if (!((Destructor) l).destruct(s)) {
-                                return;
-                            }
-                            break;
-                        case PREDICATE:
-                            SimplePredicate p = (SimplePredicate) l;
-                            if (p.isNegated()) {
-                                if (lookup(rule, pos, s).iterator().hasNext()) {
-                                    return;
-                                }
-                            } else {
-                                // Stop on the first positive user predicate.
-                                break loop;
-                            }
-                            break;
-                    }
-                } catch (EvaluationException e) {
-                    throw new EvaluationException(
-                            "Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
-                }
-            }
-            if (pos == len) {
-                try {
-                    SimplePredicate head = rule.getHead();
-                    reportFact(head.getSymbol(), head.getArgs(), s);
-                    return;
-                } catch (EvaluationException e) {
-                    throw new EvaluationException("Exception raised while evaluationg the literal: " + rule.getHead()
-                            + e.getLocalizedMessage());
-                }
-            }
-            Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
-            if (tups.hasNext()) {
-                exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, pos, s, tups));
-            }
-        }
-    }
+		void evaluate() throws EvaluationException {
+			int len = rule.getBodySize();
+			int pos = 0;
+			OverwriteSubstitution s = new OverwriteSubstitution();
+			loop: for (; pos < len; ++pos) {
+				SimpleLiteral l = rule.getBody(pos);
+				try {
+					switch (l.getTag()) {
+					case ASSIGNMENT:
+						((Assignment) l).assign(s);
+						break;
+					case CHECK:
+						if (!((Check) l).check(s)) {
+							return;
+						}
+						break;
+					case DESTRUCTOR:
+						if (!((Destructor) l).destruct(s)) {
+							return;
+						}
+						break;
+					case PREDICATE:
+						SimplePredicate p = (SimplePredicate) l;
+						if (p.isNegated()) {
+							if (lookup(rule, pos, s).iterator().hasNext()) {
+								return;
+							}
+						} else {
+							// Stop on the first positive user predicate.
+							break loop;
+						}
+						break;
+					}
+				} catch (EvaluationException e) {
+					throw new EvaluationException(
+							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
+				}
+			}
+			if (pos == len) {
+				try {
+					SimplePredicate head = rule.getHead();
+					reportFact(head.getSymbol(), head.getArgs(), s);
+					return;
+				} catch (EvaluationException e) {
+					throw new EvaluationException("Exception raised while evaluationg the literal: " + rule.getHead()
+							+ e.getLocalizedMessage());
+				}
+			}
+			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
+			if (tups.hasNext()) {
+				exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, pos, s, tups));
+			}
+		}
+	}
 
-    StopWatch recordRoundStart(int round) {
-        if (!Configuration.debugRounds) {
-            return null;
-        }
-        System.err.println("#####");
-        System.err.println("[START] Stratum " + stratumNum + ", round " + round);
-        LocalDateTime now = LocalDateTime.now();
-        System.err.println("Start: " + now);
-        StopWatch watch = new StopWatch();
-        watch.start();
-        return watch;
-    }
+	StopWatch recordRoundStart(int round) {
+		if (!Configuration.debugRounds) {
+			return null;
+		}
+		System.err.println("#####");
+		System.err.println("[START] Stratum " + stratumNum + ", round " + round);
+		LocalDateTime now = LocalDateTime.now();
+		System.err.println("Start: " + now);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		return watch;
+	}
 
-    void recordRoundEnd(int round, StopWatch watch) {
-        if (watch == null) {
-            return;
-        }
-        watch.stop();
-        System.err.println("[END] Stratum " + stratumNum + ", round " + round);
-        System.err.println("Time: " + watch.getTime() + "ms");
-    }
+	void recordRoundEnd(int round, StopWatch watch) {
+		if (watch == null) {
+			return;
+		}
+		watch.stop();
+		System.err.println("[END] Stratum " + stratumNum + ", round " + round);
+		System.err.println("Time: " + watch.getTime() + "ms");
+	}
 
-    StopWatch recordDbUpdateStart() {
-        if (!Configuration.debugRounds) {
-            return null;
-        }
-        System.err.println("[START] Updating DBs");
-        LocalDateTime now = LocalDateTime.now();
-        System.err.println("Start: " + now);
-        StopWatch watch = new StopWatch();
-        watch.start();
-        return watch;
-    }
+	StopWatch recordDbUpdateStart() {
+		if (!Configuration.debugRounds) {
+			return null;
+		}
+		System.err.println("[START] Updating DBs");
+		LocalDateTime now = LocalDateTime.now();
+		System.err.println("Start: " + now);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		return watch;
+	}
 
-    void recordDbUpdateEnd(StopWatch watch) {
-        if (watch == null) {
-            return;
-        }
-        watch.stop();
-        Configuration.printRelSizes(System.err, "DELTA SIZE", deltaDb, false);
-        System.err.println("[END] Updating DBs");
-        System.err.println("Time: " + watch.getTime() + "ms");
-    }
+	void recordDbUpdateEnd(StopWatch watch) {
+		if (watch == null) {
+			return;
+		}
+		watch.stop();
+		Configuration.printRelSizes(System.err, "DELTA SIZE", deltaDb, false);
+		System.err.println("[END] Updating DBs");
+		System.err.println("Time: " + watch.getTime() + "ms");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
@@ -45,540 +45,540 @@ import java.util.function.BiFunction;
 
 public class SemiNaiveEvaluation implements Evaluation {
 
-    private final SortedIndexedFactDb db;
-    private final SortedIndexedFactDb deltaDb;
-    private final SortedIndexedFactDb nextDeltaDb;
-    private final List<Stratum> strata;
-    private final UserPredicate query;
-    private final CountingFJP exec;
-    private final Set<RelationSymbol> trackedRelations;
-    private final WellTypedProgram inputProgram;
-    private final Map<RelationSymbol, Set<IndexedRule>> rules;
-    private final boolean eagerEval;
+	private final SortedIndexedFactDb db;
+	private final SortedIndexedFactDb deltaDb;
+	private final SortedIndexedFactDb nextDeltaDb;
+	private final List<Stratum> strata;
+	private final UserPredicate query;
+	private final CountingFJP exec;
+	private final Set<RelationSymbol> trackedRelations;
+	private final WellTypedProgram inputProgram;
+	private final Map<RelationSymbol, Set<IndexedRule>> rules;
+	private final boolean eagerEval;
 
-    static final boolean sequential = System.getProperty("sequential") != null;
-    static final boolean debugRounds = Configuration.debugRounds;
+	static final boolean sequential = System.getProperty("sequential") != null;
+	static final boolean debugRounds = Configuration.debugRounds;
 
-    @SuppressWarnings("serial")
-    public static SemiNaiveEvaluation setup(WellTypedProgram prog, int parallelism, boolean eagerEval)
-            throws InvalidProgramException {
-        FunctionDefValidation.validate(prog);
-        MagicSetTransformer mst = new MagicSetTransformer(prog);
-        BasicProgram magicProg = mst.transform(Configuration.useDemandTransformation,
-                Configuration.restoreStratification);
-        Set<RelationSymbol> allRelations = new HashSet<>(magicProg.getFactSymbols());
-        allRelations.addAll(magicProg.getRuleSymbols());
-        allRelations.addAll(prog.getRuleSymbols());
-        SortedIndexedFactDbBuilder dbb = new SortedIndexedFactDbBuilder(allRelations);
-        SortedIndexedFactDbBuilder deltaDbb = new SortedIndexedFactDbBuilder(magicProg.getRuleSymbols());
-        PredicateFunctionSetter predFuncs = new PredicateFunctionSetter(
-                magicProg.getFunctionCallFactory().getDefManager(), dbb);
+	@SuppressWarnings("serial")
+	public static SemiNaiveEvaluation setup(WellTypedProgram prog, int parallelism, boolean eagerEval)
+			throws InvalidProgramException {
+		FunctionDefValidation.validate(prog);
+		MagicSetTransformer mst = new MagicSetTransformer(prog);
+		BasicProgram magicProg = mst.transform(Configuration.useDemandTransformation,
+				Configuration.restoreStratification);
+		Set<RelationSymbol> allRelations = new HashSet<>(magicProg.getFactSymbols());
+		allRelations.addAll(magicProg.getRuleSymbols());
+		allRelations.addAll(prog.getRuleSymbols());
+		SortedIndexedFactDbBuilder dbb = new SortedIndexedFactDbBuilder(allRelations);
+		SortedIndexedFactDbBuilder deltaDbb = new SortedIndexedFactDbBuilder(magicProg.getRuleSymbols());
+		PredicateFunctionSetter predFuncs = new PredicateFunctionSetter(
+				magicProg.getFunctionCallFactory().getDefManager(), dbb);
 
-        Map<RelationSymbol, Set<IndexedRule>> rules = new HashMap<>();
-        List<Stratum> strata = new Stratifier(magicProg).stratify();
-        for (Stratum stratum : strata) {
-            if (stratum.hasRecursiveNegationOrAggregation()) {
-                throw new InvalidProgramException("Cannot handle recursive negation or aggregation: " + stratum);
-            }
-            Set<RelationSymbol> stratumSymbols = stratum.getPredicateSyms();
-            for (RelationSymbol sym : stratumSymbols) {
-                Set<IndexedRule> rs = new HashSet<>();
-                for (BasicRule br : magicProg.getRules(sym)) {
-                    for (SemiNaiveRule snr : SemiNaiveRule.make(br, stratumSymbols)) {
-                        BiFunction<ComplexLiteral, Set<Var>, Integer> score = chooseScoringFunction(eagerEval);
-                        ValidRule vr = ValidRule.make(tweakRule(snr, eagerEval), score);
-                        checkRule(vr, eagerEval);
-                        predFuncs.preprocess(vr);
-                        SimpleRule sr = SimpleRule.make(vr, magicProg.getFunctionCallFactory());
-                        IndexedRule ir = IndexedRule.make(sr, p -> {
-                            RelationSymbol psym = p.getSymbol();
-                            if (psym instanceof DeltaSymbol) {
-                                psym = ((DeltaSymbol) psym).getBaseSymbol();
-                                return deltaDbb.makeIndex(psym, p.getBindingPattern());
-                            } else {
-                                return dbb.makeIndex(psym, p.getBindingPattern());
-                            }
-                        });
-                        rs.add(ir);
-                        if (Configuration.printFinalRules) {
-                            System.err.println("[FINAL RULE]:\n" + ir);
-                        }
-                    }
-                }
-                rules.put(sym, rs);
-            }
-        }
-        SortedIndexedFactDb db = dbb.build();
-        predFuncs.setDb(db);
+		Map<RelationSymbol, Set<IndexedRule>> rules = new HashMap<>();
+		List<Stratum> strata = new Stratifier(magicProg).stratify();
+		for (Stratum stratum : strata) {
+			if (stratum.hasRecursiveNegationOrAggregation()) {
+				throw new InvalidProgramException("Cannot handle recursive negation or aggregation: " + stratum);
+			}
+			Set<RelationSymbol> stratumSymbols = stratum.getPredicateSyms();
+			for (RelationSymbol sym : stratumSymbols) {
+				Set<IndexedRule> rs = new HashSet<>();
+				for (BasicRule br : magicProg.getRules(sym)) {
+					for (SemiNaiveRule snr : SemiNaiveRule.make(br, stratumSymbols)) {
+						BiFunction<ComplexLiteral, Set<Var>, Integer> score = chooseScoringFunction(eagerEval);
+						ValidRule vr = ValidRule.make(tweakRule(snr, eagerEval), score);
+						checkRule(vr, eagerEval);
+						predFuncs.preprocess(vr);
+						SimpleRule sr = SimpleRule.make(vr, magicProg.getFunctionCallFactory());
+						IndexedRule ir = IndexedRule.make(sr, p -> {
+							RelationSymbol psym = p.getSymbol();
+							if (psym instanceof DeltaSymbol) {
+								psym = ((DeltaSymbol) psym).getBaseSymbol();
+								return deltaDbb.makeIndex(psym, p.getBindingPattern());
+							} else {
+								return dbb.makeIndex(psym, p.getBindingPattern());
+							}
+						});
+						rs.add(ir);
+						if (Configuration.printFinalRules) {
+							System.err.println("[FINAL RULE]:\n" + ir);
+						}
+					}
+				}
+				rules.put(sym, rs);
+			}
+		}
+		SortedIndexedFactDb db = dbb.build();
+		predFuncs.setDb(db);
 
-        SmtLibSolver smt = getSmtManager();
-        try {
-            smt.start(magicProg);
-        } catch (EvaluationException e) {
-            throw new InvalidProgramException("Problem initializing SMT shims: " + e.getMessage());
-        }
-        FunctionDefManager defManager = magicProg.getFunctionCallFactory().getDefManager();
-        defManager.loadBuiltInFunctions(smt);
+		SmtLibSolver smt = getSmtManager();
+		try {
+			smt.start(magicProg);
+		} catch (EvaluationException e) {
+			throw new InvalidProgramException("Problem initializing SMT shims: " + e.getMessage());
+		}
+		FunctionDefManager defManager = magicProg.getFunctionCallFactory().getDefManager();
+		defManager.loadBuiltInFunctions(smt);
 
-        CountingFJP exec;
-        if (sequential) {
-            exec = new MockCountingFJP();
-        } else {
-            exec = new CountingFJPImpl(parallelism);
-        }
+		CountingFJP exec;
+		if (sequential) {
+			exec = new MockCountingFJP();
+		} else {
+			exec = new CountingFJPImpl(parallelism);
+		}
 
-        for (RelationSymbol sym : magicProg.getFactSymbols()) {
-            for (Iterable<Term[]> tups : Util.splitIterable(magicProg.getFacts(sym), Configuration.taskSize)) {
-                exec.externallyAddTask(new AbstractFJPTask(exec) {
+		for (RelationSymbol sym : magicProg.getFactSymbols()) {
+			for (Iterable<Term[]> tups : Util.splitIterable(magicProg.getFacts(sym), Configuration.taskSize)) {
+				exec.externallyAddTask(new AbstractFJPTask(exec) {
 
-                    @Override
-                    public void doTask() throws EvaluationException {
-                        for (Term[] tup : tups) {
-                            try {
-                                db.add(sym, Terms.normalize(tup, new SimpleSubstitution()));
-                            } catch (EvaluationException e) {
-                                UserPredicate p = UserPredicate.make(sym, tup, false);
-                                throw new EvaluationException("Cannot normalize fact " + p + ":\n" + e.getMessage());
-                            }
-                        }
-                    }
+					@Override
+					public void doTask() throws EvaluationException {
+						for (Term[] tup : tups) {
+							try {
+								db.add(sym, Terms.normalize(tup, new SimpleSubstitution()));
+							} catch (EvaluationException e) {
+								UserPredicate p = UserPredicate.make(sym, tup, false);
+								throw new EvaluationException("Cannot normalize fact " + p + ":\n" + e.getMessage());
+							}
+						}
+					}
 
-                });
-            }
-        }
-        exec.blockUntilFinished();
-        if (exec.hasFailed()) {
-            exec.shutdown();
-            throw new InvalidProgramException(exec.getFailureCause());
-        }
-        return new SemiNaiveEvaluation(prog, db, deltaDbb, rules, magicProg.getQuery(), strata, exec,
-                getTrackedRelations(magicProg.getSymbolManager()), eagerEval);
-    }
+				});
+			}
+		}
+		exec.blockUntilFinished();
+		if (exec.hasFailed()) {
+			exec.shutdown();
+			throw new InvalidProgramException(exec.getFailureCause());
+		}
+		return new SemiNaiveEvaluation(prog, db, deltaDbb, rules, magicProg.getQuery(), strata, exec,
+				getTrackedRelations(magicProg.getSymbolManager()), eagerEval);
+	}
 
-    private static Rule<UserPredicate, ComplexLiteral> tweakRule(Rule<UserPredicate, ComplexLiteral> r,
-                                                                 boolean eagerEval) {
-        if (!eagerEval) {
-            return r;
-        }
-        List<ComplexLiteral> newBody = new ArrayList<>();
-        for (ComplexLiteral l : r) {
-            l.accept(new ComplexLiteralVisitor<Void, Void>() {
+	private static Rule<UserPredicate, ComplexLiteral> tweakRule(Rule<UserPredicate, ComplexLiteral> r,
+			boolean eagerEval) {
+		if (!eagerEval) {
+			return r;
+		}
+		List<ComplexLiteral> newBody = new ArrayList<>();
+		for (ComplexLiteral l : r) {
+			l.accept(new ComplexLiteralVisitor<Void, Void>() {
 
-                @Override
-                public Void visit(UnificationPredicate unificationPredicate, Void input) {
-                    newBody.add(unificationPredicate);
-                    return null;
-                }
+				@Override
+				public Void visit(UnificationPredicate unificationPredicate, Void input) {
+					newBody.add(unificationPredicate);
+					return null;
+				}
 
-                @Override
-                public Void visit(UserPredicate userPredicate, Void input) {
-                    RelationSymbol sym = userPredicate.getSymbol();
-                    if (sym instanceof DeltaSymbol) {
-                        Term[] args = userPredicate.getArgs();
-                        Term[] newArgs = new Term[args.length];
-                        for (int i = 0; i < args.length; ++i) {
-                            Term arg = args[i];
-                            if (arg.containsUnevaluatedTerm()) {
-                                Var x = Var.fresh();
-                                newBody.add(UnificationPredicate.make(x, arg, false));
-                                arg = x;
-                            }
-                            newArgs[i] = arg;
-                        }
-                        newBody.add(UserPredicate.make(sym, newArgs, false));
-                    } else {
-                        newBody.add(userPredicate);
-                    }
-                    return null;
-                }
+				@Override
+				public Void visit(UserPredicate userPredicate, Void input) {
+					RelationSymbol sym = userPredicate.getSymbol();
+					if (sym instanceof DeltaSymbol) {
+						Term[] args = userPredicate.getArgs();
+						Term[] newArgs = new Term[args.length];
+						for (int i = 0; i < args.length; ++i) {
+							Term arg = args[i];
+							if (arg.containsUnevaluatedTerm()) {
+								Var x = Var.fresh();
+								newBody.add(UnificationPredicate.make(x, arg, false));
+								arg = x;
+							}
+							newArgs[i] = arg;
+						}
+						newBody.add(UserPredicate.make(sym, newArgs, false));
+					} else {
+						newBody.add(userPredicate);
+					}
+					return null;
+				}
 
-            }, null);
-        }
-        return BasicRule.make(r.getHead(), newBody);
-    }
+			}, null);
+		}
+		return BasicRule.make(r.getHead(), newBody);
+	}
 
-    private static void checkRule(ValidRule r, boolean eagerEval) throws InvalidProgramException {
-        if (!eagerEval) {
-            return;
-        }
-        boolean seenUserPred = false;
-        for (ComplexLiteral l : r) {
-            if (l instanceof UserPredicate) {
-                UserPredicate pred = (UserPredicate) l;
-                if (seenUserPred && pred.getSymbol() instanceof DeltaSymbol) {
-                    throw new InvalidProgramException("Delta symbol could not be placed first:\n" + r);
-                }
-                seenUserPred = true;
-            }
-        }
-    }
+	private static void checkRule(ValidRule r, boolean eagerEval) throws InvalidProgramException {
+		if (!eagerEval) {
+			return;
+		}
+		boolean seenUserPred = false;
+		for (ComplexLiteral l : r) {
+			if (l instanceof UserPredicate) {
+				UserPredicate pred = (UserPredicate) l;
+				if (seenUserPred && pred.getSymbol() instanceof DeltaSymbol) {
+					throw new InvalidProgramException("Delta symbol could not be placed first:\n" + r);
+				}
+				seenUserPred = true;
+			}
+		}
+	}
 
-    private static SmtLibSolver maybeDoubleCheckSolver(SmtLibSolver inner) {
-        if (Configuration.smtDoubleCheckUnknowns) {
-            return new DoubleCheckingSolver(inner);
-        }
-        return inner;
-    }
+	private static SmtLibSolver maybeDoubleCheckSolver(SmtLibSolver inner) {
+		if (Configuration.smtDoubleCheckUnknowns) {
+			return new DoubleCheckingSolver(inner);
+		}
+		return inner;
+	}
 
-    private static SmtLibSolver makeNaiveSolver() {
-        return Configuration.smtUseSingleShotSolver ? new SingleShotSolver() : new CallAndResetSolver();
-    }
+	private static SmtLibSolver makeNaiveSolver() {
+		return Configuration.smtUseSingleShotSolver ? new SingleShotSolver() : new CallAndResetSolver();
+	}
 
-    private static SmtLibSolver getSmtManager() {
-        SmtStrategy strategy = Main.smtStrategy;
-        switch (strategy.getTag()) {
-            case QUEUE: {
-                int size = (int) strategy.getMetadata();
-                return new QueueSmtManager(size, () -> maybeDoubleCheckSolver(new CheckSatAssumingSolver()));
-            }
-            case NAIVE:
-                return maybeDoubleCheckSolver(makeNaiveSolver());
-            case PUSH_POP:
-                return new PushPopSolver();
-            case PUSH_POP_NAIVE:
-                return new PushPopNaiveSolver();
-            case BEST_MATCH: {
-                int size = (int) strategy.getMetadata();
-                return maybeDoubleCheckSolver(new BestMatchSmtManager(size));
-            }
-            case PER_THREAD_QUEUE: {
-                int size = (int) strategy.getMetadata();
-                return new PerThreadSmtManager(() -> new NotThreadSafeQueueSmtManager(size,
-                        () -> maybeDoubleCheckSolver(new CheckSatAssumingSolver())));
-            }
-            case PER_THREAD_BEST_MATCH: {
-                int size = (int) strategy.getMetadata();
-                return new PerThreadSmtManager(() -> maybeDoubleCheckSolver(new BestMatchSmtManager(size)));
-            }
-            case PER_THREAD_PUSH_POP: {
-                return new PerThreadSmtManager(() -> new PushPopSolver());
-            }
-            case PER_THREAD_PUSH_POP_NAIVE: {
-                return new PerThreadSmtManager(() -> new PushPopNaiveSolver());
-            }
-            case PER_THREAD_NAIVE: {
-                return new PerThreadSmtManager(() -> maybeDoubleCheckSolver(
-                        Configuration.smtUseSingleShotSolver ? new SingleShotSolver() : new CallAndResetSolver()));
-            }
-            default:
-                throw new UnsupportedOperationException("Cannot support SMT strategy: " + strategy);
-        }
-    }
+	private static SmtLibSolver getSmtManager() {
+		SmtStrategy strategy = Main.smtStrategy;
+		switch (strategy.getTag()) {
+		case QUEUE: {
+			int size = (int) strategy.getMetadata();
+			return new QueueSmtManager(size, () -> maybeDoubleCheckSolver(new CheckSatAssumingSolver()));
+		}
+		case NAIVE:
+			return maybeDoubleCheckSolver(makeNaiveSolver());
+		case PUSH_POP:
+			return new PushPopSolver();
+		case PUSH_POP_NAIVE:
+			return new PushPopNaiveSolver();
+		case BEST_MATCH: {
+			int size = (int) strategy.getMetadata();
+			return maybeDoubleCheckSolver(new BestMatchSmtManager(size));
+		}
+		case PER_THREAD_QUEUE: {
+			int size = (int) strategy.getMetadata();
+			return new PerThreadSmtManager(() -> new NotThreadSafeQueueSmtManager(size,
+					() -> maybeDoubleCheckSolver(new CheckSatAssumingSolver())));
+		}
+		case PER_THREAD_BEST_MATCH: {
+			int size = (int) strategy.getMetadata();
+			return new PerThreadSmtManager(() -> maybeDoubleCheckSolver(new BestMatchSmtManager(size)));
+		}
+		case PER_THREAD_PUSH_POP: {
+			return new PerThreadSmtManager(() -> new PushPopSolver());
+		}
+		case PER_THREAD_PUSH_POP_NAIVE: {
+			return new PerThreadSmtManager(() -> new PushPopNaiveSolver());
+		}
+		case PER_THREAD_NAIVE: {
+			return new PerThreadSmtManager(() -> maybeDoubleCheckSolver(
+					Configuration.smtUseSingleShotSolver ? new SingleShotSolver() : new CallAndResetSolver()));
+		}
+		default:
+			throw new UnsupportedOperationException("Cannot support SMT strategy: " + strategy);
+		}
+	}
 
-    static Set<RelationSymbol> getTrackedRelations(SymbolManager sm) {
-        Set<RelationSymbol> s = new HashSet<>();
-        for (String name : Configuration.trackedRelations) {
-            if (sm.hasName(name)) {
-                Symbol sym = sm.lookupSymbol(name);
-                if (sym instanceof RelationSymbol) {
-                    s.add((RelationSymbol) sm.lookupSymbol(name));
-                } else {
-                    System.err.println("[WARNING] Cannot track non-relation " + sym);
-                }
+	static Set<RelationSymbol> getTrackedRelations(SymbolManager sm) {
+		Set<RelationSymbol> s = new HashSet<>();
+		for (String name : Configuration.trackedRelations) {
+			if (sm.hasName(name)) {
+				Symbol sym = sm.lookupSymbol(name);
+				if (sym instanceof RelationSymbol) {
+					s.add((RelationSymbol) sm.lookupSymbol(name));
+				} else {
+					System.err.println("[WARNING] Cannot track non-relation " + sym);
+				}
 
-            } else {
-                System.err.println("[WARNING] Cannot track unrecognized relation " + name);
-            }
-        }
-        return s;
-    }
+			} else {
+				System.err.println("[WARNING] Cannot track unrecognized relation " + name);
+			}
+		}
+		return s;
+	}
 
-    static BiFunction<ComplexLiteral, Set<Var>, Integer> chooseScoringFunction(boolean eagerEval) {
-        if (eagerEval) {
-            return SemiNaiveEvaluation::score5;
-        }
-        switch (Configuration.optimizationSetting) {
-            case 0:
-                return SemiNaiveEvaluation::score0;
-            case 1:
-                return SemiNaiveEvaluation::score1;
-            case 2:
-                return SemiNaiveEvaluation::score2;
-            case 3:
-                return SemiNaiveEvaluation::score3;
-            case 4:
-                return SemiNaiveEvaluation::score4;
-            case 5:
-                return SemiNaiveEvaluation::score5;
-            default:
-                throw new IllegalArgumentException(
-                        "Unrecognized optimization setting: " + Configuration.optimizationSetting);
-        }
-    }
+	static BiFunction<ComplexLiteral, Set<Var>, Integer> chooseScoringFunction(boolean eagerEval) {
+		if (eagerEval) {
+			return SemiNaiveEvaluation::score5;
+		}
+		switch (Configuration.optimizationSetting) {
+		case 0:
+			return SemiNaiveEvaluation::score0;
+		case 1:
+			return SemiNaiveEvaluation::score1;
+		case 2:
+			return SemiNaiveEvaluation::score2;
+		case 3:
+			return SemiNaiveEvaluation::score3;
+		case 4:
+			return SemiNaiveEvaluation::score4;
+		case 5:
+			return SemiNaiveEvaluation::score5;
+		default:
+			throw new IllegalArgumentException(
+					"Unrecognized optimization setting: " + Configuration.optimizationSetting);
+		}
+	}
 
-    static int score0(ComplexLiteral l, Set<Var> boundVars) {
-        return 0;
-    }
+	static int score0(ComplexLiteral l, Set<Var> boundVars) {
+		return 0;
+	}
 
-    static int score1(ComplexLiteral l, Set<Var> boundVars) {
-        // This seems to be worse than just doing nothing.
-        return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
+	static int score1(ComplexLiteral l, Set<Var> boundVars) {
+		// This seems to be worse than just doing nothing.
+		return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
 
-            @Override
-            public Integer visit(UnificationPredicate unificationPredicate, Void input) {
-                return Integer.MAX_VALUE;
-            }
+			@Override
+			public Integer visit(UnificationPredicate unificationPredicate, Void input) {
+				return Integer.MAX_VALUE;
+			}
 
-            @Override
-            public Integer visit(UserPredicate pred, Void input) {
-                if (pred.isNegated()) {
-                    return Integer.MAX_VALUE;
-                }
-                if (pred.getSymbol() instanceof DeltaSymbol) {
-                    return 100;
-                }
-                Term[] args = pred.getArgs();
-                if (args.length == 0) {
-                    return 150;
-                }
-                int bound = 0;
-                for (int i = 0; i < args.length; ++i) {
-                    if (boundVars.containsAll(args[i].varSet())) {
-                        bound++;
-                    }
-                }
-                double percentBound = ((double) bound) / args.length * 100;
-                return (int) percentBound;
-            }
+			@Override
+			public Integer visit(UserPredicate pred, Void input) {
+				if (pred.isNegated()) {
+					return Integer.MAX_VALUE;
+				}
+				if (pred.getSymbol() instanceof DeltaSymbol) {
+					return 100;
+				}
+				Term[] args = pred.getArgs();
+				if (args.length == 0) {
+					return 150;
+				}
+				int bound = 0;
+				for (int i = 0; i < args.length; ++i) {
+					if (boundVars.containsAll(args[i].varSet())) {
+						bound++;
+					}
+				}
+				double percentBound = ((double) bound) / args.length * 100;
+				return (int) percentBound;
+			}
 
-        }, null);
-    }
+		}, null);
+	}
 
-    static int score2(ComplexLiteral l, Set<Var> boundVars) {
-        return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
+	static int score2(ComplexLiteral l, Set<Var> boundVars) {
+		return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
 
-            @Override
-            public Integer visit(UnificationPredicate unificationPredicate, Void input) {
-                return Integer.MAX_VALUE;
-            }
+			@Override
+			public Integer visit(UnificationPredicate unificationPredicate, Void input) {
+				return Integer.MAX_VALUE;
+			}
 
-            @Override
-            public Integer visit(UserPredicate pred, Void input) {
-                Term[] args = pred.getArgs();
-                if (args.length == 0) {
-                    return 150;
-                }
-                int bound = 0;
-                for (int i = 0; i < args.length; ++i) {
-                    if (boundVars.containsAll(args[i].varSet())) {
-                        bound++;
-                    }
-                }
-                double percentBound = ((double) bound) / args.length * 100;
-                return (int) percentBound;
-            }
+			@Override
+			public Integer visit(UserPredicate pred, Void input) {
+				Term[] args = pred.getArgs();
+				if (args.length == 0) {
+					return 150;
+				}
+				int bound = 0;
+				for (int i = 0; i < args.length; ++i) {
+					if (boundVars.containsAll(args[i].varSet())) {
+						bound++;
+					}
+				}
+				double percentBound = ((double) bound) / args.length * 100;
+				return (int) percentBound;
+			}
 
-        }, null);
-    }
+		}, null);
+	}
 
-    static int score3(ComplexLiteral l, Set<Var> boundVars) {
-        return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
+	static int score3(ComplexLiteral l, Set<Var> boundVars) {
+		return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
 
-            @Override
-            public Integer visit(UnificationPredicate unificationPredicate, Void input) {
-                return Integer.MAX_VALUE;
-            }
+			@Override
+			public Integer visit(UnificationPredicate unificationPredicate, Void input) {
+				return Integer.MAX_VALUE;
+			}
 
-            @Override
-            public Integer visit(UserPredicate pred, Void input) {
-                if (pred.isNegated()) {
-                    return Integer.MAX_VALUE;
-                }
-                if (pred.getSymbol() instanceof DeltaSymbol) {
-                    return 125;
-                }
-                Term[] args = pred.getArgs();
-                if (args.length == 0) {
-                    return Integer.MAX_VALUE;
-                }
-                int bound = 0;
-                for (int i = 0; i < args.length; ++i) {
-                    if (boundVars.containsAll(args[i].varSet())) {
-                        bound++;
-                    }
-                }
-                double percentBound = ((double) bound) / args.length * 100;
-                return (int) percentBound;
-            }
+			@Override
+			public Integer visit(UserPredicate pred, Void input) {
+				if (pred.isNegated()) {
+					return Integer.MAX_VALUE;
+				}
+				if (pred.getSymbol() instanceof DeltaSymbol) {
+					return 125;
+				}
+				Term[] args = pred.getArgs();
+				if (args.length == 0) {
+					return Integer.MAX_VALUE;
+				}
+				int bound = 0;
+				for (int i = 0; i < args.length; ++i) {
+					if (boundVars.containsAll(args[i].varSet())) {
+						bound++;
+					}
+				}
+				double percentBound = ((double) bound) / args.length * 100;
+				return (int) percentBound;
+			}
 
-        }, null);
-    }
+		}, null);
+	}
 
-    static int score4(ComplexLiteral l, Set<Var> boundVars) {
-        return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
+	static int score4(ComplexLiteral l, Set<Var> boundVars) {
+		return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
 
-            @Override
-            public Integer visit(UnificationPredicate unificationPredicate, Void input) {
-                return Integer.MAX_VALUE;
-            }
+			@Override
+			public Integer visit(UnificationPredicate unificationPredicate, Void input) {
+				return Integer.MAX_VALUE;
+			}
 
-            @Override
-            public Integer visit(UserPredicate pred, Void input) {
-                if (pred.isNegated() || pred.getSymbol() instanceof DeltaSymbol) {
-                    return Integer.MAX_VALUE;
-                }
-                return 0;
-            }
+			@Override
+			public Integer visit(UserPredicate pred, Void input) {
+				if (pred.isNegated() || pred.getSymbol() instanceof DeltaSymbol) {
+					return Integer.MAX_VALUE;
+				}
+				return 0;
+			}
 
-        }, null);
-    }
-    
-    static int score5(ComplexLiteral l, Set<Var> boundVars) {
-        return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
+		}, null);
+	}
 
-            @Override
-            public Integer visit(UnificationPredicate unificationPredicate, Void input) {
-                return 0;
-            }
+	static int score5(ComplexLiteral l, Set<Var> boundVars) {
+		return l.accept(new ComplexLiteralVisitor<Void, Integer>() {
 
-            @Override
-            public Integer visit(UserPredicate pred, Void input) {
-                if (pred.getSymbol() instanceof DeltaSymbol) {
-                    return Integer.MAX_VALUE;
-                }
-                return 0;
-            }
+			@Override
+			public Integer visit(UnificationPredicate unificationPredicate, Void input) {
+				return 0;
+			}
 
-        }, null);
-    }
+			@Override
+			public Integer visit(UserPredicate pred, Void input) {
+				if (pred.getSymbol() instanceof DeltaSymbol) {
+					return Integer.MAX_VALUE;
+				}
+				return 0;
+			}
 
-    SemiNaiveEvaluation(WellTypedProgram inputProgram, SortedIndexedFactDb db,
-                        IndexedFactDbBuilder<SortedIndexedFactDb> deltaDbb, Map<RelationSymbol, Set<IndexedRule>> rules,
-                        UserPredicate query, List<Stratum> strata, CountingFJP exec, Set<RelationSymbol> trackedRelations,
-                        boolean eagerEval) {
-        this.inputProgram = inputProgram;
-        this.db = db;
-        this.query = query;
-        this.strata = strata;
-        this.exec = exec;
-        this.trackedRelations = trackedRelations;
-        this.deltaDb = deltaDbb.build();
-        this.nextDeltaDb = deltaDbb.build();
-        this.rules = rules;
-        this.eagerEval = eagerEval;
-    }
+		}, null);
+	}
 
-    @Override
-    public WellTypedProgram getInputProgram() {
-        return inputProgram;
-    }
+	SemiNaiveEvaluation(WellTypedProgram inputProgram, SortedIndexedFactDb db,
+			IndexedFactDbBuilder<SortedIndexedFactDb> deltaDbb, Map<RelationSymbol, Set<IndexedRule>> rules,
+			UserPredicate query, List<Stratum> strata, CountingFJP exec, Set<RelationSymbol> trackedRelations,
+			boolean eagerEval) {
+		this.inputProgram = inputProgram;
+		this.db = db;
+		this.query = query;
+		this.strata = strata;
+		this.exec = exec;
+		this.trackedRelations = trackedRelations;
+		this.deltaDb = deltaDbb.build();
+		this.nextDeltaDb = deltaDbb.build();
+		this.rules = rules;
+		this.eagerEval = eagerEval;
+	}
 
-    @Override
-    public synchronized void run() throws EvaluationException {
-        if (Configuration.printRelSizes) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
+	@Override
+	public WellTypedProgram getInputProgram() {
+		return inputProgram;
+	}
 
-                @Override
-                public void run() {
-                    Configuration.printRelSizes(System.err, "REL SIZE", db, true);
-                }
+	@Override
+	public synchronized void run() throws EvaluationException {
+		if (Configuration.printRelSizes) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
 
-            });
-        }
-        if (Configuration.debugParallelism) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
+				@Override
+				public void run() {
+					Configuration.printRelSizes(System.err, "REL SIZE", db, true);
+				}
 
-                @Override
-                public void run() {
-                    System.err.println("[STEAL COUNT] " + exec.getStealCount());
-                }
+			});
+		}
+		if (Configuration.debugParallelism) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
 
-            });
-        }
-        if (Configuration.recordWork) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    System.err.println("[WORK] " + Configuration.work.get());
-                }
-            });
-        }
-        for (Stratum stratum : strata) {
-            evaluateStratum(stratum);
-        }
-    }
+				@Override
+				public void run() {
+					System.err.println("[STEAL COUNT] " + exec.getStealCount());
+				}
 
-    private void evaluateStratum(Stratum stratum) throws EvaluationException {
-        List<IndexedRule> l = new ArrayList<>();
-        for (RelationSymbol sym : stratum.getPredicateSyms()) {
-            l.addAll(rules.get(sym));
-        }
-        if (eagerEval) {
-            new EagerStratumEvaluator(stratum.getRank(), db, l, exec, trackedRelations).evaluate();
-        } else {
-            new RoundBasedStratumEvaluator(stratum.getRank(), db, deltaDb, nextDeltaDb, l, exec, trackedRelations)
-                    .evaluate();
-        }
-    }
+			});
+		}
+		if (Configuration.recordWork) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+				@Override
+				public void run() {
+					System.err.println("[WORK] " + Configuration.work.get());
+				}
+			});
+		}
+		for (Stratum stratum : strata) {
+			evaluateStratum(stratum);
+		}
+	}
 
-    @Override
-    public synchronized EvaluationResult getResult() {
-        return new EvaluationResult() {
+	private void evaluateStratum(Stratum stratum) throws EvaluationException {
+		List<IndexedRule> l = new ArrayList<>();
+		for (RelationSymbol sym : stratum.getPredicateSyms()) {
+			l.addAll(rules.get(sym));
+		}
+		if (eagerEval) {
+			new EagerStratumEvaluator(stratum.getRank(), db, l, exec, trackedRelations).evaluate();
+		} else {
+			new RoundBasedStratumEvaluator(stratum.getRank(), db, deltaDb, nextDeltaDb, l, exec, trackedRelations)
+					.evaluate();
+		}
+	}
 
-            @Override
-            public Iterable<UserPredicate> getAll(RelationSymbol sym) {
-                if (!db.getSymbols().contains(sym)) {
-                    throw new IllegalArgumentException("Unrecognized relation symbol " + sym);
-                }
-                return () -> new FactIterator(sym, db.getAll(sym).iterator());
-            }
+	@Override
+	public synchronized EvaluationResult getResult() {
+		return new EvaluationResult() {
 
-            @Override
-            public Iterable<UserPredicate> getQueryAnswer() {
-                if (query == null) {
-                    return null;
-                }
-                RelationSymbol querySym = query.getSymbol();
-                return () -> new FactIterator(querySym, db.getAll(querySym).iterator());
-            }
+			@Override
+			public Iterable<UserPredicate> getAll(RelationSymbol sym) {
+				if (!db.getSymbols().contains(sym)) {
+					throw new IllegalArgumentException("Unrecognized relation symbol " + sym);
+				}
+				return () -> new FactIterator(sym, db.getAll(sym).iterator());
+			}
 
-            @Override
-            public Set<RelationSymbol> getSymbols() {
-                return Collections.unmodifiableSet(db.getSymbols());
-            }
+			@Override
+			public Iterable<UserPredicate> getQueryAnswer() {
+				if (query == null) {
+					return null;
+				}
+				RelationSymbol querySym = query.getSymbol();
+				return () -> new FactIterator(querySym, db.getAll(querySym).iterator());
+			}
 
-            @Override
-            public int getCount(RelationSymbol sym) {
-                return db.countDistinct(sym);
-            }
+			@Override
+			public Set<RelationSymbol> getSymbols() {
+				return Collections.unmodifiableSet(db.getSymbols());
+			}
 
-        };
-    }
+			@Override
+			public int getCount(RelationSymbol sym) {
+				return db.countDistinct(sym);
+			}
 
-    static class FactIterator implements Iterator<UserPredicate> {
+		};
+	}
 
-        final RelationSymbol sym;
-        final Iterator<Term[]> bindings;
+	static class FactIterator implements Iterator<UserPredicate> {
 
-        public FactIterator(RelationSymbol sym, Iterator<Term[]> bindings) {
-            this.sym = sym;
-            this.bindings = bindings;
-        }
+		final RelationSymbol sym;
+		final Iterator<Term[]> bindings;
 
-        @Override
-        public boolean hasNext() {
-            return bindings.hasNext();
-        }
+		public FactIterator(RelationSymbol sym, Iterator<Term[]> bindings) {
+			this.sym = sym;
+			this.bindings = bindings;
+		}
 
-        @Override
-        public UserPredicate next() {
-            return UserPredicate.make(sym, bindings.next(), false);
-        }
+		@Override
+		public boolean hasNext() {
+			return bindings.hasNext();
+		}
 
-    }
+		@Override
+		public UserPredicate next() {
+			return UserPredicate.make(sym, bindings.next(), false);
+		}
 
-    @Override
-    public boolean hasQuery() {
-        return query != null;
-    }
+	}
 
-    @Override
-    public UserPredicate getQuery() {
-        return query;
-    }
+	@Override
+	public boolean hasQuery() {
+		return query != null;
+	}
 
-    public SortedIndexedFactDb getDb() {
-        return db;
-    }
+	@Override
+	public UserPredicate getQuery() {
+		return query;
+	}
+
+	public SortedIndexedFactDb getDb() {
+		return db;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveRule.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -42,8 +41,9 @@ public class SemiNaiveRule extends AbstractRule<UserPredicate, ComplexLiteral> {
 	private SemiNaiveRule(UserPredicate head, List<ComplexLiteral> body) {
 		super(head, body);
 	}
-	
-	public static Set<SemiNaiveRule> make(Rule<UserPredicate, ComplexLiteral> rule, Set<RelationSymbol> stratumSymbols) {
+
+	public static Set<SemiNaiveRule> make(Rule<UserPredicate, ComplexLiteral> rule,
+			Set<RelationSymbol> stratumSymbols) {
 		Set<SemiNaiveRule> rules = new HashSet<>();
 		for (int i = 0; i < rule.getBodySize(); ++i) {
 			boolean canBeDelta = rule.getBody(i).accept(new ComplexLiteralVisitor<Void, Boolean>() {
@@ -57,7 +57,7 @@ public class SemiNaiveRule extends AbstractRule<UserPredicate, ComplexLiteral> {
 				public Boolean visit(UserPredicate userPredicate, Void input) {
 					return stratumSymbols.contains(userPredicate.getSymbol());
 				}
-				
+
 			}, null);
 			if (canBeDelta) {
 				rules.add(make(rule, stratumSymbols, i));
@@ -69,7 +69,8 @@ public class SemiNaiveRule extends AbstractRule<UserPredicate, ComplexLiteral> {
 		return rules;
 	}
 
-	private static SemiNaiveRule make(Rule<UserPredicate, ComplexLiteral> rule, Set<RelationSymbol> stratumSymbols, int deltaIdx) {
+	private static SemiNaiveRule make(Rule<UserPredicate, ComplexLiteral> rule, Set<RelationSymbol> stratumSymbols,
+			int deltaIdx) {
 		List<ComplexLiteral> body = new ArrayList<>();
 		for (int i = 0; i < rule.getBodySize(); ++i) {
 			ComplexLiteral l = rule.getBody(i);
@@ -83,7 +84,7 @@ public class SemiNaiveRule extends AbstractRule<UserPredicate, ComplexLiteral> {
 		}
 		return new SemiNaiveRule(rule.getHead(), body);
 	}
-	
+
 	public static class DeltaSymbol extends AbstractWrappedRelationSymbol<RelationSymbol> {
 
 		public DeltaSymbol(RelationSymbol baseSymbol) {
@@ -95,7 +96,7 @@ public class SemiNaiveRule extends AbstractRule<UserPredicate, ComplexLiteral> {
 		public String toString() {
 			return "delta:" + getBaseSymbol();
 		}
-		
+
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SmtCallFinder.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SmtCallFinder.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -53,7 +52,7 @@ public class SmtCallFinder {
 		smtCallSymbols.add(BuiltInFunctionSymbol.IS_VALID);
 		smtCallSymbols.add(BuiltInFunctionSymbol.GET_MODEL);
 	}
-	
+
 	public boolean containsSmtCall(Literal l) {
 		for (Term arg : l.getArgs()) {
 			if (arg.accept(tv, null)) {
@@ -126,7 +125,6 @@ public class SmtCallFinder {
 			}
 			return false;
 		}
-
 
 		@Override
 		public Boolean visit(LetFunExpr funcDef, Void in) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/StratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/StratumEvaluator.java
@@ -20,9 +20,8 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 public interface StratumEvaluator {
 
 	void evaluate() throws EvaluationException;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/UncheckedEvaluationException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/UncheckedEvaluationException.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 public class UncheckedEvaluationException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
 	public UncheckedEvaluationException() {
-		
+
 	}
 
 	public UncheckedEvaluationException(String message) {
@@ -41,7 +40,8 @@ public class UncheckedEvaluationException extends RuntimeException {
 		super(message, cause);
 	}
 
-	public UncheckedEvaluationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+	public UncheckedEvaluationException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/BuiltInFunctionDefFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/BuiltInFunctionDefFactory.java
@@ -43,1903 +43,1903 @@ import java.util.function.BiFunction;
 
 public final class BuiltInFunctionDefFactory {
 
-    private final SmtLibSolver smt;
-
-    public BuiltInFunctionDefFactory(SmtLibSolver smt) {
-        this.smt = smt;
-    }
-
-    public FunctionDef get(BuiltInFunctionSymbol sym) {
-        switch (sym) {
-            case I32_ADD:
-                return I32Add.INSTANCE;
-            case I32_SUB:
-                return I32Sub.INSTANCE;
-            case I32_MUL:
-                return I32Mul.INSTANCE;
-            case I32_SDIV:
-                return I32Sdiv.INSTANCE;
-            case I32_SREM:
-                return I32Srem.INSTANCE;
-            case I32_UDIV:
-                return i32Udiv;
-            case I32_UREM:
-                return i32Urem;
-            case I32_NEG:
-                return I32Neg.INSTANCE;
-            case I32_AND:
-                return I32And.INSTANCE;
-            case I32_OR:
-                return I32Or.INSTANCE;
-            case I32_XOR:
-                return I32Xor.INSTANCE;
-            case I32_GT:
-                return I32Gt.INSTANCE;
-            case I32_GE:
-                return I32Gte.INSTANCE;
-            case I32_LT:
-                return I32Lt.INSTANCE;
-            case I32_LE:
-                return I32Lte.INSTANCE;
-            case I32_SHL:
-                return i32Shl;
-            case I32_ASHR:
-                return i32Ashr;
-            case I32_LSHR:
-                return i32Lshr;
-            case I64_SHL:
-                return i64Shl;
-            case I64_ASHR:
-                return i64Ashr;
-            case I64_LSHR:
-                return i64Lshr;
-            case I64_ADD:
-                return I64Add.INSTANCE;
-            case I64_SUB:
-                return I64Sub.INSTANCE;
-            case I64_MUL:
-                return I64Mul.INSTANCE;
-            case I64_SDIV:
-                return I64Sdiv.INSTANCE;
-            case I64_SREM:
-                return I64Srem.INSTANCE;
-            case I64_UDIV:
-                return i64Udiv;
-            case I64_UREM:
-                return i64Urem;
-            case I64_NEG:
-                return I64Neg.INSTANCE;
-            case I64_AND:
-                return I64And.INSTANCE;
-            case I64_OR:
-                return I64Or.INSTANCE;
-            case I64_XOR:
-                return I64Xor.INSTANCE;
-            case I64_GT:
-                return I64Gt.INSTANCE;
-            case I64_GE:
-                return I64Gte.INSTANCE;
-            case I64_LT:
-                return I64Lt.INSTANCE;
-            case I64_LE:
-                return I64Lte.INSTANCE;
-            case FP32_ADD:
-                return FP32Add.INSTANCE;
-            case FP32_SUB:
-                return FP32Sub.INSTANCE;
-            case FP32_MUL:
-                return FP32Mul.INSTANCE;
-            case FP32_DIV:
-                return FP32Div.INSTANCE;
-            case FP32_REM:
-                return FP32Rem.INSTANCE;
-            case FP32_NEG:
-                return FP32Neg.INSTANCE;
-            case FP32_GT:
-                return FP32Gt.INSTANCE;
-            case FP32_GE:
-                return FP32Gte.INSTANCE;
-            case FP32_LT:
-                return FP32Lt.INSTANCE;
-            case FP32_LE:
-                return FP32Lte.INSTANCE;
-            case FP32_EQ:
-                return FP32Eq.INSTANCE;
-            case FP64_ADD:
-                return FP64Add.INSTANCE;
-            case FP64_SUB:
-                return FP64Sub.INSTANCE;
-            case FP64_MUL:
-                return FP64Mul.INSTANCE;
-            case FP64_DIV:
-                return FP64Div.INSTANCE;
-            case FP64_REM:
-                return FP64Rem.INSTANCE;
-            case FP64_NEG:
-                return FP64Neg.INSTANCE;
-            case FP64_GT:
-                return FP64Gt.INSTANCE;
-            case FP64_GE:
-                return FP64Gte.INSTANCE;
-            case FP64_LT:
-                return FP64Lt.INSTANCE;
-            case FP64_LE:
-                return FP64Lte.INSTANCE;
-            case FP64_EQ:
-                return FP64Eq.INSTANCE;
-            case BEQ:
-                return Beq.INSTANCE;
-            case BNEQ:
-                return Bneq.INSTANCE;
-            case BNOT:
-                return bnot;
-            case TO_STRING:
-                return ToString.INSTANCE;
-            case STRING_CMP:
-                return StringCmp.INSTANCE;
-            case I32_SCMP:
-                return I32Scmp.INSTANCE;
-            case I32_UCMP:
-                return I32Ucmp.INSTANCE;
-            case I64_SCMP:
-                return I64Scmp.INSTANCE;
-            case I64_UCMP:
-                return I64Ucmp.INSTANCE;
-            case STRING_CONCAT:
-                return StringConcat.INSTANCE;
-            case STRING_MATCHES:
-                return stringMatches;
-            case STRING_STARTS_WITH:
-                return stringStartsWith;
-            case STRING_TO_LIST:
-                return stringToList;
-            case LIST_TO_STRING:
-                return listToString;
-            case CHAR_AT:
-                return charAt;
-            case SUBSTRING:
-                return substring;
-            case STRING_LENGTH:
-                return stringLength;
-            case IS_SAT:
-                return isSat;
-            case IS_SAT_OPT:
-                return isSatOpt;
-            case IS_SET_SAT:
-                return isSetSat;
-            case IS_VALID:
-                return isValid;
-            case GET_MODEL:
-                return getModel;
-            case QUERY_MODEL:
-                return QueryModel.INSTANCE;
-            case fp32ToFp64:
-                return PrimitiveConversions.fp32ToFp64;
-            case fp32ToI32:
-                return PrimitiveConversions.fp32ToI32;
-            case fp32ToI64:
-                return PrimitiveConversions.fp32ToI64;
-            case fp64ToFp32:
-                return PrimitiveConversions.fp64ToFp32;
-            case fp64ToI32:
-                return PrimitiveConversions.fp64ToI32;
-            case fp64ToI64:
-                return PrimitiveConversions.fp64ToI64;
-            case i32ToFp32:
-                return PrimitiveConversions.i32ToFp32;
-            case i32ToFp64:
-                return PrimitiveConversions.i32ToFp64;
-            case i32ToI64:
-                return PrimitiveConversions.i32ToI64;
-            case i64ToFp32:
-                return PrimitiveConversions.i64ToFp32;
-            case i64ToFp64:
-                return PrimitiveConversions.i64ToFp64;
-            case i64ToI32:
-                return PrimitiveConversions.i64ToI32;
-            case stringToI32:
-                return PrimitiveConversions.stringToI32;
-            case stringToI64:
-                return PrimitiveConversions.stringToI64;
-            case PRINT:
-                return Print.INSTANCE;
-            case OPAQUE_SET_CHOOSE:
-                return OpaqueSetOps.choose;
-            case OPAQUE_SET_DIFF:
-                return OpaqueSetOps.diff;
-            case OPAQUE_SET_EMPTY:
-                return OpaqueSetOps.empty;
-            case OPAQUE_SET_MINUS:
-                return OpaqueSetOps.minus;
-            case OPAQUE_SET_PLUS:
-                return OpaqueSetOps.plus;
-            case OPAQUE_SET_SIZE:
-                return OpaqueSetOps.size;
-            case OPAQUE_SET_UNION:
-                return OpaqueSetOps.union;
-            case OPAQUE_SET_MEMBER:
-                return OpaqueSetOps.member;
-            case OPAQUE_SET_SINGLETON:
-                return OpaqueSetOps.singleton;
-            case OPAQUE_SET_SUBSET:
-                return OpaqueSetOps.subset;
-            case OPAQUE_SET_FROM_LIST:
-                return OpaqueSetOps.fromList;
-        }
-        throw new AssertionError();
-    }
-
-    private enum I32Add implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_ADD;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() + arg2.getVal());
-        }
-
-    }
-
-    private enum I32Sub implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_SUB;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() - arg2.getVal());
-        }
-
-    }
-
-    private enum I32Mul implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_MUL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() * arg2.getVal());
-        }
-
-    }
-
-    private enum I32Sdiv implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_SDIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return I32.make(arg1.getVal() / arg2.getVal());
-        }
-
-    }
-
-    private enum I32Srem implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_SREM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return I32.make(arg1.getVal() % arg2.getVal());
-        }
-
-    }
-
-    private static final FunctionDef i32Udiv = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_UDIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return I32.make(Integer.divideUnsigned(arg1.getVal(), arg2.getVal()));
-        }
-
-    };
-
-    private static final FunctionDef i32Urem = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_UREM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return I32.make(Integer.remainderUnsigned(arg1.getVal(), arg2.getVal()));
-        }
-
-    };
-
-    private enum I32Gt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_GT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return boolToBoolTerm(arg1.getVal() > arg2.getVal());
-        }
-
-    }
-
-    private enum I32Gte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_GE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
-        }
-
-    }
-
-    private enum I32Lt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_LT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return boolToBoolTerm(arg1.getVal() < arg2.getVal());
-        }
-
-    }
-
-    private enum I32Lte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_LE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
-        }
-
-    }
-
-    private enum I32And implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_AND;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() & arg2.getVal());
-        }
-
-    }
-
-    private enum I32Or implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_OR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() | arg2.getVal());
-        }
-
-    }
-
-    private enum I32Xor implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_XOR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() ^ arg2.getVal());
-        }
-
-    }
-
-    private enum I32Neg implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_NEG;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            return I32.make(-arg1.getVal());
-        }
-
-    }
-
-    private static final FunctionDef i32Shl = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_SHL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() << arg2.getVal());
-        }
-
-    };
-
-    private static final FunctionDef i32Ashr = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_ASHR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() >> arg2.getVal());
-        }
-
-    };
-
-    private static final FunctionDef i32Lshr = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_LSHR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I32 arg1 = (I32) args[0];
-            I32 arg2 = (I32) args[1];
-            return I32.make(arg1.getVal() >>> arg2.getVal());
-        }
-
-    };
-
-    private static final FunctionDef i64Shl = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_SHL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() << arg2.getVal());
-        }
-
-    };
-
-    private static final FunctionDef i64Ashr = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_ASHR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() >> arg2.getVal());
-        }
-
-    };
-
-    private static final FunctionDef i64Lshr = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_LSHR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() >>> arg2.getVal());
-        }
-
-    };
-
-    private enum I64Add implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_ADD;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() + arg2.getVal());
-        }
-
-    }
-
-    private enum I64Sub implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_SUB;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() - arg2.getVal());
-        }
-
-    }
-
-    private enum I64Mul implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_MUL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() * arg2.getVal());
-        }
-
-    }
-
-    private enum I64Sdiv implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_SDIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return I64.make(arg1.getVal() / arg2.getVal());
-        }
-
-    }
-
-    private enum I64Srem implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_SREM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return I64.make(arg1.getVal() % arg2.getVal());
-        }
-
-    }
-
-    private static final FunctionDef i64Udiv = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_UDIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return I64.make(Long.divideUnsigned(arg1.getVal(), arg2.getVal()));
-        }
-
-    };
-
-    private static final FunctionDef i64Urem = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_UREM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return I64.make(Long.remainderUnsigned(arg1.getVal(), arg2.getVal()));
-        }
-
-    };
-
-    private enum I64Gt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_GT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return boolToBoolTerm(arg1.getVal() > arg2.getVal());
-        }
-
-    }
-
-    private enum I64Gte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_GE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
-        }
-
-    }
-
-    private enum I64Lt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_LT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return boolToBoolTerm(arg1.getVal() < arg2.getVal());
-        }
-
-    }
-
-    private enum I64Lte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_LE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
-        }
-
-    }
-
-    private enum I64And implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_AND;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() & arg2.getVal());
-        }
-
-    }
-
-    private enum I64Or implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_OR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() | arg2.getVal());
-        }
-
-    }
-
-    private enum I64Xor implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_XOR;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            I64 arg2 = (I64) args[1];
-            return I64.make(arg1.getVal() ^ arg2.getVal());
-        }
-
-    }
-
-    private enum I64Neg implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_NEG;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            I64 arg1 = (I64) args[0];
-            return I64.make(-arg1.getVal());
-        }
-
-    }
-
-    private enum FP32Add implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_ADD;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return FP32.make(arg1.getVal() + arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Sub implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_SUB;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return FP32.make(arg1.getVal() - arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Mul implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_MUL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return FP32.make(arg1.getVal() * arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Div implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_DIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return FP32.make(arg1.getVal() / arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Rem implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_REM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return FP32.make(arg1.getVal() % arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Gt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_GT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return boolToBoolTerm(arg1.getVal() > arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Gte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_GE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Lt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_LT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return boolToBoolTerm(arg1.getVal() < arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Lte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_LE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
-        }
-
-    }
-
-    private enum FP32Eq implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_EQ;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            FP32 arg2 = (FP32) args[1];
-            return boolToBoolTerm(arg1.getVal().floatValue() == arg2.getVal().floatValue());
-        }
-
-    }
-
-    private enum FP32Neg implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP32_NEG;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP32 arg1 = (FP32) args[0];
-            return FP32.make(-arg1.getVal());
-        }
-
-    }
-
-    private enum FP64Add implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_ADD;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return FP64.make(arg1.getVal() + arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Sub implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_SUB;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return FP64.make(arg1.getVal() - arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Mul implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_MUL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return FP64.make(arg1.getVal() * arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Div implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_DIV;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Division by zero");
-            }
-            return FP64.make(arg1.getVal() / arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Rem implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_REM;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            if (arg2.getVal() == 0) {
-                throw new EvaluationException("Remainder by zero");
-            }
-            return FP64.make(arg1.getVal() % arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Gt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_GT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return boolToBoolTerm(arg1.getVal() > arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Gte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_GE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Lt implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_LT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return boolToBoolTerm(arg1.getVal() < arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Lte implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_LE;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
-        }
-
-    }
-
-    private enum FP64Eq implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_EQ;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            FP64 arg2 = (FP64) args[1];
-            return boolToBoolTerm(arg1.getVal().doubleValue() == arg2.getVal().doubleValue());
-        }
-
-    }
-
-    private enum FP64Neg implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.FP64_NEG;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            FP64 arg1 = (FP64) args[0];
-            return FP64.make(-arg1.getVal());
-        }
-
-    }
-
-    private enum Beq implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.BEQ;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            Term arg1 = args[0];
-            Term arg2 = args[1];
-            return boolToBoolTerm(arg1.equals(arg2));
-        }
-
-    }
-
-    private enum Bneq implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.BNEQ;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            Term arg1 = args[0];
-            Term arg2 = args[1];
-            return boolToBoolTerm(!arg1.equals(arg2));
-        }
-
-    }
-
-    private static final FunctionDef bnot = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.BNOT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            Term arg = args[0];
-            if (arg.equals(trueTerm)) {
-                return falseTerm;
-            }
-            return trueTerm;
-        }
-
-    };
-
-    private enum ToString implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.TO_STRING;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            Term arg = args[0];
-            if (arg instanceof StringTerm) {
-                return arg;
-            }
-            return StringTerm.make(args[0].toString());
-        }
-
-    }
-
-    private enum StringCmp implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_CMP;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s1 = ((StringTerm) args[0]).getVal();
-            String s2 = ((StringTerm) args[1]).getVal();
-            return makeCmp(s1, s2, (x, y) -> x.compareTo(y));
-        }
-
-    }
-
-    private enum I32Scmp implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_SCMP;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            int x = ((I32) args[0]).getVal();
-            int y = ((I32) args[1]).getVal();
-            return makeCmp(x, y, Integer::compare);
-        }
-
-    }
-
-    private enum I32Ucmp implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I32_UCMP;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            int x = ((I32) args[0]).getVal();
-            int y = ((I32) args[1]).getVal();
-            return makeCmp(x, y, Integer::compareUnsigned);
-        }
-
-    }
-
-    private enum I64Scmp implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_SCMP;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            long x = ((I64) args[0]).getVal();
-            long y = ((I64) args[1]).getVal();
-            return makeCmp(x, y, Long::compare);
-        }
-
-    }
-
-    private enum I64Ucmp implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.I64_UCMP;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            long x = ((I64) args[0]).getVal();
-            long y = ((I64) args[1]).getVal();
-            return makeCmp(x, y, Long::compareUnsigned);
-        }
-
-    }
-
-    private enum StringConcat implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_CONCAT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s1 = ((StringTerm) args[0]).getVal();
-            String s2 = ((StringTerm) args[1]).getVal();
-            return StringTerm.make(s1 + s2);
-        }
-
-    }
-
-    private static final FunctionDef stringMatches = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_MATCHES;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String str = ((StringTerm) args[0]).getVal();
-            String re = ((StringTerm) args[1]).getVal();
-            return boolToBoolTerm(str.matches(re));
-        }
-
-    };
-
-    private static final FunctionDef stringStartsWith = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_STARTS_WITH;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String str = ((StringTerm) args[0]).getVal();
-            String pre = ((StringTerm) args[1]).getVal();
-            return boolToBoolTerm(str.startsWith(pre));
-        }
-
-    };
-
-    private static final FunctionDef stringToList = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_TO_LIST;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s = ((StringTerm) args[0]).getVal();
-            List<I32> l = new ArrayList<>();
-            for (int i = 0; i < s.length(); ++i) {
-                l.add(I32.make(s.charAt(i)));
-            }
-            return Terms.termListToTerm(l);
-        }
-
-    };
-
-    private static final FunctionDef listToString = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.LIST_TO_STRING;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            List<I32> l = Terms.termToTermList(args[0]);
-            char[] cs = new char[l.size()];
-            int i = 0;
-            for (I32 c : l) {
-                cs[i] = (char) c.getVal().intValue();
-                i++;
-            }
-            return StringTerm.make(new String(cs));
-        }
-
-    };
-
-    private static final FunctionDef charAt = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.CHAR_AT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s = ((StringTerm) args[0]).getVal();
-            int i = ((I32) args[1]).getVal();
-            if (i < 0 || i >= s.length()) {
-                return Constructors.none();
-            }
-            return Constructors.some(I32.make(s.charAt(i)));
-        }
-
-    };
-
-    private static final FunctionDef substring = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.SUBSTRING;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s = ((StringTerm) args[0]).getVal();
-            int i = ((I32) args[1]).getVal();
-            int j = ((I32) args[2]).getVal();
-            if (i < 0 || j > s.length() || i > j) {
-                return Constructors.none();
-            }
-            return Constructors.some(StringTerm.make(s.substring(i, j)));
-        }
-
-    };
-
-    private static final FunctionDef stringLength = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.STRING_LENGTH;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            String s = ((StringTerm) args[0]).getVal();
-            return I32.make(s.length());
-        }
-
-    };
-
-    private final Map<Triple<Set<SmtLibTerm>, Boolean, Integer>, Future<SmtResult>> smtMemo = new ConcurrentHashMap<>();
-
-    private Pair<SmtStatus, Model> querySmt(SmtLibTerm assertions, boolean getModel) throws EvaluationException {
-        return querySmt(assertions, getModel, Integer.MAX_VALUE);
-    }
-
-    private Pair<SmtStatus, Model> querySmt(SmtLibTerm assertions, boolean getModel, int timeout)
-            throws EvaluationException {
-        return querySmt(breakIntoConjuncts(assertions), getModel, timeout);
-    }
-
-    private List<SmtLibTerm> breakIntoConjuncts(SmtLibTerm assertion) {
-        List<SmtLibTerm> l = new ArrayList<>();
-        breakIntoConjuncts(assertion, l);
-        return l;
-    }
-
-    private void breakIntoConjunctsNegated(SmtLibTerm assertion, List<SmtLibTerm> acc) {
-        if (assertion instanceof Constructor) {
-            Constructor c = (Constructor) assertion;
-            ConstructorSymbol sym = c.getSymbol();
-            Term[] args = c.getArgs();
-            if (sym.equals(BuiltInConstructorSymbol.SMT_NOT)) {
-                // Turn ~~A into A
-                breakIntoConjuncts((SmtLibTerm) args[0], acc);
-                return;
-            } else if (sym.equals(BuiltInConstructorSymbol.SMT_IMP)) {
-                // Turn ~(A => B) into A /\ ~B
-                breakIntoConjuncts((SmtLibTerm) args[0], acc);
-                breakIntoConjunctsNegated((SmtLibTerm) args[1], acc);
-                return;
-            } else if (sym.equals(BuiltInConstructorSymbol.SMT_OR)) {
-                // Turn ~(A \/ B) into ~A /\ ~B
-                breakIntoConjunctsNegated((SmtLibTerm) args[0], acc);
-                breakIntoConjunctsNegated((SmtLibTerm) args[1], acc);
-                return;
-            }
-        } else if (assertion.equals(trueTerm)) {
-            // Turn ~True into False
-            acc.add(falseTerm);
-            return;
-        }
-        if (!assertion.equals(falseTerm)) {
-            acc.add(negate(assertion));
-        }
-    }
-
-    private void breakIntoConjuncts(SmtLibTerm assertion, List<SmtLibTerm> acc) {
-        if (assertion instanceof Constructor) {
-            Constructor c = (Constructor) assertion;
-            ConstructorSymbol sym = c.getSymbol();
-            Term[] args = c.getArgs();
-            if (sym.equals(BuiltInConstructorSymbol.SMT_AND)) {
-                breakIntoConjuncts((SmtLibTerm) args[0], acc);
-                breakIntoConjuncts((SmtLibTerm) args[1], acc);
-                return;
-            } else if (sym.equals(BuiltInConstructorSymbol.SMT_NOT)) {
-                breakIntoConjunctsNegated((SmtLibTerm) args[0], acc);
-                return;
-            }
-        }
-        if (!assertion.equals(trueTerm)) {
-            acc.add(assertion);
-        }
-    }
-
-    private SmtLibTerm negate(Term t) {
-        return Constructors.make(BuiltInConstructorSymbol.SMT_NOT, Terms.singletonArray(t));
-    }
-
-    private Pair<SmtStatus, Model> querySmt(Collection<SmtLibTerm> assertions, boolean getModel, int timeout)
-            throws EvaluationException {
-        long start = System.nanoTime();
-        try {
-            if (timeout < 0) {
-                timeout = -1;
-            }
-            Set<SmtLibTerm> set = new LinkedHashSet<>(assertions);
-            if (set.contains(BoolTerm.mkFalse())) {
-                return new Pair<>(SmtStatus.UNSATISFIABLE, null);
-            }
-            set.remove(BoolTerm.mkTrue());
-            if (set.isEmpty()) {
-                Model m = getModel ? Model.make(Collections.emptyMap()) : null;
-                return new Pair<>(SmtStatus.SATISFIABLE, m);
-            }
-            SmtResult res;
-            if (Configuration.smtMemoize) {
-                res = querySmtWithMemo(set, getModel, timeout);
-            } else {
-                res = smt.check(set, getModel, timeout);
-            }
-            return new Pair<>(res.status, res.model);
-        } finally {
-            Configuration.recordSmtTime(System.nanoTime() - start);
-        }
-    }
-
-    private SmtResult querySmtWithMemo(Set<SmtLibTerm> assertions, boolean getModel, int timeout)
-            throws EvaluationException {
-        Triple<Set<SmtLibTerm>, Boolean, Integer> key = new Triple<>(assertions, getModel, timeout);
-        CompletableFuture<SmtResult> completableFut = new CompletableFuture<>();
-        Future<SmtResult> fut = smtMemo.putIfAbsent(key, completableFut);
-        if (fut == null) {
-            completableFut.complete(smt.check(assertions, getModel, timeout));
-            fut = completableFut;
-        }
-        long waitStart = 0;
-        if (Configuration.timeSmt) {
-            waitStart = System.nanoTime();
-        }
-        try {
-            return fut.get();
-        } catch (InterruptedException | ExecutionException e) {
-            throw new EvaluationException(e);
-        } finally {
-            if (Configuration.timeSmt) {
-                Configuration.recordSmtWaitTime(System.nanoTime() - waitStart);
-            }
-        }
-    }
-
-    private final FunctionDef isSat = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.IS_SAT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            SmtLibTerm formula = (SmtLibTerm) args[0];
-            Pair<SmtStatus, Model> p = querySmt(formula, false);
-            switch (p.fst()) {
-                case SATISFIABLE:
-                    return trueTerm;
-                case UNKNOWN:
-                    throw new EvaluationException("Z3 returned \"unknown\"");
-                case UNSATISFIABLE:
-                    return falseTerm;
-            }
-            throw new AssertionError("impossible");
-        }
-
-    };
-
-    private final FunctionDef isSatOpt = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.IS_SAT_OPT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            SmtLibTerm formula = (SmtLibTerm) args[0];
-            List<SmtLibTerm> assertions = Terms.termToTermList(formula);
-            Collections.reverse(assertions);
-            Constructor timeoutOpt = (Constructor) args[1];
-            Integer timeout = extractOptionalTimeout(timeoutOpt);
-            Pair<SmtStatus, Model> p = querySmt(assertions, false, timeout);
-            switch (p.fst()) {
-                case SATISFIABLE:
-                    return Constructors.some(trueTerm);
-                case UNKNOWN:
-                    return Constructors.none();
-                case UNSATISFIABLE:
-                    return Constructors.some(falseTerm);
-            }
-            throw new AssertionError("impossible");
-        }
-
-    };
-
-    private final FunctionDef isSetSat = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.IS_SET_SAT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            OpaqueSet formula = (OpaqueSet) args[0];
-            Constructor timeoutOpt = (Constructor) args[1];
-            Integer timeout = extractOptionalTimeout(timeoutOpt);
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            Pair<SmtStatus, Model> p = querySmt((Collection) formula.getCollection(), false, timeout);
-            switch (p.fst()) {
-                case SATISFIABLE:
-                    return Constructors.some(trueTerm);
-                case UNKNOWN:
-                    return Constructors.none();
-                case UNSATISFIABLE:
-                    return Constructors.some(falseTerm);
-            }
-            throw new AssertionError("impossible");
-        }
-
-    };
-
-    private final FunctionDef isValid = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.IS_VALID;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            SmtLibTerm formula = negate((SmtLibTerm) args[0]);
-            Pair<SmtStatus, Model> p = querySmt(formula, false);
-            switch (p.fst()) {
-                case SATISFIABLE:
-                    return falseTerm;
-                case UNKNOWN:
-                    throw new EvaluationException("Z3 returned \"unknown\"");
-                case UNSATISFIABLE:
-                    return trueTerm;
-            }
-            throw new AssertionError("impossible");
-        }
-
-    };
-
-    private static int extractOptionalTimeout(Constructor opt) {
-        if (opt.getSymbol().equals(BuiltInConstructorSymbol.SOME)) {
-            return ((I32) opt.getArgs()[0]).getVal();
-        }
-        return Integer.MAX_VALUE;
-    }
-
-    private final FunctionDef getModel = new FunctionDef() {
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.GET_MODEL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            List<SmtLibTerm> assertions = Terms.termToTermList((SmtLibTerm) args[0]);
-            Collections.reverse(assertions);
-            Constructor timeoutOpt = (Constructor) args[1];
-            Integer timeout = extractOptionalTimeout(timeoutOpt);
-            Pair<SmtStatus, Model> p = querySmt(assertions, true, timeout);
-            Model model = p.snd();
-            return model == null ? Constructors.none() : Constructors.some(model);
-        }
-
-    };
-
-    private enum QueryModel implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.QUERY_MODEL;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            SolverVariable x = (SolverVariable) args[0];
-            Model m = (Model) args[1];
-            Term t = m.getVal().get(x);
-            return t == null ? Constructors.none() : Constructors.some(t);
-        }
-
-    }
-
-    private static final SmtLibTerm trueTerm = BoolTerm.mkTrue();
-    private static final SmtLibTerm falseTerm = BoolTerm.mkFalse();
-
-    private static Term boolToBoolTerm(boolean b) {
-        if (b) {
-            return trueTerm;
-        } else {
-            return falseTerm;
-        }
-    }
-
-    private enum Print implements FunctionDef {
-
-        INSTANCE;
-
-        @Override
-        public FunctionSymbol getSymbol() {
-            return BuiltInFunctionSymbol.PRINT;
-        }
-
-        @Override
-        public Term evaluate(Term[] args) throws EvaluationException {
-            System.out.println(args[0]);
-            return trueTerm;
-        }
-
-    }
-
-    private static <T> Term makeCmp(T x, T y, BiFunction<T, T, Integer> cmp) {
-        int z = cmp.apply(x, y);
-        if (z < 0) {
-            return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_LT);
-        } else if (z > 0) {
-            return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_GT);
-        }
-        return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_EQ);
-    }
+	private final SmtLibSolver smt;
+
+	public BuiltInFunctionDefFactory(SmtLibSolver smt) {
+		this.smt = smt;
+	}
+
+	public FunctionDef get(BuiltInFunctionSymbol sym) {
+		switch (sym) {
+		case I32_ADD:
+			return I32Add.INSTANCE;
+		case I32_SUB:
+			return I32Sub.INSTANCE;
+		case I32_MUL:
+			return I32Mul.INSTANCE;
+		case I32_SDIV:
+			return I32Sdiv.INSTANCE;
+		case I32_SREM:
+			return I32Srem.INSTANCE;
+		case I32_UDIV:
+			return i32Udiv;
+		case I32_UREM:
+			return i32Urem;
+		case I32_NEG:
+			return I32Neg.INSTANCE;
+		case I32_AND:
+			return I32And.INSTANCE;
+		case I32_OR:
+			return I32Or.INSTANCE;
+		case I32_XOR:
+			return I32Xor.INSTANCE;
+		case I32_GT:
+			return I32Gt.INSTANCE;
+		case I32_GE:
+			return I32Gte.INSTANCE;
+		case I32_LT:
+			return I32Lt.INSTANCE;
+		case I32_LE:
+			return I32Lte.INSTANCE;
+		case I32_SHL:
+			return i32Shl;
+		case I32_ASHR:
+			return i32Ashr;
+		case I32_LSHR:
+			return i32Lshr;
+		case I64_SHL:
+			return i64Shl;
+		case I64_ASHR:
+			return i64Ashr;
+		case I64_LSHR:
+			return i64Lshr;
+		case I64_ADD:
+			return I64Add.INSTANCE;
+		case I64_SUB:
+			return I64Sub.INSTANCE;
+		case I64_MUL:
+			return I64Mul.INSTANCE;
+		case I64_SDIV:
+			return I64Sdiv.INSTANCE;
+		case I64_SREM:
+			return I64Srem.INSTANCE;
+		case I64_UDIV:
+			return i64Udiv;
+		case I64_UREM:
+			return i64Urem;
+		case I64_NEG:
+			return I64Neg.INSTANCE;
+		case I64_AND:
+			return I64And.INSTANCE;
+		case I64_OR:
+			return I64Or.INSTANCE;
+		case I64_XOR:
+			return I64Xor.INSTANCE;
+		case I64_GT:
+			return I64Gt.INSTANCE;
+		case I64_GE:
+			return I64Gte.INSTANCE;
+		case I64_LT:
+			return I64Lt.INSTANCE;
+		case I64_LE:
+			return I64Lte.INSTANCE;
+		case FP32_ADD:
+			return FP32Add.INSTANCE;
+		case FP32_SUB:
+			return FP32Sub.INSTANCE;
+		case FP32_MUL:
+			return FP32Mul.INSTANCE;
+		case FP32_DIV:
+			return FP32Div.INSTANCE;
+		case FP32_REM:
+			return FP32Rem.INSTANCE;
+		case FP32_NEG:
+			return FP32Neg.INSTANCE;
+		case FP32_GT:
+			return FP32Gt.INSTANCE;
+		case FP32_GE:
+			return FP32Gte.INSTANCE;
+		case FP32_LT:
+			return FP32Lt.INSTANCE;
+		case FP32_LE:
+			return FP32Lte.INSTANCE;
+		case FP32_EQ:
+			return FP32Eq.INSTANCE;
+		case FP64_ADD:
+			return FP64Add.INSTANCE;
+		case FP64_SUB:
+			return FP64Sub.INSTANCE;
+		case FP64_MUL:
+			return FP64Mul.INSTANCE;
+		case FP64_DIV:
+			return FP64Div.INSTANCE;
+		case FP64_REM:
+			return FP64Rem.INSTANCE;
+		case FP64_NEG:
+			return FP64Neg.INSTANCE;
+		case FP64_GT:
+			return FP64Gt.INSTANCE;
+		case FP64_GE:
+			return FP64Gte.INSTANCE;
+		case FP64_LT:
+			return FP64Lt.INSTANCE;
+		case FP64_LE:
+			return FP64Lte.INSTANCE;
+		case FP64_EQ:
+			return FP64Eq.INSTANCE;
+		case BEQ:
+			return Beq.INSTANCE;
+		case BNEQ:
+			return Bneq.INSTANCE;
+		case BNOT:
+			return bnot;
+		case TO_STRING:
+			return ToString.INSTANCE;
+		case STRING_CMP:
+			return StringCmp.INSTANCE;
+		case I32_SCMP:
+			return I32Scmp.INSTANCE;
+		case I32_UCMP:
+			return I32Ucmp.INSTANCE;
+		case I64_SCMP:
+			return I64Scmp.INSTANCE;
+		case I64_UCMP:
+			return I64Ucmp.INSTANCE;
+		case STRING_CONCAT:
+			return StringConcat.INSTANCE;
+		case STRING_MATCHES:
+			return stringMatches;
+		case STRING_STARTS_WITH:
+			return stringStartsWith;
+		case STRING_TO_LIST:
+			return stringToList;
+		case LIST_TO_STRING:
+			return listToString;
+		case CHAR_AT:
+			return charAt;
+		case SUBSTRING:
+			return substring;
+		case STRING_LENGTH:
+			return stringLength;
+		case IS_SAT:
+			return isSat;
+		case IS_SAT_OPT:
+			return isSatOpt;
+		case IS_SET_SAT:
+			return isSetSat;
+		case IS_VALID:
+			return isValid;
+		case GET_MODEL:
+			return getModel;
+		case QUERY_MODEL:
+			return QueryModel.INSTANCE;
+		case fp32ToFp64:
+			return PrimitiveConversions.fp32ToFp64;
+		case fp32ToI32:
+			return PrimitiveConversions.fp32ToI32;
+		case fp32ToI64:
+			return PrimitiveConversions.fp32ToI64;
+		case fp64ToFp32:
+			return PrimitiveConversions.fp64ToFp32;
+		case fp64ToI32:
+			return PrimitiveConversions.fp64ToI32;
+		case fp64ToI64:
+			return PrimitiveConversions.fp64ToI64;
+		case i32ToFp32:
+			return PrimitiveConversions.i32ToFp32;
+		case i32ToFp64:
+			return PrimitiveConversions.i32ToFp64;
+		case i32ToI64:
+			return PrimitiveConversions.i32ToI64;
+		case i64ToFp32:
+			return PrimitiveConversions.i64ToFp32;
+		case i64ToFp64:
+			return PrimitiveConversions.i64ToFp64;
+		case i64ToI32:
+			return PrimitiveConversions.i64ToI32;
+		case stringToI32:
+			return PrimitiveConversions.stringToI32;
+		case stringToI64:
+			return PrimitiveConversions.stringToI64;
+		case PRINT:
+			return Print.INSTANCE;
+		case OPAQUE_SET_CHOOSE:
+			return OpaqueSetOps.choose;
+		case OPAQUE_SET_DIFF:
+			return OpaqueSetOps.diff;
+		case OPAQUE_SET_EMPTY:
+			return OpaqueSetOps.empty;
+		case OPAQUE_SET_MINUS:
+			return OpaqueSetOps.minus;
+		case OPAQUE_SET_PLUS:
+			return OpaqueSetOps.plus;
+		case OPAQUE_SET_SIZE:
+			return OpaqueSetOps.size;
+		case OPAQUE_SET_UNION:
+			return OpaqueSetOps.union;
+		case OPAQUE_SET_MEMBER:
+			return OpaqueSetOps.member;
+		case OPAQUE_SET_SINGLETON:
+			return OpaqueSetOps.singleton;
+		case OPAQUE_SET_SUBSET:
+			return OpaqueSetOps.subset;
+		case OPAQUE_SET_FROM_LIST:
+			return OpaqueSetOps.fromList;
+		}
+		throw new AssertionError();
+	}
+
+	private enum I32Add implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_ADD;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() + arg2.getVal());
+		}
+
+	}
+
+	private enum I32Sub implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_SUB;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() - arg2.getVal());
+		}
+
+	}
+
+	private enum I32Mul implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_MUL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() * arg2.getVal());
+		}
+
+	}
+
+	private enum I32Sdiv implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_SDIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return I32.make(arg1.getVal() / arg2.getVal());
+		}
+
+	}
+
+	private enum I32Srem implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_SREM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return I32.make(arg1.getVal() % arg2.getVal());
+		}
+
+	}
+
+	private static final FunctionDef i32Udiv = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_UDIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return I32.make(Integer.divideUnsigned(arg1.getVal(), arg2.getVal()));
+		}
+
+	};
+
+	private static final FunctionDef i32Urem = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_UREM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return I32.make(Integer.remainderUnsigned(arg1.getVal(), arg2.getVal()));
+		}
+
+	};
+
+	private enum I32Gt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_GT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return boolToBoolTerm(arg1.getVal() > arg2.getVal());
+		}
+
+	}
+
+	private enum I32Gte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_GE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
+		}
+
+	}
+
+	private enum I32Lt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_LT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return boolToBoolTerm(arg1.getVal() < arg2.getVal());
+		}
+
+	}
+
+	private enum I32Lte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_LE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
+		}
+
+	}
+
+	private enum I32And implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_AND;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() & arg2.getVal());
+		}
+
+	}
+
+	private enum I32Or implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_OR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() | arg2.getVal());
+		}
+
+	}
+
+	private enum I32Xor implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_XOR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() ^ arg2.getVal());
+		}
+
+	}
+
+	private enum I32Neg implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_NEG;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			return I32.make(-arg1.getVal());
+		}
+
+	}
+
+	private static final FunctionDef i32Shl = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_SHL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() << arg2.getVal());
+		}
+
+	};
+
+	private static final FunctionDef i32Ashr = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_ASHR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() >> arg2.getVal());
+		}
+
+	};
+
+	private static final FunctionDef i32Lshr = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_LSHR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I32 arg1 = (I32) args[0];
+			I32 arg2 = (I32) args[1];
+			return I32.make(arg1.getVal() >>> arg2.getVal());
+		}
+
+	};
+
+	private static final FunctionDef i64Shl = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_SHL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() << arg2.getVal());
+		}
+
+	};
+
+	private static final FunctionDef i64Ashr = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_ASHR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() >> arg2.getVal());
+		}
+
+	};
+
+	private static final FunctionDef i64Lshr = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_LSHR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() >>> arg2.getVal());
+		}
+
+	};
+
+	private enum I64Add implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_ADD;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() + arg2.getVal());
+		}
+
+	}
+
+	private enum I64Sub implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_SUB;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() - arg2.getVal());
+		}
+
+	}
+
+	private enum I64Mul implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_MUL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() * arg2.getVal());
+		}
+
+	}
+
+	private enum I64Sdiv implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_SDIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return I64.make(arg1.getVal() / arg2.getVal());
+		}
+
+	}
+
+	private enum I64Srem implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_SREM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return I64.make(arg1.getVal() % arg2.getVal());
+		}
+
+	}
+
+	private static final FunctionDef i64Udiv = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_UDIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return I64.make(Long.divideUnsigned(arg1.getVal(), arg2.getVal()));
+		}
+
+	};
+
+	private static final FunctionDef i64Urem = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_UREM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return I64.make(Long.remainderUnsigned(arg1.getVal(), arg2.getVal()));
+		}
+
+	};
+
+	private enum I64Gt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_GT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return boolToBoolTerm(arg1.getVal() > arg2.getVal());
+		}
+
+	}
+
+	private enum I64Gte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_GE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
+		}
+
+	}
+
+	private enum I64Lt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_LT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return boolToBoolTerm(arg1.getVal() < arg2.getVal());
+		}
+
+	}
+
+	private enum I64Lte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_LE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
+		}
+
+	}
+
+	private enum I64And implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_AND;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() & arg2.getVal());
+		}
+
+	}
+
+	private enum I64Or implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_OR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() | arg2.getVal());
+		}
+
+	}
+
+	private enum I64Xor implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_XOR;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			I64 arg2 = (I64) args[1];
+			return I64.make(arg1.getVal() ^ arg2.getVal());
+		}
+
+	}
+
+	private enum I64Neg implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_NEG;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			I64 arg1 = (I64) args[0];
+			return I64.make(-arg1.getVal());
+		}
+
+	}
+
+	private enum FP32Add implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_ADD;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return FP32.make(arg1.getVal() + arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Sub implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_SUB;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return FP32.make(arg1.getVal() - arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Mul implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_MUL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return FP32.make(arg1.getVal() * arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Div implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_DIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return FP32.make(arg1.getVal() / arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Rem implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_REM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return FP32.make(arg1.getVal() % arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Gt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_GT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return boolToBoolTerm(arg1.getVal() > arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Gte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_GE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Lt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_LT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return boolToBoolTerm(arg1.getVal() < arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Lte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_LE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
+		}
+
+	}
+
+	private enum FP32Eq implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_EQ;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			FP32 arg2 = (FP32) args[1];
+			return boolToBoolTerm(arg1.getVal().floatValue() == arg2.getVal().floatValue());
+		}
+
+	}
+
+	private enum FP32Neg implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP32_NEG;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP32 arg1 = (FP32) args[0];
+			return FP32.make(-arg1.getVal());
+		}
+
+	}
+
+	private enum FP64Add implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_ADD;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return FP64.make(arg1.getVal() + arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Sub implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_SUB;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return FP64.make(arg1.getVal() - arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Mul implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_MUL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return FP64.make(arg1.getVal() * arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Div implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_DIV;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Division by zero");
+			}
+			return FP64.make(arg1.getVal() / arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Rem implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_REM;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			if (arg2.getVal() == 0) {
+				throw new EvaluationException("Remainder by zero");
+			}
+			return FP64.make(arg1.getVal() % arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Gt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_GT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return boolToBoolTerm(arg1.getVal() > arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Gte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_GE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return boolToBoolTerm(arg1.getVal() >= arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Lt implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_LT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return boolToBoolTerm(arg1.getVal() < arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Lte implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_LE;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return boolToBoolTerm(arg1.getVal() <= arg2.getVal());
+		}
+
+	}
+
+	private enum FP64Eq implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_EQ;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			FP64 arg2 = (FP64) args[1];
+			return boolToBoolTerm(arg1.getVal().doubleValue() == arg2.getVal().doubleValue());
+		}
+
+	}
+
+	private enum FP64Neg implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.FP64_NEG;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			FP64 arg1 = (FP64) args[0];
+			return FP64.make(-arg1.getVal());
+		}
+
+	}
+
+	private enum Beq implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.BEQ;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			Term arg1 = args[0];
+			Term arg2 = args[1];
+			return boolToBoolTerm(arg1.equals(arg2));
+		}
+
+	}
+
+	private enum Bneq implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.BNEQ;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			Term arg1 = args[0];
+			Term arg2 = args[1];
+			return boolToBoolTerm(!arg1.equals(arg2));
+		}
+
+	}
+
+	private static final FunctionDef bnot = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.BNOT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			Term arg = args[0];
+			if (arg.equals(trueTerm)) {
+				return falseTerm;
+			}
+			return trueTerm;
+		}
+
+	};
+
+	private enum ToString implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.TO_STRING;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			Term arg = args[0];
+			if (arg instanceof StringTerm) {
+				return arg;
+			}
+			return StringTerm.make(args[0].toString());
+		}
+
+	}
+
+	private enum StringCmp implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_CMP;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s1 = ((StringTerm) args[0]).getVal();
+			String s2 = ((StringTerm) args[1]).getVal();
+			return makeCmp(s1, s2, (x, y) -> x.compareTo(y));
+		}
+
+	}
+
+	private enum I32Scmp implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_SCMP;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			int x = ((I32) args[0]).getVal();
+			int y = ((I32) args[1]).getVal();
+			return makeCmp(x, y, Integer::compare);
+		}
+
+	}
+
+	private enum I32Ucmp implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I32_UCMP;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			int x = ((I32) args[0]).getVal();
+			int y = ((I32) args[1]).getVal();
+			return makeCmp(x, y, Integer::compareUnsigned);
+		}
+
+	}
+
+	private enum I64Scmp implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_SCMP;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			long x = ((I64) args[0]).getVal();
+			long y = ((I64) args[1]).getVal();
+			return makeCmp(x, y, Long::compare);
+		}
+
+	}
+
+	private enum I64Ucmp implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.I64_UCMP;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			long x = ((I64) args[0]).getVal();
+			long y = ((I64) args[1]).getVal();
+			return makeCmp(x, y, Long::compareUnsigned);
+		}
+
+	}
+
+	private enum StringConcat implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_CONCAT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s1 = ((StringTerm) args[0]).getVal();
+			String s2 = ((StringTerm) args[1]).getVal();
+			return StringTerm.make(s1 + s2);
+		}
+
+	}
+
+	private static final FunctionDef stringMatches = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_MATCHES;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String str = ((StringTerm) args[0]).getVal();
+			String re = ((StringTerm) args[1]).getVal();
+			return boolToBoolTerm(str.matches(re));
+		}
+
+	};
+
+	private static final FunctionDef stringStartsWith = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_STARTS_WITH;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String str = ((StringTerm) args[0]).getVal();
+			String pre = ((StringTerm) args[1]).getVal();
+			return boolToBoolTerm(str.startsWith(pre));
+		}
+
+	};
+
+	private static final FunctionDef stringToList = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_TO_LIST;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s = ((StringTerm) args[0]).getVal();
+			List<I32> l = new ArrayList<>();
+			for (int i = 0; i < s.length(); ++i) {
+				l.add(I32.make(s.charAt(i)));
+			}
+			return Terms.termListToTerm(l);
+		}
+
+	};
+
+	private static final FunctionDef listToString = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.LIST_TO_STRING;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			List<I32> l = Terms.termToTermList(args[0]);
+			char[] cs = new char[l.size()];
+			int i = 0;
+			for (I32 c : l) {
+				cs[i] = (char) c.getVal().intValue();
+				i++;
+			}
+			return StringTerm.make(new String(cs));
+		}
+
+	};
+
+	private static final FunctionDef charAt = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.CHAR_AT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s = ((StringTerm) args[0]).getVal();
+			int i = ((I32) args[1]).getVal();
+			if (i < 0 || i >= s.length()) {
+				return Constructors.none();
+			}
+			return Constructors.some(I32.make(s.charAt(i)));
+		}
+
+	};
+
+	private static final FunctionDef substring = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.SUBSTRING;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s = ((StringTerm) args[0]).getVal();
+			int i = ((I32) args[1]).getVal();
+			int j = ((I32) args[2]).getVal();
+			if (i < 0 || j > s.length() || i > j) {
+				return Constructors.none();
+			}
+			return Constructors.some(StringTerm.make(s.substring(i, j)));
+		}
+
+	};
+
+	private static final FunctionDef stringLength = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.STRING_LENGTH;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			String s = ((StringTerm) args[0]).getVal();
+			return I32.make(s.length());
+		}
+
+	};
+
+	private final Map<Triple<Set<SmtLibTerm>, Boolean, Integer>, Future<SmtResult>> smtMemo = new ConcurrentHashMap<>();
+
+	private Pair<SmtStatus, Model> querySmt(SmtLibTerm assertions, boolean getModel) throws EvaluationException {
+		return querySmt(assertions, getModel, Integer.MAX_VALUE);
+	}
+
+	private Pair<SmtStatus, Model> querySmt(SmtLibTerm assertions, boolean getModel, int timeout)
+			throws EvaluationException {
+		return querySmt(breakIntoConjuncts(assertions), getModel, timeout);
+	}
+
+	private List<SmtLibTerm> breakIntoConjuncts(SmtLibTerm assertion) {
+		List<SmtLibTerm> l = new ArrayList<>();
+		breakIntoConjuncts(assertion, l);
+		return l;
+	}
+
+	private void breakIntoConjunctsNegated(SmtLibTerm assertion, List<SmtLibTerm> acc) {
+		if (assertion instanceof Constructor) {
+			Constructor c = (Constructor) assertion;
+			ConstructorSymbol sym = c.getSymbol();
+			Term[] args = c.getArgs();
+			if (sym.equals(BuiltInConstructorSymbol.SMT_NOT)) {
+				// Turn ~~A into A
+				breakIntoConjuncts((SmtLibTerm) args[0], acc);
+				return;
+			} else if (sym.equals(BuiltInConstructorSymbol.SMT_IMP)) {
+				// Turn ~(A => B) into A /\ ~B
+				breakIntoConjuncts((SmtLibTerm) args[0], acc);
+				breakIntoConjunctsNegated((SmtLibTerm) args[1], acc);
+				return;
+			} else if (sym.equals(BuiltInConstructorSymbol.SMT_OR)) {
+				// Turn ~(A \/ B) into ~A /\ ~B
+				breakIntoConjunctsNegated((SmtLibTerm) args[0], acc);
+				breakIntoConjunctsNegated((SmtLibTerm) args[1], acc);
+				return;
+			}
+		} else if (assertion.equals(trueTerm)) {
+			// Turn ~True into False
+			acc.add(falseTerm);
+			return;
+		}
+		if (!assertion.equals(falseTerm)) {
+			acc.add(negate(assertion));
+		}
+	}
+
+	private void breakIntoConjuncts(SmtLibTerm assertion, List<SmtLibTerm> acc) {
+		if (assertion instanceof Constructor) {
+			Constructor c = (Constructor) assertion;
+			ConstructorSymbol sym = c.getSymbol();
+			Term[] args = c.getArgs();
+			if (sym.equals(BuiltInConstructorSymbol.SMT_AND)) {
+				breakIntoConjuncts((SmtLibTerm) args[0], acc);
+				breakIntoConjuncts((SmtLibTerm) args[1], acc);
+				return;
+			} else if (sym.equals(BuiltInConstructorSymbol.SMT_NOT)) {
+				breakIntoConjunctsNegated((SmtLibTerm) args[0], acc);
+				return;
+			}
+		}
+		if (!assertion.equals(trueTerm)) {
+			acc.add(assertion);
+		}
+	}
+
+	private SmtLibTerm negate(Term t) {
+		return Constructors.make(BuiltInConstructorSymbol.SMT_NOT, Terms.singletonArray(t));
+	}
+
+	private Pair<SmtStatus, Model> querySmt(Collection<SmtLibTerm> assertions, boolean getModel, int timeout)
+			throws EvaluationException {
+		long start = System.nanoTime();
+		try {
+			if (timeout < 0) {
+				timeout = -1;
+			}
+			Set<SmtLibTerm> set = new LinkedHashSet<>(assertions);
+			if (set.contains(BoolTerm.mkFalse())) {
+				return new Pair<>(SmtStatus.UNSATISFIABLE, null);
+			}
+			set.remove(BoolTerm.mkTrue());
+			if (set.isEmpty()) {
+				Model m = getModel ? Model.make(Collections.emptyMap()) : null;
+				return new Pair<>(SmtStatus.SATISFIABLE, m);
+			}
+			SmtResult res;
+			if (Configuration.smtMemoize) {
+				res = querySmtWithMemo(set, getModel, timeout);
+			} else {
+				res = smt.check(set, getModel, timeout);
+			}
+			return new Pair<>(res.status, res.model);
+		} finally {
+			Configuration.recordSmtTime(System.nanoTime() - start);
+		}
+	}
+
+	private SmtResult querySmtWithMemo(Set<SmtLibTerm> assertions, boolean getModel, int timeout)
+			throws EvaluationException {
+		Triple<Set<SmtLibTerm>, Boolean, Integer> key = new Triple<>(assertions, getModel, timeout);
+		CompletableFuture<SmtResult> completableFut = new CompletableFuture<>();
+		Future<SmtResult> fut = smtMemo.putIfAbsent(key, completableFut);
+		if (fut == null) {
+			completableFut.complete(smt.check(assertions, getModel, timeout));
+			fut = completableFut;
+		}
+		long waitStart = 0;
+		if (Configuration.timeSmt) {
+			waitStart = System.nanoTime();
+		}
+		try {
+			return fut.get();
+		} catch (InterruptedException | ExecutionException e) {
+			throw new EvaluationException(e);
+		} finally {
+			if (Configuration.timeSmt) {
+				Configuration.recordSmtWaitTime(System.nanoTime() - waitStart);
+			}
+		}
+	}
+
+	private final FunctionDef isSat = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.IS_SAT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			SmtLibTerm formula = (SmtLibTerm) args[0];
+			Pair<SmtStatus, Model> p = querySmt(formula, false);
+			switch (p.fst()) {
+			case SATISFIABLE:
+				return trueTerm;
+			case UNKNOWN:
+				throw new EvaluationException("Z3 returned \"unknown\"");
+			case UNSATISFIABLE:
+				return falseTerm;
+			}
+			throw new AssertionError("impossible");
+		}
+
+	};
+
+	private final FunctionDef isSatOpt = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.IS_SAT_OPT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			SmtLibTerm formula = (SmtLibTerm) args[0];
+			List<SmtLibTerm> assertions = Terms.termToTermList(formula);
+			Collections.reverse(assertions);
+			Constructor timeoutOpt = (Constructor) args[1];
+			Integer timeout = extractOptionalTimeout(timeoutOpt);
+			Pair<SmtStatus, Model> p = querySmt(assertions, false, timeout);
+			switch (p.fst()) {
+			case SATISFIABLE:
+				return Constructors.some(trueTerm);
+			case UNKNOWN:
+				return Constructors.none();
+			case UNSATISFIABLE:
+				return Constructors.some(falseTerm);
+			}
+			throw new AssertionError("impossible");
+		}
+
+	};
+
+	private final FunctionDef isSetSat = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.IS_SET_SAT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			OpaqueSet formula = (OpaqueSet) args[0];
+			Constructor timeoutOpt = (Constructor) args[1];
+			Integer timeout = extractOptionalTimeout(timeoutOpt);
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			Pair<SmtStatus, Model> p = querySmt((Collection) formula.getCollection(), false, timeout);
+			switch (p.fst()) {
+			case SATISFIABLE:
+				return Constructors.some(trueTerm);
+			case UNKNOWN:
+				return Constructors.none();
+			case UNSATISFIABLE:
+				return Constructors.some(falseTerm);
+			}
+			throw new AssertionError("impossible");
+		}
+
+	};
+
+	private final FunctionDef isValid = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.IS_VALID;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			SmtLibTerm formula = negate((SmtLibTerm) args[0]);
+			Pair<SmtStatus, Model> p = querySmt(formula, false);
+			switch (p.fst()) {
+			case SATISFIABLE:
+				return falseTerm;
+			case UNKNOWN:
+				throw new EvaluationException("Z3 returned \"unknown\"");
+			case UNSATISFIABLE:
+				return trueTerm;
+			}
+			throw new AssertionError("impossible");
+		}
+
+	};
+
+	private static int extractOptionalTimeout(Constructor opt) {
+		if (opt.getSymbol().equals(BuiltInConstructorSymbol.SOME)) {
+			return ((I32) opt.getArgs()[0]).getVal();
+		}
+		return Integer.MAX_VALUE;
+	}
+
+	private final FunctionDef getModel = new FunctionDef() {
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.GET_MODEL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			List<SmtLibTerm> assertions = Terms.termToTermList((SmtLibTerm) args[0]);
+			Collections.reverse(assertions);
+			Constructor timeoutOpt = (Constructor) args[1];
+			Integer timeout = extractOptionalTimeout(timeoutOpt);
+			Pair<SmtStatus, Model> p = querySmt(assertions, true, timeout);
+			Model model = p.snd();
+			return model == null ? Constructors.none() : Constructors.some(model);
+		}
+
+	};
+
+	private enum QueryModel implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.QUERY_MODEL;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			SolverVariable x = (SolverVariable) args[0];
+			Model m = (Model) args[1];
+			Term t = m.getVal().get(x);
+			return t == null ? Constructors.none() : Constructors.some(t);
+		}
+
+	}
+
+	private static final SmtLibTerm trueTerm = BoolTerm.mkTrue();
+	private static final SmtLibTerm falseTerm = BoolTerm.mkFalse();
+
+	private static Term boolToBoolTerm(boolean b) {
+		if (b) {
+			return trueTerm;
+		} else {
+			return falseTerm;
+		}
+	}
+
+	private enum Print implements FunctionDef {
+
+		INSTANCE;
+
+		@Override
+		public FunctionSymbol getSymbol() {
+			return BuiltInFunctionSymbol.PRINT;
+		}
+
+		@Override
+		public Term evaluate(Term[] args) throws EvaluationException {
+			System.out.println(args[0]);
+			return trueTerm;
+		}
+
+	}
+
+	private static <T> Term makeCmp(T x, T y, BiFunction<T, T, Integer> cmp) {
+		int z = cmp.apply(x, y);
+		if (z < 0) {
+			return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_LT);
+		} else if (z > 0) {
+			return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_GT);
+		}
+		return Constructors.makeZeroAry(BuiltInConstructorSymbol.CMP_EQ);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/DummyFunctionDef.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/DummyFunctionDef.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.functions;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
@@ -29,11 +28,11 @@ public class DummyFunctionDef implements FunctionDef {
 
 	private final FunctionSymbol sym;
 	private volatile FunctionDef def;
-	
+
 	public DummyFunctionDef(FunctionSymbol sym) {
 		this.sym = sym;
 	}
-	
+
 	@Override
 	public FunctionSymbol getSymbol() {
 		return sym;
@@ -46,7 +45,7 @@ public class DummyFunctionDef implements FunctionDef {
 		}
 		return def.evaluate(args);
 	}
-	
+
 	public void setDef(FunctionDef def) {
 		this.def = def;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/FunctionDef.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/FunctionDef.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.functions;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
@@ -28,7 +27,7 @@ import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
 public interface FunctionDef {
 
 	FunctionSymbol getSymbol();
-	
+
 	Term evaluate(Term[] args) throws EvaluationException;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/FunctionDefManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/FunctionDefManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.functions;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,7 +39,7 @@ public class FunctionDefManager {
 			memo.put(sym, new DummyFunctionDef(sym));
 		}
 	}
-	
+
 	public void register(FunctionDef def) {
 		if (memo.put(def.getSymbol(), def) != null) {
 			throw new IllegalArgumentException(

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/OpaqueSetOps.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/OpaqueSetOps.java
@@ -36,7 +36,7 @@ public final class OpaqueSetOps {
 	private OpaqueSetOps() {
 		throw new AssertionError("impossible");
 	}
-	
+
 	public static final FunctionDef empty = new FunctionDef() {
 
 		@Override
@@ -48,9 +48,9 @@ public final class OpaqueSetOps {
 		public Term evaluate(Term[] args) throws EvaluationException {
 			return OpaqueSet.empty();
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef size = new FunctionDef() {
 
 		@Override
@@ -63,9 +63,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s = (OpaqueSet) args[0];
 			return I32.make(s.size());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef plus = new FunctionDef() {
 
 		@Override
@@ -78,9 +78,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s = (OpaqueSet) args[1];
 			return s.plus(args[0]);
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef minus = new FunctionDef() {
 
 		@Override
@@ -93,9 +93,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s = (OpaqueSet) args[1];
 			return s.minus(args[0]);
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef union = new FunctionDef() {
 
 		@Override
@@ -109,9 +109,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s2 = (OpaqueSet) args[1];
 			return s1.union(s2);
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef diff = new FunctionDef() {
 
 		@Override
@@ -125,9 +125,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s2 = (OpaqueSet) args[1];
 			return s1.diff(s2);
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef choose = new FunctionDef() {
 
 		@Override
@@ -144,9 +144,9 @@ public final class OpaqueSetOps {
 			}
 			return Constructors.some(Constructors.tuple(p.fst(), p.snd()));
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef member = new FunctionDef() {
 
 		@Override
@@ -159,9 +159,9 @@ public final class OpaqueSetOps {
 			OpaqueSet s = (OpaqueSet) args[1];
 			return BoolTerm.mk(s.member(args[0]));
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef singleton = new FunctionDef() {
 
 		@Override
@@ -173,9 +173,9 @@ public final class OpaqueSetOps {
 		public Term evaluate(Term[] args) throws EvaluationException {
 			return OpaqueSet.singleton(args[0]);
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef subset = new FunctionDef() {
 
 		@Override
@@ -189,7 +189,7 @@ public final class OpaqueSetOps {
 			OpaqueSet s2 = (OpaqueSet) args[1];
 			return BoolTerm.mk(s2.containsAll(s1));
 		}
-		
+
 	};
 
 	public static final FunctionDef fromList = new FunctionDef() {
@@ -203,7 +203,7 @@ public final class OpaqueSetOps {
 		public Term evaluate(Term[] args) throws EvaluationException {
 			return OpaqueSet.fromCollection(Terms.termToTermList(args[0]));
 		}
-		
+
 	};
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/PredicateFunctionDef.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/PredicateFunctionDef.java
@@ -22,11 +22,10 @@ package edu.harvard.seas.pl.formulog.functions;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;
 
-
 public interface PredicateFunctionDef extends FunctionDef {
 
 	int getIndex();
-	
+
 	BindingType[] getBindingsForIndex();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/PrimitiveConversions.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/PrimitiveConversions.java
@@ -25,7 +25,6 @@ import edu.harvard.seas.pl.formulog.ast.Constructors;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.FP32;
 import edu.harvard.seas.pl.formulog.ast.FP64;
 import edu.harvard.seas.pl.formulog.ast.I32;
@@ -37,11 +36,11 @@ import edu.harvard.seas.pl.formulog.symbols.BuiltInFunctionSymbol;
 import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
 
 public final class PrimitiveConversions {
-	
+
 	private PrimitiveConversions() {
 		throw new AssertionError();
 	}
-	
+
 	public static final FunctionDef i32ToI64 = new FunctionDef() {
 
 		@Override
@@ -54,9 +53,9 @@ public final class PrimitiveConversions {
 			I32 x = (I32) args[0];
 			return I64.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef i32ToFp32 = new FunctionDef() {
 
 		@Override
@@ -69,9 +68,9 @@ public final class PrimitiveConversions {
 			I32 x = (I32) args[0];
 			return FP32.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef i32ToFp64 = new FunctionDef() {
 
 		@Override
@@ -84,9 +83,9 @@ public final class PrimitiveConversions {
 			I32 x = (I32) args[0];
 			return FP64.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef i64ToI32 = new FunctionDef() {
 
 		@Override
@@ -99,9 +98,9 @@ public final class PrimitiveConversions {
 			I64 x = (I64) args[0];
 			return I32.make(x.getVal().intValue());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef i64ToFp32 = new FunctionDef() {
 
 		@Override
@@ -114,9 +113,9 @@ public final class PrimitiveConversions {
 			I64 x = (I64) args[0];
 			return FP32.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef i64ToFp64 = new FunctionDef() {
 
 		@Override
@@ -129,9 +128,9 @@ public final class PrimitiveConversions {
 			I64 x = (I64) args[0];
 			return FP64.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp32ToI32 = new FunctionDef() {
 
 		@Override
@@ -144,9 +143,9 @@ public final class PrimitiveConversions {
 			FP32 x = (FP32) args[0];
 			return I32.make(x.getVal().intValue());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp32ToI64 = new FunctionDef() {
 
 		@Override
@@ -159,9 +158,9 @@ public final class PrimitiveConversions {
 			FP32 x = (FP32) args[0];
 			return I64.make(x.getVal().longValue());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp32ToFp64 = new FunctionDef() {
 
 		@Override
@@ -174,9 +173,9 @@ public final class PrimitiveConversions {
 			FP32 x = (FP32) args[0];
 			return FP64.make(x.getVal());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp64ToI32 = new FunctionDef() {
 
 		@Override
@@ -189,9 +188,9 @@ public final class PrimitiveConversions {
 			FP64 x = (FP64) args[0];
 			return I32.make(x.getVal().intValue());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp64ToI64 = new FunctionDef() {
 
 		@Override
@@ -204,9 +203,9 @@ public final class PrimitiveConversions {
 			FP64 x = (FP64) args[0];
 			return I64.make(x.getVal().longValue());
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef fp64ToFp32 = new FunctionDef() {
 
 		@Override
@@ -219,11 +218,11 @@ public final class PrimitiveConversions {
 			FP64 x = (FP64) args[0];
 			return FP32.make(x.getVal().floatValue());
 		}
-		
+
 	};
 
 	private static final Pattern hex = Pattern.compile("0x([0-9a-fA-F]+)");
-	
+
 	public static final FunctionDef stringToI32 = new FunctionDef() {
 
 		@Override
@@ -247,9 +246,9 @@ public final class PrimitiveConversions {
 				return Constructors.none();
 			}
 		}
-		
+
 	};
-	
+
 	public static final FunctionDef stringToI64 = new FunctionDef() {
 
 		@Override
@@ -273,7 +272,7 @@ public final class PrimitiveConversions {
 				return Constructors.none();
 			}
 		}
-		
+
 	};
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/RecordAccessor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/RecordAccessor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.functions;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Constructor;
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -29,8 +28,8 @@ import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
 public class RecordAccessor implements FunctionDef {
 
 	private final FunctionSymbol sym;
-	private final int index; 
-	
+	private final int index;
+
 	public RecordAccessor(FunctionSymbol sym, int index) {
 		this.sym = sym;
 		this.index = index;
@@ -40,7 +39,7 @@ public class RecordAccessor implements FunctionDef {
 	public FunctionSymbol getSymbol() {
 		return sym;
 	}
-	
+
 	public int getIndex() {
 		return index;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/UserFunctionDef.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/UserFunctionDef.java
@@ -81,6 +81,6 @@ public class UserFunctionDef implements FunctionDef {
 	@Override
 	public String toString() {
 		return "UserFunctionDef [sym=" + sym + ", params=" + params + ", body=" + body + "]";
-	}	
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/magic/AdornedSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/magic/AdornedSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import java.util.Arrays;
 
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
@@ -29,91 +28,91 @@ import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 class AdornedSymbol implements WrappedRelationSymbol<RelationSymbol> {
 
-    private final RelationSymbol baseSymbol;
-    private final boolean[] adornment;
+	private final RelationSymbol baseSymbol;
+	private final boolean[] adornment;
 
-    public AdornedSymbol(RelationSymbol baseSymbol, boolean[] adornment) {
-        assert adornment != null;
-        assert !(baseSymbol instanceof AdornedSymbol);
-        assert baseSymbol.isIdbSymbol();
-        this.baseSymbol = baseSymbol;
-        this.adornment = adornment;
-    }
+	public AdornedSymbol(RelationSymbol baseSymbol, boolean[] adornment) {
+		assert adornment != null;
+		assert !(baseSymbol instanceof AdornedSymbol);
+		assert baseSymbol.isIdbSymbol();
+		this.baseSymbol = baseSymbol;
+		this.adornment = adornment;
+	}
 
-    public boolean[] getAdornment() {
-        return adornment;
-    }
+	public boolean[] getAdornment() {
+		return adornment;
+	}
 
-    @Override
-    public String toString() {
-        String s = getBaseSymbol() + "_";
-        for (boolean b : adornment) {
-            s += b ? "b" : "f";
-        }
-        return s;
-    }
+	@Override
+	public String toString() {
+		String s = getBaseSymbol() + "_";
+		for (boolean b : adornment) {
+			s += b ? "b" : "f";
+		}
+		return s;
+	}
 
-    @Override
-    public boolean isIdbSymbol() {
-        return baseSymbol.isIdbSymbol();
-    }
+	@Override
+	public boolean isIdbSymbol() {
+		return baseSymbol.isIdbSymbol();
+	}
 
-    @Override
-    public boolean isBottomUp() {
-        return baseSymbol.isBottomUp();
-    }
+	@Override
+	public boolean isBottomUp() {
+		return baseSymbol.isBottomUp();
+	}
 
-    @Override
-    public boolean isTopDown() {
-        return baseSymbol.isTopDown();
-    }
+	@Override
+	public boolean isTopDown() {
+		return baseSymbol.isTopDown();
+	}
 
-    @Override
-    public FunctorType getCompileTimeType() {
-        return baseSymbol.getCompileTimeType();
-    }
+	@Override
+	public FunctorType getCompileTimeType() {
+		return baseSymbol.getCompileTimeType();
+	}
 
-    @Override
-    public int getArity() {
-        return baseSymbol.getArity();
-    }
+	@Override
+	public int getArity() {
+		return baseSymbol.getArity();
+	}
 
-    @Override
-    public RelationSymbol getBaseSymbol() {
-        return baseSymbol;
-    }
+	@Override
+	public RelationSymbol getBaseSymbol() {
+		return baseSymbol;
+	}
 
-    @Override
-    public boolean isDisk() {
-        return false;
-    }
+	@Override
+	public boolean isDisk() {
+		return false;
+	}
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(adornment);
-        result = prime * result + ((baseSymbol == null) ? 0 : baseSymbol.hashCode());
-        return result;
-    }
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(adornment);
+		result = prime * result + ((baseSymbol == null) ? 0 : baseSymbol.hashCode());
+		return result;
+	}
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AdornedSymbol other = (AdornedSymbol) obj;
-        if (!Arrays.equals(adornment, other.adornment))
-            return false;
-        if (baseSymbol == null) {
-            if (other.baseSymbol != null)
-                return false;
-        } else if (!baseSymbol.equals(other.baseSymbol))
-            return false;
-        return true;
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AdornedSymbol other = (AdornedSymbol) obj;
+		if (!Arrays.equals(adornment, other.adornment))
+			return false;
+		if (baseSymbol == null) {
+			if (other.baseSymbol != null)
+				return false;
+		} else if (!baseSymbol.equals(other.baseSymbol))
+			return false;
+		return true;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/magic/Adornments.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/magic/Adornments.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/edu/harvard/seas/pl/formulog/magic/MagicSetTransformer.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/magic/MagicSetTransformer.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,932 +74,932 @@ import edu.harvard.seas.pl.formulog.validating.Stratum;
 
 public class MagicSetTransformer {
 
-    private final Program<UserPredicate, BasicRule> origProg;
-    private boolean topDownIsDefault;
-
-    private static final boolean debug = Configuration.debugMst;
-
-    public MagicSetTransformer(Program<UserPredicate, BasicRule> prog) {
-        this.origProg = prog;
-    }
-
-    public BasicProgram transform(boolean useDemandTransformation, boolean restoreStratification)
-            throws InvalidProgramException {
-        BasicProgram prog;
-        if (origProg.hasQuery()) {
-            prog = transformForQuery(origProg.getQuery(), useDemandTransformation, restoreStratification);
-        } else {
-            prog = transformNoQuery(useDemandTransformation, restoreStratification);
-        }
-        if (debug) {
-            System.err.println("Rewritten rules...");
-            List<RelationSymbol> syms = prog.getRuleSymbols().stream().sorted(SymbolComparator.INSTANCE)
-                    .collect(Collectors.toList());
-            for (RelationSymbol sym : syms) {
-                for (BasicRule r : prog.getRules(sym)) {
-                    System.err.println(r);
-                }
-            }
-        }
-        return prog;
-    }
-
-    private BasicProgram transformForQuery(UserPredicate query, boolean useDemandTransformation,
-                                           boolean restoreStratification) throws InvalidProgramException {
-        topDownIsDefault = true;
-        if (query.isNegated()) {
-            throw new InvalidProgramException("Query cannot be negated");
-        }
-        BasicProgram newProg;
-        if (query.getSymbol().isEdbSymbol()) {
-            newProg = makeEdbProgram(query);
-        } else {
-            UserPredicate adornedQuery = Adornments.adorn(query, Collections.emptySet(), topDownIsDefault);
-            Set<Pair<BasicRule, Integer>> adRules = adorn(Collections.singleton(adornedQuery.getSymbol()));
-            Set<BasicRule> magicRules = makeMagicRules(adRules);
-            magicRules.add(makeSeedRule(adornedQuery));
-            BasicRule queryRule = makeQueryRule(adornedQuery);
-            UserPredicate newQuery = queryRule.getHead();
-            BasicProgram magicProg = new ProgramImpl(magicRules, newQuery);
-            if (restoreStratification && !isStratified(magicProg)) {
-                magicProg = stratify(magicProg, Pair.map(adRules, (rule, num) -> rule));
-            }
-            ((ProgramImpl) magicProg).rules.put(newQuery.getSymbol(), Collections.singleton(queryRule));
-            if (useDemandTransformation) {
-                magicProg = applyDemandTransformation(magicProg, restoreStratification);
-            }
-            newProg = magicProg;
-        }
-        return newProg;
-    }
-
-    private BasicRule makeSeedRule(UserPredicate adornedQuery) {
-        return BasicRule.make(createInputAtom(adornedQuery));
-    }
-
-    private BasicRule makeQueryRule(UserPredicate query) {
-        RelationSymbol oldSym = query.getSymbol();
-        RelationSymbol querySym = new RelationSymbol() {
-
-            @Override
-            public FunctorType getCompileTimeType() {
-                return oldSym.getCompileTimeType();
-            }
-
-            @Override
-            public int getArity() {
-                return oldSym.getArity();
-            }
-
-            @Override
-            public boolean isIdbSymbol() {
-                return true;
-            }
-
-            @Override
-            public boolean isBottomUp() {
-                return true;
-            }
-
-            @Override
-            public boolean isTopDown() {
-                return false;
-            }
-
-            @Override
-            public boolean isDisk() {
-                return false;
-            }
-
-            @Override
-            public String toString() {
-                Symbol sym = oldSym;
-                if (oldSym instanceof AdornedSymbol) {
-                    sym = ((AdornedSymbol) oldSym).getBaseSymbol();
-                }
-                return "query:" + sym;
-            }
-
-        };
-        Term[] args = query.getArgs();
-        Term[] newArgs = new Term[args.length];
-        Term[] hdArgs = new Term[args.length];
-        List<ComplexLiteral> body = new ArrayList<>();
-        Set<Var> seen = new HashSet<>();
-        for (int i = 0; i < args.length; ++i) {
-            Term t = args[i];
-            if (!(t instanceof Var) || !seen.add((Var) t)) {
-                Var x = Var.fresh();
-                body.add(UnificationPredicate.make(x, t, false));
-                t = x;
-            }
-            newArgs[i] = hdArgs[i] = t;
-        }
-        body.add(0, UserPredicate.make(oldSym, newArgs, query.isNegated()));
-        UserPredicate hd = UserPredicate.make(querySym, hdArgs, query.isNegated());
-        return BasicRule.make(hd, body);
-    }
-
-    private BasicProgram makeEdbProgram(UserPredicate query) {
-        BasicRule queryRule = makeQueryRule(query);
-        RelationSymbol oldQuerySym = query.getSymbol();
-        return new BasicProgram() {
-
-            @Override
-            public Set<FunctionSymbol> getFunctionSymbols() {
-                return Collections.emptySet();
-            }
-
-            @Override
-            public Set<RelationSymbol> getFactSymbols() {
-                return Collections.singleton(oldQuerySym);
-            }
-
-            @Override
-            public Set<RelationSymbol> getRuleSymbols() {
-                return Collections.singleton(getQuery().getSymbol());
-            }
-
-            @Override
-            public FunctionDef getDef(FunctionSymbol sym) {
-                throw new IllegalArgumentException("No definition for function with symbol: " + sym);
-            }
-
-            @Override
-            public Set<Term[]> getFacts(RelationSymbol sym) {
-                if (oldQuerySym.equals(sym)) {
-                    return origProg.getFacts(oldQuerySym);
-                }
-                return Collections.emptySet();
-            }
-
-            @Override
-            public Set<BasicRule> getRules(RelationSymbol sym) {
-                if (!sym.equals(getQuery().getSymbol())) {
-                    return Collections.emptySet();
-                }
-                return Collections.singleton(queryRule);
-            }
-
-            @Override
-            public SymbolManager getSymbolManager() {
-                return origProg.getSymbolManager();
-            }
-
-            @Override
-            public boolean hasQuery() {
-                return true;
-            }
-
-            @Override
-            public UserPredicate getQuery() {
-                return queryRule.getHead();
-            }
-
-            @Override
-            public FunctionCallFactory getFunctionCallFactory() {
-                return origProg.getFunctionCallFactory();
-            }
-
-            @Override
-            public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
-                return origProg.getUninterpretedFunctionSymbols();
-            }
-
-            @Override
-            public Set<TypeSymbol> getTypeSymbols() {
-                return origProg.getTypeSymbols();
-            }
-
-        };
-    }
-
-    private BasicProgram transformNoQuery(boolean useDemandTransformation, boolean restoreStratification)
-            throws InvalidProgramException {
-        topDownIsDefault = false;
-        Set<RelationSymbol> bottomUpSymbols = new HashSet<>();
-        for (RelationSymbol sym : origProg.getRuleSymbols()) {
-            if (!sym.isTopDown()) {
-                bottomUpSymbols.add(sym);
-            }
-        }
-        Set<Pair<BasicRule, Integer>> adRules = adorn(bottomUpSymbols);
-        Set<BasicRule> magicRules = makeMagicRules(adRules);
-        BasicProgram magicProg = new ProgramImpl(magicRules, null);
-        if (restoreStratification && !isStratified(magicProg)) {
-            magicProg = stratify(magicProg, Pair.map(adRules, (rule, num) -> rule));
-        }
-        if (useDemandTransformation) {
-            magicProg = applyDemandTransformation(magicProg, restoreStratification);
-        }
-        return magicProg;
-    }
-
-    private BasicProgram applyDemandTransformation(BasicProgram prog, boolean mustBeStratified)
-            throws InvalidProgramException {
-        BasicProgram prog2 = stripAdornments(prog);
-        if (isStratified(prog2)) {
-            return prog2;
-        }
-        return prog;
-    }
-
-    private BasicProgram stripAdornments(BasicProgram prog) throws InvalidProgramException {
-        Set<BasicRule> rules = new HashSet<>();
-        for (RelationSymbol sym : prog.getRuleSymbols()) {
-            for (BasicRule r : prog.getRules(sym)) {
-                UserPredicate newHead = stripAdornment(r.getHead());
-                List<ComplexLiteral> newBody = new ArrayList<>();
-                for (ComplexLiteral atom : r) {
-                    newBody.add(stripAdornment(atom));
-                }
-                rules.add(BasicRule.make(newHead, newBody));
-            }
-        }
-        UserPredicate query = null;
-        if (prog.hasQuery()) {
-            query = stripAdornment(prog.getQuery());
-        }
-        return new ProgramImpl(rules, query);
-    }
-
-    private static <C extends ComplexLiteral> C stripAdornment(C atom) {
-        return atom.accept(new ComplexLiteralVisitor<Void, C>() {
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public C visit(UnificationPredicate unificationPredicate, Void input) {
-                return (C) unificationPredicate;
-            }
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public C visit(UserPredicate userPredicate, Void input) {
-                RelationSymbol sym = userPredicate.getSymbol();
-                if (sym instanceof PositiveSymbol) {
-                    sym = ((PositiveSymbol) sym).getBaseSymbol();
-                    if (sym instanceof AdornedSymbol) {
-                        sym = ((AdornedSymbol) sym).getBaseSymbol();
-                    }
-                    sym = new PositiveSymbol(sym);
-                } else if (sym instanceof AdornedSymbol) {
-                    sym = ((AdornedSymbol) sym).getBaseSymbol();
-                }
-                return (C) UserPredicate.make(sym, userPredicate.getArgs(), userPredicate.isNegated());
-            }
-
-        }, null);
-    }
-
-    private Set<Pair<BasicRule, Integer>> adorn(Set<RelationSymbol> seeds) throws InvalidProgramException {
-        if (debug) {
-            System.err.println("Adorning rules...");
-        }
-        Set<Pair<BasicRule, Integer>> adRules = new HashSet<>();
-        DedupWorkList<RelationSymbol> worklist = new DedupWorkList<>();
-        for (RelationSymbol seed : seeds) {
-            worklist.push(seed);
-        }
-        HiddenPredicateFinder hpf = new HiddenPredicateFinder(origProg);
-        int ruleNum = 0;
-        while (!worklist.isEmpty()) {
-            RelationSymbol adSym = worklist.pop();
-            RelationSymbol origSym = adSym;
-            if (adSym instanceof AdornedSymbol) {
-                origSym = ((AdornedSymbol) adSym).getBaseSymbol();
-            }
-            for (BasicRule r : origProg.getRules(origSym)) {
-                for (RelationSymbol sym : hpf.visit(r)) {
-                    if (exploreTopDown(sym)) {
-                        throw new InvalidProgramException("Cannot refer to top-down IDB predicate " + sym
-                                + " in a function; consider annotating " + sym + " with @bottomup");
-                    }
-                    if (sym.isIdbSymbol()) {
-                        worklist.push(sym);
-                    }
-                }
-                UserPredicate head = r.getHead();
-                UserPredicate adHead = UserPredicate.make(adSym, head.getArgs(), head.isNegated());
-                BasicRule adRule = Adornments.adornRule(adHead, Util.iterableToList(r), topDownIsDefault);
-                for (ComplexLiteral a : adRule) {
-                    a.accept(new ComplexLiteralVisitor<Void, Void>() {
-
-                        @Override
-                        public Void visit(UnificationPredicate unificationPredicate, Void input) {
-                            // Do nothing
-                            return null;
-                        }
-
-                        @Override
-                        public Void visit(UserPredicate userPredicate, Void input) {
-                            RelationSymbol sym = userPredicate.getSymbol();
-                            if (sym.isIdbSymbol()) {
-                                worklist.push(sym);
-                            }
-                            return null;
-                        }
-
-                    }, null);
-                }
-                if (debug) {
-                    System.err.println("--" + ruleNum + "--\n" + adRule);
-                }
-                adRules.add(new Pair<>(adRule, ruleNum));
-                ruleNum++;
-            }
-        }
-        return adRules;
-    }
-
-    private Set<BasicRule> makeMagicRules(Set<Pair<BasicRule, Integer>> adornedRules) {
-        Set<BasicRule> magicRules = new HashSet<>();
-        for (Pair<BasicRule, Integer> p : adornedRules) {
-            magicRules.addAll(makeMagicRules(p.fst(), p.snd()));
-        }
-        return magicRules;
-    }
-
-    private boolean exploreTopDown(RelationSymbol sym) {
-        if (sym instanceof AdornedSymbol) {
-            sym = ((AdornedSymbol) sym).getBaseSymbol();
-        }
-        if (!sym.isIdbSymbol()) {
-            return false;
-        }
-        return sym.isTopDown() || (topDownIsDefault && !sym.isBottomUp());
-    }
-
-    private Set<BasicRule> makeMagicRules(BasicRule r, int number) {
-        int[] supCount = {0};
-        Set<BasicRule> magicRules = new HashSet<>();
-        List<Set<Var>> liveVarsByAtom = liveVarsByAtom(r);
-        List<ComplexLiteral> l = new ArrayList<>();
-        UserPredicate head = r.getHead();
-        Set<Var> curLiveVars = new HashSet<>();
-        if (exploreTopDown(head.getSymbol())) {
-            UserPredicate inputAtom = createInputAtom(head);
-            l.add(inputAtom);
-            curLiveVars.addAll(inputAtom.varSet());
-        }
-        int i = 0;
-        for (ComplexLiteral a : r) {
-            Set<Var> futureLiveVars = liveVarsByAtom.get(i);
-            Set<Var> nextLiveVars = curLiveVars.stream().filter(futureLiveVars::contains).collect(Collectors.toSet());
-            l = a.accept(new ComplexLiteralVisitor<List<ComplexLiteral>, List<ComplexLiteral>>() {
-
-                @Override
-                public List<ComplexLiteral> visit(UnificationPredicate unificationPredicate, List<ComplexLiteral> l) {
-                    l.add(a);
-                    return l;
-                }
-
-                @Override
-                public List<ComplexLiteral> visit(UserPredicate userPredicate, List<ComplexLiteral> l) {
-                    RelationSymbol sym = userPredicate.getSymbol();
-                    if (exploreTopDown(sym)) {
-                        Set<Var> supVars = a.varSet().stream().filter(curLiveVars::contains)
-                                .collect(Collectors.toSet());
-                        supVars.addAll(nextLiveVars);
-                        UserPredicate supAtom = createSupAtom(supVars, number, supCount[0], head.getSymbol());
-                        magicRules.add(BasicRule.make(supAtom, l));
-                        magicRules.add(
-                                BasicRule.make(createInputAtom(userPredicate), Collections.singletonList(supAtom)));
-                        l = new ArrayList<>();
-                        l.add(supAtom);
-                        l.add(a);
-                        supCount[0]++;
-                    } else {
-                        l.add(a);
-                    }
-                    return l;
-                }
-
-            }, l);
-            curLiveVars.clear();
-            curLiveVars.addAll(nextLiveVars);
-            for (Var v : a.varSet()) {
-                if (futureLiveVars.contains(v)) {
-                    curLiveVars.add(v);
-                }
-            }
-            i++;
-        }
-        magicRules.add(BasicRule.make(head, l));
-        return magicRules;
-    }
-
-    private List<Set<Var>> liveVarsByAtom(BasicRule r) {
-        List<Set<Var>> liveVars = new ArrayList<>();
-        Set<Var> acc = r.getHead().varSet();
-        liveVars.add(acc);
-        for (int i = r.getBodySize() - 1; i > 0; i--) {
-            acc = new HashSet<>(acc);
-            acc.addAll(r.getBody(i).varSet());
-            liveVars.add(acc);
-        }
-        Collections.reverse(liveVars);
-        return liveVars;
-    }
-
-    private UserPredicate createSupAtom(Set<Var> curLiveVars, int ruleNum, int supCount, Symbol headSym) {
-        List<Term> l = new ArrayList<>(curLiveVars);
-        l.sort(new Comparator<Term>() {
-
-            @Override
-            public int compare(Term o1, Term o2) {
-                return o1.toString().compareTo(o2.toString());
-            }
-
-        });
-        Term[] args = l.toArray(new Term[0]);
-        SupSymbol supSym = new SupSymbol(ruleNum, supCount, args.length);
-        return UserPredicate.make(supSym, args, false);
-    }
-
-    private UserPredicate createInputAtom(UserPredicate a) {
-        AdornedSymbol headSym = (AdornedSymbol) a.getSymbol();
-        InputSymbol inputSym = new InputSymbol(headSym);
-        Term[] inputArgs = new Term[inputSym.getArity()];
-        Term[] args = a.getArgs();
-        boolean[] adornment = headSym.getAdornment();
-        for (int i = 0, j = 0; i < args.length; i++) {
-            if (adornment[i]) {
-                inputArgs[j] = args[i];
-                j++;
-            }
-        }
-        return UserPredicate.make(inputSym, inputArgs, false);
-    }
-
-    public static class SupSymbol implements RelationSymbol {
-
-        private final int ruleNum;
-        private final int supCount;
-        private final int arity;
-
-        public SupSymbol(int ruleNum, int supCount, int arity) {
-            this.ruleNum = ruleNum;
-            this.supCount = supCount;
-            this.arity = arity;
-        }
-
-        @Override
-        public int getArity() {
-            return arity;
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + arity;
-            result = prime * result + ruleNum;
-            result = prime * result + supCount;
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            SupSymbol other = (SupSymbol) obj;
-            if (arity != other.arity)
-                return false;
-            if (ruleNum != other.ruleNum)
-                return false;
-            if (supCount != other.supCount)
-                return false;
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return "sup_" + ruleNum + "_" + supCount;
-        }
-
-        @Override
-        public FunctorType getCompileTimeType() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isIdbSymbol() {
-            return true;
-        }
-
-        @Override
-        public boolean isDisk() {
-            return false;
-        }
-
-        @Override
-        public boolean isBottomUp() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isTopDown() {
-            throw new UnsupportedOperationException();
-        }
-
-    }
-
-    public static class InputSymbol extends AbstractWrappedRelationSymbol<AdornedSymbol> {
-
-        private final int arity;
-
-        public InputSymbol(AdornedSymbol baseSymbol) {
-            super(baseSymbol);
-            int nbound = 0;
-            for (boolean b : getBaseSymbol().getAdornment()) {
-                nbound += b ? 1 : 0;
-            }
-            arity = nbound;
-        }
-
-        @Override
-        public int getArity() {
-            return arity;
-        }
-
-        @Override
-        public String toString() {
-            return "input_" + getBaseSymbol();
-        }
-
-        @Override
-        public FunctorType getCompileTimeType() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isBottomUp() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isTopDown() {
-            throw new UnsupportedOperationException();
-        }
-
-    }
-
-    private boolean isStratified(BasicProgram p) {
-        try {
-            Stratifier stratifier = new Stratifier(p);
-            for (Stratum s : stratifier.stratify()) {
-                if (s.hasRecursiveNegationOrAggregation()) {
-                    return false;
-                }
-            }
-            return true;
-        } catch (InvalidProgramException e) {
-            return false;
-        }
-    }
-
-    private Set<BasicRule> adjustAdornedRules(Collection<BasicRule> adRules) {
-        Set<BasicRule> newRules = new HashSet<>();
-        for (BasicRule r : adRules) {
-            UserPredicate head = r.getHead();
-            if (exploreTopDown(head.getSymbol())) {
-                List<ComplexLiteral> body = new ArrayList<>();
-                body.add(createInputAtom(head));
-                r.forEach(body::add);
-                newRules.add(BasicRule.make(head, body));
-            } else {
-                newRules.add(r);
-            }
-        }
-        return newRules;
-    }
-
-    private ProgramImpl stratify(BasicProgram p, Set<BasicRule> adornedRules) throws InvalidProgramException {
-        Set<BasicRule> newRules = new HashSet<>();
-        for (RelationSymbol sym : p.getRuleSymbols()) {
-            for (BasicRule r : p.getRules(sym)) {
-                UserPredicate head = makePositive(r.getHead());
-                List<ComplexLiteral> body = makePositive(r);
-                newRules.add(BasicRule.make(head, body));
-            }
-        }
-        newRules.addAll(adjustAdornedRules(adornedRules));
-        return new ProgramImpl(newRules, p.getQuery());
-    }
-
-    private <C extends ComplexLiteral> C makePositive(C atom) {
-        return atom.accept(new ComplexLiteralVisitor<Void, C>() {
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public C visit(UnificationPredicate unificationPredicate, Void input) {
-                return (C) unificationPredicate;
-            }
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public C visit(UserPredicate userPredicate, Void input) {
-                RelationSymbol sym = userPredicate.getSymbol();
-                if (sym.isIdbSymbol() && !(sym instanceof InputSymbol || sym instanceof SupSymbol)) {
-                    if (userPredicate.isNegated()) {
-                        return null;
-                    }
-                    userPredicate = UserPredicate.make(new PositiveSymbol(sym), userPredicate.getArgs(), false);
-                }
-                return (C) userPredicate;
-            }
-
-        }, null);
-    }
-
-    private List<ComplexLiteral> makePositive(Iterable<ComplexLiteral> atoms) {
-        List<ComplexLiteral> l = new ArrayList<>();
-        for (ComplexLiteral a : atoms) {
-            ComplexLiteral b = makePositive(a);
-            if (b != null) {
-                l.add(b);
-            }
-        }
-        return l;
-    }
-
-    private static class PositiveSymbol extends AbstractWrappedRelationSymbol<RelationSymbol> {
-
-        public PositiveSymbol(RelationSymbol baseSymbol) {
-            super(baseSymbol);
-        }
-
-        @Override
-        public String toString() {
-            return "p_" + getBaseSymbol();
-        }
-
-        @Override
-        public FunctorType getCompileTimeType() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isBottomUp() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isTopDown() {
-            throw new UnsupportedOperationException();
-        }
-
-    }
-
-    private static class HiddenPredicateFinder {
-
-        private final Program<UserPredicate, BasicRule> origProg;
-        private final Set<FunctionSymbol> visitedFunctions = new HashSet<>();
-        private final Set<RelationSymbol> seenPredicates = new HashSet<>();
-
-        public HiddenPredicateFinder(Program<UserPredicate, BasicRule> origProg) {
-            this.origProg = origProg;
-        }
-
-        private void findHiddenPredicates(Term t, Set<RelationSymbol> s) {
-            t.accept(predicatesInTermExtractor, s);
-        }
-
-        public Set<RelationSymbol> allSeenPredicates() {
-            return seenPredicates;
-        }
-
-        public Set<RelationSymbol> visit(UserFunctionDef def) {
-            Set<RelationSymbol> s = new HashSet<>();
-            if (visitedFunctions.add(def.getSymbol())) {
-                findHiddenPredicates(def.getBody(), s);
-            }
-            return s;
-        }
-
-        private void visit(ComplexLiteral l, Set<RelationSymbol> s) {
-            l.accept(new ComplexLiteralVisitor<Void, Void>() {
-
-                @Override
-                public Void visit(UnificationPredicate unificationPredicate, Void input) {
-                    findHiddenPredicates(unificationPredicate.getLhs(), s);
-                    findHiddenPredicates(unificationPredicate.getRhs(), s);
-                    return null;
-                }
-
-                @Override
-                public Void visit(UserPredicate userPredicate, Void input) {
-                    for (Term t : userPredicate.getArgs()) {
-                        findHiddenPredicates(t, s);
-                    }
-                    return null;
-                }
-
-            }, null);
-        }
-
-        public Set<RelationSymbol> visit(Rule<? extends ComplexLiteral, ? extends ComplexLiteral> rule) {
-            Set<RelationSymbol> s = new HashSet<>();
-            visit(rule.getHead(), s);
-            for (ComplexLiteral l : rule) {
-                visit(l, s);
-            }
-            return s;
-        }
-
-        private TermVisitor<Set<RelationSymbol>, Void> predicatesInTermExtractor = new TermVisitor<Set<RelationSymbol>, Void>() {
-
-            @Override
-            public Void visit(Var t, Set<RelationSymbol> in) {
-                return null;
-            }
-
-            @Override
-            public Void visit(Constructor c, Set<RelationSymbol> in) {
-                for (Term t : c.getArgs()) {
-                    t.accept(this, in);
-                }
-                return null;
-            }
-
-            @Override
-            public Void visit(Primitive<?> p, Set<RelationSymbol> in) {
-                return null;
-            }
-
-            @Override
-            public Void visit(Expr e, Set<RelationSymbol> in) {
-                e.accept(predicatesInExprExtractor, in);
-                return null;
-            }
-
-        };
-
-        private ExprVisitor<Set<RelationSymbol>, Void> predicatesInExprExtractor = new ExprVisitor<Set<RelationSymbol>, Void>() {
-
-            @Override
-            public Void visit(MatchExpr matchExpr, Set<RelationSymbol> in) {
-                matchExpr.getMatchee().accept(predicatesInTermExtractor, in);
-                for (MatchClause cl : matchExpr) {
-                    cl.getRhs().accept(predicatesInTermExtractor, in);
-                }
-                return null;
-            }
-
-            @Override
-            public Void visit(FunctionCall funcCall, Set<RelationSymbol> in) {
-                FunctionSymbol sym = funcCall.getSymbol();
-                if (visitedFunctions.add(sym)) {
-                    if (sym instanceof PredicateFunctionSymbol) {
-                        RelationSymbol psym = ((PredicateFunctionSymbol) sym).getPredicateSymbol();
-                        seenPredicates.add(psym);
-                        in.add(psym);
-                    }
-                    FunctionDef def = origProg.getDef(sym);
-                    if (def instanceof UserFunctionDef) {
-                        ((UserFunctionDef) def).getBody().accept(predicatesInTermExtractor, in);
-                    }
-                }
-                for (Term t : funcCall.getArgs()) {
-                    t.accept(predicatesInTermExtractor, in);
-                }
-                return null;
-            }
-
-            @Override
-            public Void visit(LetFunExpr funcDef, Set<RelationSymbol> in) {
-                throw new AssertionError("impossible");
-            }
-
-            @Override
-            public Void visit(Fold fold, Set<RelationSymbol> in) {
-                fold.getShamCall().accept(this, in);
-                return null;
-            }
-
-        };
-
-    }
-
-    private class ProgramImpl implements BasicProgram {
-
-        private final Map<RelationSymbol, Set<BasicRule>> rules = new HashMap<>();
-        private final Map<RelationSymbol, Set<Term[]>> facts = new HashMap<>();
-        private final UserPredicate query;
-
-        public ProgramImpl(Set<BasicRule> rs, UserPredicate query) throws InvalidProgramException {
-            SymbolManager sm = origProg.getSymbolManager();
-            HiddenPredicateFinder hpf = new HiddenPredicateFinder(origProg);
-            for (BasicRule r : rs) {
-                RelationSymbol headSym = r.getHead().getSymbol();
-                Util.lookupOrCreate(rules, headSym, HashSet::new).add(r);
-                sm.registerSymbol(headSym);
-                for (ComplexLiteral l : r) {
-                    if (l instanceof UserPredicate) {
-                        RelationSymbol sym = ((UserPredicate) l).getSymbol();
-                        sm.registerSymbol(sym);
-                        if (sym.isEdbSymbol()) {
-                            facts.putIfAbsent(sym, origProg.getFacts(sym));
-                        } else {
-                            rules.putIfAbsent(sym, new HashSet<>());
-                        }
-                    }
-                }
-                hpf.visit(r);
-            }
-            for (FunctionSymbol sym : origProg.getFunctionSymbols()) {
-                FunctionDef def = origProg.getDef(sym);
-                if (def instanceof UserFunctionDef) {
-                    hpf.visit((UserFunctionDef) def);
-                }
-            }
-            for (RelationSymbol psym : hpf.allSeenPredicates()) {
-                if (exploreTopDown(psym)) {
-                    throw new InvalidProgramException("Cannot refer to top-down IDB predicate " + psym
-                            + " in a function; consider annotating " + psym + " with @bottomup");
-                }
-                if (psym.isEdbSymbol()) {
-                    facts.putIfAbsent(psym, origProg.getFacts(psym));
-                }
-                if (psym.isIdbSymbol()) {
-                    rules.putIfAbsent(psym, new HashSet<>());
-                }
-            }
-            // Do not keep unnecessary facts around if there is a query.
-            if (query == null) {
-                for (RelationSymbol sym : origProg.getFactSymbols()) {
-                    facts.putIfAbsent(sym, origProg.getFacts(sym));
-                }
-            }
-            this.query = query;
-        }
-
-        @Override
-        public Set<FunctionSymbol> getFunctionSymbols() {
-            return origProg.getFunctionSymbols();
-        }
-
-        @Override
-        public Set<RelationSymbol> getFactSymbols() {
-            return Collections.unmodifiableSet(facts.keySet());
-        }
-
-        @Override
-        public Set<RelationSymbol> getRuleSymbols() {
-            return Collections.unmodifiableSet(rules.keySet());
-        }
-
-        @Override
-        public FunctionDef getDef(FunctionSymbol sym) {
-            return origProg.getDef(sym);
-        }
-
-        @Override
-        public Set<Term[]> getFacts(RelationSymbol sym) {
-            assert sym.isEdbSymbol();
-            return Util.lookupOrCreate(facts, sym, () -> Collections.emptySet());
-        }
-
-        @Override
-        public Set<BasicRule> getRules(RelationSymbol sym) {
-            assert sym.isIdbSymbol();
-            return Util.lookupOrCreate(rules, sym, () -> Collections.emptySet());
-        }
-
-        @Override
-        public SymbolManager getSymbolManager() {
-            return origProg.getSymbolManager();
-        }
-
-        @Override
-        public boolean hasQuery() {
-            return query != null;
-        }
-
-        @Override
-        public UserPredicate getQuery() {
-            return query;
-        }
-
-        @Override
-        public FunctionCallFactory getFunctionCallFactory() {
-            return origProg.getFunctionCallFactory();
-        }
-
-        @Override
-        public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
-            return origProg.getUninterpretedFunctionSymbols();
-        }
-
-        @Override
-        public Set<TypeSymbol> getTypeSymbols() {
-            return origProg.getTypeSymbols();
-        }
-
-    }
+	private final Program<UserPredicate, BasicRule> origProg;
+	private boolean topDownIsDefault;
+
+	private static final boolean debug = Configuration.debugMst;
+
+	public MagicSetTransformer(Program<UserPredicate, BasicRule> prog) {
+		this.origProg = prog;
+	}
+
+	public BasicProgram transform(boolean useDemandTransformation, boolean restoreStratification)
+			throws InvalidProgramException {
+		BasicProgram prog;
+		if (origProg.hasQuery()) {
+			prog = transformForQuery(origProg.getQuery(), useDemandTransformation, restoreStratification);
+		} else {
+			prog = transformNoQuery(useDemandTransformation, restoreStratification);
+		}
+		if (debug) {
+			System.err.println("Rewritten rules...");
+			List<RelationSymbol> syms = prog.getRuleSymbols().stream().sorted(SymbolComparator.INSTANCE)
+					.collect(Collectors.toList());
+			for (RelationSymbol sym : syms) {
+				for (BasicRule r : prog.getRules(sym)) {
+					System.err.println(r);
+				}
+			}
+		}
+		return prog;
+	}
+
+	private BasicProgram transformForQuery(UserPredicate query, boolean useDemandTransformation,
+			boolean restoreStratification) throws InvalidProgramException {
+		topDownIsDefault = true;
+		if (query.isNegated()) {
+			throw new InvalidProgramException("Query cannot be negated");
+		}
+		BasicProgram newProg;
+		if (query.getSymbol().isEdbSymbol()) {
+			newProg = makeEdbProgram(query);
+		} else {
+			UserPredicate adornedQuery = Adornments.adorn(query, Collections.emptySet(), topDownIsDefault);
+			Set<Pair<BasicRule, Integer>> adRules = adorn(Collections.singleton(adornedQuery.getSymbol()));
+			Set<BasicRule> magicRules = makeMagicRules(adRules);
+			magicRules.add(makeSeedRule(adornedQuery));
+			BasicRule queryRule = makeQueryRule(adornedQuery);
+			UserPredicate newQuery = queryRule.getHead();
+			BasicProgram magicProg = new ProgramImpl(magicRules, newQuery);
+			if (restoreStratification && !isStratified(magicProg)) {
+				magicProg = stratify(magicProg, Pair.map(adRules, (rule, num) -> rule));
+			}
+			((ProgramImpl) magicProg).rules.put(newQuery.getSymbol(), Collections.singleton(queryRule));
+			if (useDemandTransformation) {
+				magicProg = applyDemandTransformation(magicProg, restoreStratification);
+			}
+			newProg = magicProg;
+		}
+		return newProg;
+	}
+
+	private BasicRule makeSeedRule(UserPredicate adornedQuery) {
+		return BasicRule.make(createInputAtom(adornedQuery));
+	}
+
+	private BasicRule makeQueryRule(UserPredicate query) {
+		RelationSymbol oldSym = query.getSymbol();
+		RelationSymbol querySym = new RelationSymbol() {
+
+			@Override
+			public FunctorType getCompileTimeType() {
+				return oldSym.getCompileTimeType();
+			}
+
+			@Override
+			public int getArity() {
+				return oldSym.getArity();
+			}
+
+			@Override
+			public boolean isIdbSymbol() {
+				return true;
+			}
+
+			@Override
+			public boolean isBottomUp() {
+				return true;
+			}
+
+			@Override
+			public boolean isTopDown() {
+				return false;
+			}
+
+			@Override
+			public boolean isDisk() {
+				return false;
+			}
+
+			@Override
+			public String toString() {
+				Symbol sym = oldSym;
+				if (oldSym instanceof AdornedSymbol) {
+					sym = ((AdornedSymbol) oldSym).getBaseSymbol();
+				}
+				return "query:" + sym;
+			}
+
+		};
+		Term[] args = query.getArgs();
+		Term[] newArgs = new Term[args.length];
+		Term[] hdArgs = new Term[args.length];
+		List<ComplexLiteral> body = new ArrayList<>();
+		Set<Var> seen = new HashSet<>();
+		for (int i = 0; i < args.length; ++i) {
+			Term t = args[i];
+			if (!(t instanceof Var) || !seen.add((Var) t)) {
+				Var x = Var.fresh();
+				body.add(UnificationPredicate.make(x, t, false));
+				t = x;
+			}
+			newArgs[i] = hdArgs[i] = t;
+		}
+		body.add(0, UserPredicate.make(oldSym, newArgs, query.isNegated()));
+		UserPredicate hd = UserPredicate.make(querySym, hdArgs, query.isNegated());
+		return BasicRule.make(hd, body);
+	}
+
+	private BasicProgram makeEdbProgram(UserPredicate query) {
+		BasicRule queryRule = makeQueryRule(query);
+		RelationSymbol oldQuerySym = query.getSymbol();
+		return new BasicProgram() {
+
+			@Override
+			public Set<FunctionSymbol> getFunctionSymbols() {
+				return Collections.emptySet();
+			}
+
+			@Override
+			public Set<RelationSymbol> getFactSymbols() {
+				return Collections.singleton(oldQuerySym);
+			}
+
+			@Override
+			public Set<RelationSymbol> getRuleSymbols() {
+				return Collections.singleton(getQuery().getSymbol());
+			}
+
+			@Override
+			public FunctionDef getDef(FunctionSymbol sym) {
+				throw new IllegalArgumentException("No definition for function with symbol: " + sym);
+			}
+
+			@Override
+			public Set<Term[]> getFacts(RelationSymbol sym) {
+				if (oldQuerySym.equals(sym)) {
+					return origProg.getFacts(oldQuerySym);
+				}
+				return Collections.emptySet();
+			}
+
+			@Override
+			public Set<BasicRule> getRules(RelationSymbol sym) {
+				if (!sym.equals(getQuery().getSymbol())) {
+					return Collections.emptySet();
+				}
+				return Collections.singleton(queryRule);
+			}
+
+			@Override
+			public SymbolManager getSymbolManager() {
+				return origProg.getSymbolManager();
+			}
+
+			@Override
+			public boolean hasQuery() {
+				return true;
+			}
+
+			@Override
+			public UserPredicate getQuery() {
+				return queryRule.getHead();
+			}
+
+			@Override
+			public FunctionCallFactory getFunctionCallFactory() {
+				return origProg.getFunctionCallFactory();
+			}
+
+			@Override
+			public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
+				return origProg.getUninterpretedFunctionSymbols();
+			}
+
+			@Override
+			public Set<TypeSymbol> getTypeSymbols() {
+				return origProg.getTypeSymbols();
+			}
+
+		};
+	}
+
+	private BasicProgram transformNoQuery(boolean useDemandTransformation, boolean restoreStratification)
+			throws InvalidProgramException {
+		topDownIsDefault = false;
+		Set<RelationSymbol> bottomUpSymbols = new HashSet<>();
+		for (RelationSymbol sym : origProg.getRuleSymbols()) {
+			if (!sym.isTopDown()) {
+				bottomUpSymbols.add(sym);
+			}
+		}
+		Set<Pair<BasicRule, Integer>> adRules = adorn(bottomUpSymbols);
+		Set<BasicRule> magicRules = makeMagicRules(adRules);
+		BasicProgram magicProg = new ProgramImpl(magicRules, null);
+		if (restoreStratification && !isStratified(magicProg)) {
+			magicProg = stratify(magicProg, Pair.map(adRules, (rule, num) -> rule));
+		}
+		if (useDemandTransformation) {
+			magicProg = applyDemandTransformation(magicProg, restoreStratification);
+		}
+		return magicProg;
+	}
+
+	private BasicProgram applyDemandTransformation(BasicProgram prog, boolean mustBeStratified)
+			throws InvalidProgramException {
+		BasicProgram prog2 = stripAdornments(prog);
+		if (isStratified(prog2)) {
+			return prog2;
+		}
+		return prog;
+	}
+
+	private BasicProgram stripAdornments(BasicProgram prog) throws InvalidProgramException {
+		Set<BasicRule> rules = new HashSet<>();
+		for (RelationSymbol sym : prog.getRuleSymbols()) {
+			for (BasicRule r : prog.getRules(sym)) {
+				UserPredicate newHead = stripAdornment(r.getHead());
+				List<ComplexLiteral> newBody = new ArrayList<>();
+				for (ComplexLiteral atom : r) {
+					newBody.add(stripAdornment(atom));
+				}
+				rules.add(BasicRule.make(newHead, newBody));
+			}
+		}
+		UserPredicate query = null;
+		if (prog.hasQuery()) {
+			query = stripAdornment(prog.getQuery());
+		}
+		return new ProgramImpl(rules, query);
+	}
+
+	private static <C extends ComplexLiteral> C stripAdornment(C atom) {
+		return atom.accept(new ComplexLiteralVisitor<Void, C>() {
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public C visit(UnificationPredicate unificationPredicate, Void input) {
+				return (C) unificationPredicate;
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public C visit(UserPredicate userPredicate, Void input) {
+				RelationSymbol sym = userPredicate.getSymbol();
+				if (sym instanceof PositiveSymbol) {
+					sym = ((PositiveSymbol) sym).getBaseSymbol();
+					if (sym instanceof AdornedSymbol) {
+						sym = ((AdornedSymbol) sym).getBaseSymbol();
+					}
+					sym = new PositiveSymbol(sym);
+				} else if (sym instanceof AdornedSymbol) {
+					sym = ((AdornedSymbol) sym).getBaseSymbol();
+				}
+				return (C) UserPredicate.make(sym, userPredicate.getArgs(), userPredicate.isNegated());
+			}
+
+		}, null);
+	}
+
+	private Set<Pair<BasicRule, Integer>> adorn(Set<RelationSymbol> seeds) throws InvalidProgramException {
+		if (debug) {
+			System.err.println("Adorning rules...");
+		}
+		Set<Pair<BasicRule, Integer>> adRules = new HashSet<>();
+		DedupWorkList<RelationSymbol> worklist = new DedupWorkList<>();
+		for (RelationSymbol seed : seeds) {
+			worklist.push(seed);
+		}
+		HiddenPredicateFinder hpf = new HiddenPredicateFinder(origProg);
+		int ruleNum = 0;
+		while (!worklist.isEmpty()) {
+			RelationSymbol adSym = worklist.pop();
+			RelationSymbol origSym = adSym;
+			if (adSym instanceof AdornedSymbol) {
+				origSym = ((AdornedSymbol) adSym).getBaseSymbol();
+			}
+			for (BasicRule r : origProg.getRules(origSym)) {
+				for (RelationSymbol sym : hpf.visit(r)) {
+					if (exploreTopDown(sym)) {
+						throw new InvalidProgramException("Cannot refer to top-down IDB predicate " + sym
+								+ " in a function; consider annotating " + sym + " with @bottomup");
+					}
+					if (sym.isIdbSymbol()) {
+						worklist.push(sym);
+					}
+				}
+				UserPredicate head = r.getHead();
+				UserPredicate adHead = UserPredicate.make(adSym, head.getArgs(), head.isNegated());
+				BasicRule adRule = Adornments.adornRule(adHead, Util.iterableToList(r), topDownIsDefault);
+				for (ComplexLiteral a : adRule) {
+					a.accept(new ComplexLiteralVisitor<Void, Void>() {
+
+						@Override
+						public Void visit(UnificationPredicate unificationPredicate, Void input) {
+							// Do nothing
+							return null;
+						}
+
+						@Override
+						public Void visit(UserPredicate userPredicate, Void input) {
+							RelationSymbol sym = userPredicate.getSymbol();
+							if (sym.isIdbSymbol()) {
+								worklist.push(sym);
+							}
+							return null;
+						}
+
+					}, null);
+				}
+				if (debug) {
+					System.err.println("--" + ruleNum + "--\n" + adRule);
+				}
+				adRules.add(new Pair<>(adRule, ruleNum));
+				ruleNum++;
+			}
+		}
+		return adRules;
+	}
+
+	private Set<BasicRule> makeMagicRules(Set<Pair<BasicRule, Integer>> adornedRules) {
+		Set<BasicRule> magicRules = new HashSet<>();
+		for (Pair<BasicRule, Integer> p : adornedRules) {
+			magicRules.addAll(makeMagicRules(p.fst(), p.snd()));
+		}
+		return magicRules;
+	}
+
+	private boolean exploreTopDown(RelationSymbol sym) {
+		if (sym instanceof AdornedSymbol) {
+			sym = ((AdornedSymbol) sym).getBaseSymbol();
+		}
+		if (!sym.isIdbSymbol()) {
+			return false;
+		}
+		return sym.isTopDown() || (topDownIsDefault && !sym.isBottomUp());
+	}
+
+	private Set<BasicRule> makeMagicRules(BasicRule r, int number) {
+		int[] supCount = { 0 };
+		Set<BasicRule> magicRules = new HashSet<>();
+		List<Set<Var>> liveVarsByAtom = liveVarsByAtom(r);
+		List<ComplexLiteral> l = new ArrayList<>();
+		UserPredicate head = r.getHead();
+		Set<Var> curLiveVars = new HashSet<>();
+		if (exploreTopDown(head.getSymbol())) {
+			UserPredicate inputAtom = createInputAtom(head);
+			l.add(inputAtom);
+			curLiveVars.addAll(inputAtom.varSet());
+		}
+		int i = 0;
+		for (ComplexLiteral a : r) {
+			Set<Var> futureLiveVars = liveVarsByAtom.get(i);
+			Set<Var> nextLiveVars = curLiveVars.stream().filter(futureLiveVars::contains).collect(Collectors.toSet());
+			l = a.accept(new ComplexLiteralVisitor<List<ComplexLiteral>, List<ComplexLiteral>>() {
+
+				@Override
+				public List<ComplexLiteral> visit(UnificationPredicate unificationPredicate, List<ComplexLiteral> l) {
+					l.add(a);
+					return l;
+				}
+
+				@Override
+				public List<ComplexLiteral> visit(UserPredicate userPredicate, List<ComplexLiteral> l) {
+					RelationSymbol sym = userPredicate.getSymbol();
+					if (exploreTopDown(sym)) {
+						Set<Var> supVars = a.varSet().stream().filter(curLiveVars::contains)
+								.collect(Collectors.toSet());
+						supVars.addAll(nextLiveVars);
+						UserPredicate supAtom = createSupAtom(supVars, number, supCount[0], head.getSymbol());
+						magicRules.add(BasicRule.make(supAtom, l));
+						magicRules.add(
+								BasicRule.make(createInputAtom(userPredicate), Collections.singletonList(supAtom)));
+						l = new ArrayList<>();
+						l.add(supAtom);
+						l.add(a);
+						supCount[0]++;
+					} else {
+						l.add(a);
+					}
+					return l;
+				}
+
+			}, l);
+			curLiveVars.clear();
+			curLiveVars.addAll(nextLiveVars);
+			for (Var v : a.varSet()) {
+				if (futureLiveVars.contains(v)) {
+					curLiveVars.add(v);
+				}
+			}
+			i++;
+		}
+		magicRules.add(BasicRule.make(head, l));
+		return magicRules;
+	}
+
+	private List<Set<Var>> liveVarsByAtom(BasicRule r) {
+		List<Set<Var>> liveVars = new ArrayList<>();
+		Set<Var> acc = r.getHead().varSet();
+		liveVars.add(acc);
+		for (int i = r.getBodySize() - 1; i > 0; i--) {
+			acc = new HashSet<>(acc);
+			acc.addAll(r.getBody(i).varSet());
+			liveVars.add(acc);
+		}
+		Collections.reverse(liveVars);
+		return liveVars;
+	}
+
+	private UserPredicate createSupAtom(Set<Var> curLiveVars, int ruleNum, int supCount, Symbol headSym) {
+		List<Term> l = new ArrayList<>(curLiveVars);
+		l.sort(new Comparator<Term>() {
+
+			@Override
+			public int compare(Term o1, Term o2) {
+				return o1.toString().compareTo(o2.toString());
+			}
+
+		});
+		Term[] args = l.toArray(new Term[0]);
+		SupSymbol supSym = new SupSymbol(ruleNum, supCount, args.length);
+		return UserPredicate.make(supSym, args, false);
+	}
+
+	private UserPredicate createInputAtom(UserPredicate a) {
+		AdornedSymbol headSym = (AdornedSymbol) a.getSymbol();
+		InputSymbol inputSym = new InputSymbol(headSym);
+		Term[] inputArgs = new Term[inputSym.getArity()];
+		Term[] args = a.getArgs();
+		boolean[] adornment = headSym.getAdornment();
+		for (int i = 0, j = 0; i < args.length; i++) {
+			if (adornment[i]) {
+				inputArgs[j] = args[i];
+				j++;
+			}
+		}
+		return UserPredicate.make(inputSym, inputArgs, false);
+	}
+
+	public static class SupSymbol implements RelationSymbol {
+
+		private final int ruleNum;
+		private final int supCount;
+		private final int arity;
+
+		public SupSymbol(int ruleNum, int supCount, int arity) {
+			this.ruleNum = ruleNum;
+			this.supCount = supCount;
+			this.arity = arity;
+		}
+
+		@Override
+		public int getArity() {
+			return arity;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + arity;
+			result = prime * result + ruleNum;
+			result = prime * result + supCount;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			SupSymbol other = (SupSymbol) obj;
+			if (arity != other.arity)
+				return false;
+			if (ruleNum != other.ruleNum)
+				return false;
+			if (supCount != other.supCount)
+				return false;
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "sup_" + ruleNum + "_" + supCount;
+		}
+
+		@Override
+		public FunctorType getCompileTimeType() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isIdbSymbol() {
+			return true;
+		}
+
+		@Override
+		public boolean isDisk() {
+			return false;
+		}
+
+		@Override
+		public boolean isBottomUp() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isTopDown() {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	public static class InputSymbol extends AbstractWrappedRelationSymbol<AdornedSymbol> {
+
+		private final int arity;
+
+		public InputSymbol(AdornedSymbol baseSymbol) {
+			super(baseSymbol);
+			int nbound = 0;
+			for (boolean b : getBaseSymbol().getAdornment()) {
+				nbound += b ? 1 : 0;
+			}
+			arity = nbound;
+		}
+
+		@Override
+		public int getArity() {
+			return arity;
+		}
+
+		@Override
+		public String toString() {
+			return "input_" + getBaseSymbol();
+		}
+
+		@Override
+		public FunctorType getCompileTimeType() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isBottomUp() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isTopDown() {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	private boolean isStratified(BasicProgram p) {
+		try {
+			Stratifier stratifier = new Stratifier(p);
+			for (Stratum s : stratifier.stratify()) {
+				if (s.hasRecursiveNegationOrAggregation()) {
+					return false;
+				}
+			}
+			return true;
+		} catch (InvalidProgramException e) {
+			return false;
+		}
+	}
+
+	private Set<BasicRule> adjustAdornedRules(Collection<BasicRule> adRules) {
+		Set<BasicRule> newRules = new HashSet<>();
+		for (BasicRule r : adRules) {
+			UserPredicate head = r.getHead();
+			if (exploreTopDown(head.getSymbol())) {
+				List<ComplexLiteral> body = new ArrayList<>();
+				body.add(createInputAtom(head));
+				r.forEach(body::add);
+				newRules.add(BasicRule.make(head, body));
+			} else {
+				newRules.add(r);
+			}
+		}
+		return newRules;
+	}
+
+	private ProgramImpl stratify(BasicProgram p, Set<BasicRule> adornedRules) throws InvalidProgramException {
+		Set<BasicRule> newRules = new HashSet<>();
+		for (RelationSymbol sym : p.getRuleSymbols()) {
+			for (BasicRule r : p.getRules(sym)) {
+				UserPredicate head = makePositive(r.getHead());
+				List<ComplexLiteral> body = makePositive(r);
+				newRules.add(BasicRule.make(head, body));
+			}
+		}
+		newRules.addAll(adjustAdornedRules(adornedRules));
+		return new ProgramImpl(newRules, p.getQuery());
+	}
+
+	private <C extends ComplexLiteral> C makePositive(C atom) {
+		return atom.accept(new ComplexLiteralVisitor<Void, C>() {
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public C visit(UnificationPredicate unificationPredicate, Void input) {
+				return (C) unificationPredicate;
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public C visit(UserPredicate userPredicate, Void input) {
+				RelationSymbol sym = userPredicate.getSymbol();
+				if (sym.isIdbSymbol() && !(sym instanceof InputSymbol || sym instanceof SupSymbol)) {
+					if (userPredicate.isNegated()) {
+						return null;
+					}
+					userPredicate = UserPredicate.make(new PositiveSymbol(sym), userPredicate.getArgs(), false);
+				}
+				return (C) userPredicate;
+			}
+
+		}, null);
+	}
+
+	private List<ComplexLiteral> makePositive(Iterable<ComplexLiteral> atoms) {
+		List<ComplexLiteral> l = new ArrayList<>();
+		for (ComplexLiteral a : atoms) {
+			ComplexLiteral b = makePositive(a);
+			if (b != null) {
+				l.add(b);
+			}
+		}
+		return l;
+	}
+
+	private static class PositiveSymbol extends AbstractWrappedRelationSymbol<RelationSymbol> {
+
+		public PositiveSymbol(RelationSymbol baseSymbol) {
+			super(baseSymbol);
+		}
+
+		@Override
+		public String toString() {
+			return "p_" + getBaseSymbol();
+		}
+
+		@Override
+		public FunctorType getCompileTimeType() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isBottomUp() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isTopDown() {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	private static class HiddenPredicateFinder {
+
+		private final Program<UserPredicate, BasicRule> origProg;
+		private final Set<FunctionSymbol> visitedFunctions = new HashSet<>();
+		private final Set<RelationSymbol> seenPredicates = new HashSet<>();
+
+		public HiddenPredicateFinder(Program<UserPredicate, BasicRule> origProg) {
+			this.origProg = origProg;
+		}
+
+		private void findHiddenPredicates(Term t, Set<RelationSymbol> s) {
+			t.accept(predicatesInTermExtractor, s);
+		}
+
+		public Set<RelationSymbol> allSeenPredicates() {
+			return seenPredicates;
+		}
+
+		public Set<RelationSymbol> visit(UserFunctionDef def) {
+			Set<RelationSymbol> s = new HashSet<>();
+			if (visitedFunctions.add(def.getSymbol())) {
+				findHiddenPredicates(def.getBody(), s);
+			}
+			return s;
+		}
+
+		private void visit(ComplexLiteral l, Set<RelationSymbol> s) {
+			l.accept(new ComplexLiteralVisitor<Void, Void>() {
+
+				@Override
+				public Void visit(UnificationPredicate unificationPredicate, Void input) {
+					findHiddenPredicates(unificationPredicate.getLhs(), s);
+					findHiddenPredicates(unificationPredicate.getRhs(), s);
+					return null;
+				}
+
+				@Override
+				public Void visit(UserPredicate userPredicate, Void input) {
+					for (Term t : userPredicate.getArgs()) {
+						findHiddenPredicates(t, s);
+					}
+					return null;
+				}
+
+			}, null);
+		}
+
+		public Set<RelationSymbol> visit(Rule<? extends ComplexLiteral, ? extends ComplexLiteral> rule) {
+			Set<RelationSymbol> s = new HashSet<>();
+			visit(rule.getHead(), s);
+			for (ComplexLiteral l : rule) {
+				visit(l, s);
+			}
+			return s;
+		}
+
+		private TermVisitor<Set<RelationSymbol>, Void> predicatesInTermExtractor = new TermVisitor<Set<RelationSymbol>, Void>() {
+
+			@Override
+			public Void visit(Var t, Set<RelationSymbol> in) {
+				return null;
+			}
+
+			@Override
+			public Void visit(Constructor c, Set<RelationSymbol> in) {
+				for (Term t : c.getArgs()) {
+					t.accept(this, in);
+				}
+				return null;
+			}
+
+			@Override
+			public Void visit(Primitive<?> p, Set<RelationSymbol> in) {
+				return null;
+			}
+
+			@Override
+			public Void visit(Expr e, Set<RelationSymbol> in) {
+				e.accept(predicatesInExprExtractor, in);
+				return null;
+			}
+
+		};
+
+		private ExprVisitor<Set<RelationSymbol>, Void> predicatesInExprExtractor = new ExprVisitor<Set<RelationSymbol>, Void>() {
+
+			@Override
+			public Void visit(MatchExpr matchExpr, Set<RelationSymbol> in) {
+				matchExpr.getMatchee().accept(predicatesInTermExtractor, in);
+				for (MatchClause cl : matchExpr) {
+					cl.getRhs().accept(predicatesInTermExtractor, in);
+				}
+				return null;
+			}
+
+			@Override
+			public Void visit(FunctionCall funcCall, Set<RelationSymbol> in) {
+				FunctionSymbol sym = funcCall.getSymbol();
+				if (visitedFunctions.add(sym)) {
+					if (sym instanceof PredicateFunctionSymbol) {
+						RelationSymbol psym = ((PredicateFunctionSymbol) sym).getPredicateSymbol();
+						seenPredicates.add(psym);
+						in.add(psym);
+					}
+					FunctionDef def = origProg.getDef(sym);
+					if (def instanceof UserFunctionDef) {
+						((UserFunctionDef) def).getBody().accept(predicatesInTermExtractor, in);
+					}
+				}
+				for (Term t : funcCall.getArgs()) {
+					t.accept(predicatesInTermExtractor, in);
+				}
+				return null;
+			}
+
+			@Override
+			public Void visit(LetFunExpr funcDef, Set<RelationSymbol> in) {
+				throw new AssertionError("impossible");
+			}
+
+			@Override
+			public Void visit(Fold fold, Set<RelationSymbol> in) {
+				fold.getShamCall().accept(this, in);
+				return null;
+			}
+
+		};
+
+	}
+
+	private class ProgramImpl implements BasicProgram {
+
+		private final Map<RelationSymbol, Set<BasicRule>> rules = new HashMap<>();
+		private final Map<RelationSymbol, Set<Term[]>> facts = new HashMap<>();
+		private final UserPredicate query;
+
+		public ProgramImpl(Set<BasicRule> rs, UserPredicate query) throws InvalidProgramException {
+			SymbolManager sm = origProg.getSymbolManager();
+			HiddenPredicateFinder hpf = new HiddenPredicateFinder(origProg);
+			for (BasicRule r : rs) {
+				RelationSymbol headSym = r.getHead().getSymbol();
+				Util.lookupOrCreate(rules, headSym, HashSet::new).add(r);
+				sm.registerSymbol(headSym);
+				for (ComplexLiteral l : r) {
+					if (l instanceof UserPredicate) {
+						RelationSymbol sym = ((UserPredicate) l).getSymbol();
+						sm.registerSymbol(sym);
+						if (sym.isEdbSymbol()) {
+							facts.putIfAbsent(sym, origProg.getFacts(sym));
+						} else {
+							rules.putIfAbsent(sym, new HashSet<>());
+						}
+					}
+				}
+				hpf.visit(r);
+			}
+			for (FunctionSymbol sym : origProg.getFunctionSymbols()) {
+				FunctionDef def = origProg.getDef(sym);
+				if (def instanceof UserFunctionDef) {
+					hpf.visit((UserFunctionDef) def);
+				}
+			}
+			for (RelationSymbol psym : hpf.allSeenPredicates()) {
+				if (exploreTopDown(psym)) {
+					throw new InvalidProgramException("Cannot refer to top-down IDB predicate " + psym
+							+ " in a function; consider annotating " + psym + " with @bottomup");
+				}
+				if (psym.isEdbSymbol()) {
+					facts.putIfAbsent(psym, origProg.getFacts(psym));
+				}
+				if (psym.isIdbSymbol()) {
+					rules.putIfAbsent(psym, new HashSet<>());
+				}
+			}
+			// Do not keep unnecessary facts around if there is a query.
+			if (query == null) {
+				for (RelationSymbol sym : origProg.getFactSymbols()) {
+					facts.putIfAbsent(sym, origProg.getFacts(sym));
+				}
+			}
+			this.query = query;
+		}
+
+		@Override
+		public Set<FunctionSymbol> getFunctionSymbols() {
+			return origProg.getFunctionSymbols();
+		}
+
+		@Override
+		public Set<RelationSymbol> getFactSymbols() {
+			return Collections.unmodifiableSet(facts.keySet());
+		}
+
+		@Override
+		public Set<RelationSymbol> getRuleSymbols() {
+			return Collections.unmodifiableSet(rules.keySet());
+		}
+
+		@Override
+		public FunctionDef getDef(FunctionSymbol sym) {
+			return origProg.getDef(sym);
+		}
+
+		@Override
+		public Set<Term[]> getFacts(RelationSymbol sym) {
+			assert sym.isEdbSymbol();
+			return Util.lookupOrCreate(facts, sym, () -> Collections.emptySet());
+		}
+
+		@Override
+		public Set<BasicRule> getRules(RelationSymbol sym) {
+			assert sym.isIdbSymbol();
+			return Util.lookupOrCreate(rules, sym, () -> Collections.emptySet());
+		}
+
+		@Override
+		public SymbolManager getSymbolManager() {
+			return origProg.getSymbolManager();
+		}
+
+		@Override
+		public boolean hasQuery() {
+			return query != null;
+		}
+
+		@Override
+		public UserPredicate getQuery() {
+			return query;
+		}
+
+		@Override
+		public FunctionCallFactory getFunctionCallFactory() {
+			return origProg.getFunctionCallFactory();
+		}
+
+		@Override
+		public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
+			return origProg.getUninterpretedFunctionSymbols();
+		}
+
+		@Override
+		public Set<TypeSymbol> getTypeSymbols() {
+			return origProg.getTypeSymbols();
+		}
+
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParseException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParseException.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.parsing;
  * #L%
  */
 
-
 /**
  * An exception signifying a parsing error.
  *
@@ -30,7 +29,7 @@ public class ParseException extends Exception {
 	private static final long serialVersionUID = 1L;
 	private final String fileName;
 	private final int lineNo;
-	
+
 	/**
 	 * Constructs an exception signifying a parsing error.
 	 */
@@ -39,7 +38,7 @@ public class ParseException extends Exception {
 		this.fileName = fileName;
 		this.lineNo = lineNo;
 	}
-	
+
 	/**
 	 * Constructs an exception signifying a parsing error.
 	 */
@@ -56,7 +55,7 @@ public class ParseException extends Exception {
 	public String getFileName() {
 		return fileName;
 	}
-	
+
 	public int getLineNo() {
 		return lineNo;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/Parser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/Parser.java
@@ -57,100 +57,99 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class Parser {
 
-    private final ParsingContext pc = new ParsingContext();
+	private final ParsingContext pc = new ParsingContext();
 
-    private FormulogParser getParser(Reader r, boolean isTsv) throws ParseException {
-        try {
-            CharStream chars = CharStreams.fromReader(r);
-            FormulogLexer lexer = new FormulogLexer(chars);
-            TokenStream tokens = isTsv ? new BufferedTokenStream(lexer) : new CommonTokenStream(lexer);
-            return new FormulogParser(tokens);
-        } catch (IOException e) {
-            throw new ParseException(0, e.getMessage());
-        }
-    }
+	private FormulogParser getParser(Reader r, boolean isTsv) throws ParseException {
+		try {
+			CharStream chars = CharStreams.fromReader(r);
+			FormulogLexer lexer = new FormulogLexer(chars);
+			TokenStream tokens = isTsv ? new BufferedTokenStream(lexer) : new CommonTokenStream(lexer);
+			return new FormulogParser(tokens);
+		} catch (IOException e) {
+			throw new ParseException(0, e.getMessage());
+		}
+	}
 
-    public BasicProgram parse(Reader r) throws ParseException {
-        return parse(r, Collections.emptyList());
-    }
+	public BasicProgram parse(Reader r) throws ParseException {
+		return parse(r, Collections.emptyList());
+	}
 
-    public BasicProgram parse(Reader r, List<Path> inputDirs) throws ParseException {
-        try {
-            FormulogParser parser = getParser(r, false);
-            ProgContext progCtx = parser.prog();
-            Pair<BasicProgram, Set<RelationSymbol>> p = new TopLevelParser(pc).parse(progCtx);
-            BasicProgram prog = p.fst();
-            loadExternalEdbs(prog, p.snd(), inputDirs);
-            return prog;
-        } catch (UncheckedParseException e) {
-            throw new ParseException(e);
-        }
-    }
+	public BasicProgram parse(Reader r, List<Path> inputDirs) throws ParseException {
+		try {
+			FormulogParser parser = getParser(r, false);
+			ProgContext progCtx = parser.prog();
+			Pair<BasicProgram, Set<RelationSymbol>> p = new TopLevelParser(pc).parse(progCtx);
+			BasicProgram prog = p.fst();
+			loadExternalEdbs(prog, p.snd(), inputDirs);
+			return prog;
+		} catch (UncheckedParseException e) {
+			throw new ParseException(e);
+		}
+	}
 
-    public Set<Term[]> parseFacts(RelationSymbol sym, Reader factStream) throws ParseException {
-        Set<Term[]> facts = new HashSet<>();
-        FormulogParser parser = getParser(factStream, true);
-        FactFileParser fpp = new FactFileParser(pc);
-        fpp.loadFacts(parser.tsvFile(), sym.getArity(), facts);
-        return facts;
-    }
+	public Set<Term[]> parseFacts(RelationSymbol sym, Reader factStream) throws ParseException {
+		Set<Term[]> facts = new HashSet<>();
+		FormulogParser parser = getParser(factStream, true);
+		FactFileParser fpp = new FactFileParser(pc);
+		fpp.loadFacts(parser.tsvFile(), sym.getArity(), facts);
+		return facts;
+	}
 
-    private void loadExternalEdbs(Program<UserPredicate, BasicRule> prog, Set<RelationSymbol> rels, List<Path> inputDirs)
-            throws ParseException {
-        if (rels.isEmpty() || inputDirs.isEmpty()) {
-            return;
-        }
-        ExecutorService exec = Executors.newFixedThreadPool(Main.parallelism);
-        List<Future<?>> tasks = new ArrayList<>();
-        for (Path inputDir : inputDirs) {
-            for (RelationSymbol sym : rels) {
-                tasks.add(exec.submit(new Runnable() {
+	private void loadExternalEdbs(Program<UserPredicate, BasicRule> prog, Set<RelationSymbol> rels,
+			List<Path> inputDirs) throws ParseException {
+		if (rels.isEmpty() || inputDirs.isEmpty()) {
+			return;
+		}
+		ExecutorService exec = Executors.newFixedThreadPool(Main.parallelism);
+		List<Future<?>> tasks = new ArrayList<>();
+		for (Path inputDir : inputDirs) {
+			for (RelationSymbol sym : rels) {
+				tasks.add(exec.submit(new Runnable() {
 
-                    @Override
-                    public void run() {
-                        try {
-                            readEdbFromFile(sym, inputDir, prog.getFacts(sym));
-                        } catch (ParseException e) {
-                            throw new UncheckedParseException(e);
-                        }
-                    }
+					@Override
+					public void run() {
+						try {
+							readEdbFromFile(sym, inputDir, prog.getFacts(sym));
+						} catch (ParseException e) {
+							throw new UncheckedParseException(e);
+						}
+					}
 
-                }));
-            }
-        }
-        exec.shutdown();
-        try {
-            for (Future<?> task : tasks) {
-                task.get();
-            }
-        } catch (InterruptedException e) {
-            throw new ParseException(0, e.getMessage());
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof UncheckedParseException) {
-                throw new ParseException((UncheckedParseException) cause);
-            }
-            throw new ParseException(0, e.getMessage());
-        }
-    }
+				}));
+			}
+		}
+		exec.shutdown();
+		try {
+			for (Future<?> task : tasks) {
+				task.get();
+			}
+		} catch (InterruptedException e) {
+			throw new ParseException(0, e.getMessage());
+		} catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof UncheckedParseException) {
+				throw new ParseException((UncheckedParseException) cause);
+			}
+			throw new ParseException(0, e.getMessage());
+		}
+	}
 
-    private void readEdbFromFile(RelationSymbol sym, Path inputDir, Set<Term[]> acc)
-            throws ParseException {
-        Path path = inputDir.resolve(sym.toString() + ".tsv");
-        try (FileReader fr = new FileReader(path.toFile())) {
-            FormulogParser parser = getParser(fr, true);
-            parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
-            FactFileParser fpp = new FactFileParser(pc);
-            fpp.loadFacts(parser.tsvFile(), sym.getArity(), acc);
-        } catch (FileNotFoundException e) {
-            throw new ParseException(0, "Could not find external fact file: " + path);
-        } catch (IOException e) {
-            throw new ParseException(path.toString(), 0, e.getMessage());
-        } catch (UncheckedParseException e) {
-            throw new ParseException(path.toString(), e.getLineNo(), e.getMessage());
-        } catch (ParseException e) {
-            throw new ParseException(path.toString(), e.getLineNo(), e.getMessage());
-        }
-    }
+	private void readEdbFromFile(RelationSymbol sym, Path inputDir, Set<Term[]> acc) throws ParseException {
+		Path path = inputDir.resolve(sym.toString() + ".tsv");
+		try (FileReader fr = new FileReader(path.toFile())) {
+			FormulogParser parser = getParser(fr, true);
+			parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+			FactFileParser fpp = new FactFileParser(pc);
+			fpp.loadFacts(parser.tsvFile(), sym.getArity(), acc);
+		} catch (FileNotFoundException e) {
+			throw new ParseException(0, "Could not find external fact file: " + path);
+		} catch (IOException e) {
+			throw new ParseException(path.toString(), 0, e.getMessage());
+		} catch (UncheckedParseException e) {
+			throw new ParseException(path.toString(), e.getLineNo(), e.getMessage());
+		} catch (ParseException e) {
+			throw new ParseException(path.toString(), e.getLineNo(), e.getMessage());
+		}
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParsingContext.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParsingContext.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.parsing;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,33 +36,33 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 class ParsingContext {
 
 	private final SymbolManager sm = new SymbolManager();
-	private final FunctionDefManager fdm = new FunctionDefManager(); 
+	private final FunctionDefManager fdm = new FunctionDefManager();
 	private final FunctionCallFactory fcf = new FunctionCallFactory(fdm);
 	private final Map<FunctionSymbol, Pair<AlgebraicDataType, Integer>> rl = new HashMap<>();
 	private final Map<ConstructorSymbol, FunctionSymbol[]> cl = new HashMap<>();
 	private final TypeManager tm = new TypeManager();
 	private final Map<String, AtomicInteger> nfc = new HashMap<>();
-	
+
 	public SymbolManager symbolManager() {
 		return sm;
 	}
-	
+
 	public FunctionCallFactory functionCallFactory() {
 		return fcf;
 	}
-	
+
 	public FunctionDefManager functionDefManager() {
 		return fdm;
 	}
-	
+
 	public Map<FunctionSymbol, Pair<AlgebraicDataType, Integer>> recordLabels() {
 		return rl;
 	}
-	
+
 	public Map<ConstructorSymbol, FunctionSymbol[]> constructorLabels() {
 		return cl;
 	}
-	
+
 	public TypeManager typeManager() {
 		return tm;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParsingUtil.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/ParsingUtil.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.parsing;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.util.Util.map;
 
 import java.util.ArrayList;
@@ -47,74 +46,74 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 final class ParsingUtil {
 
-    private ParsingUtil() {
-        throw new AssertionError();
-    }
+	private ParsingUtil() {
+		throw new AssertionError();
+	}
 
-    public static List<Param> extractParams(ParsingContext pc, ParameterListContext ctx) {
-        List<Param> l = new ArrayList<>();
-        for (ParameterContext param : ctx.parameter()) {
-            l.add(extractParam(pc, param));
-        }
-        return l;
-    }
+	public static List<Param> extractParams(ParsingContext pc, ParameterListContext ctx) {
+		List<Param> l = new ArrayList<>();
+		for (ParameterContext param : ctx.parameter()) {
+			l.add(extractParam(pc, param));
+		}
+		return l;
+	}
 
-    public static Param extractParam(ParsingContext pc, ParameterContext ctx) {
-        return ctx.accept(new FormulogBaseVisitor<Param>() {
+	public static Param extractParam(ParsingContext pc, ParameterContext ctx) {
+		return ctx.accept(new FormulogBaseVisitor<Param>() {
 
-            @Override
-            public Param visitWildCardParam(WildCardParamContext ctx) {
-                return Param.wildCard();
-            }
+			@Override
+			public Param visitWildCardParam(WildCardParamContext ctx) {
+				return Param.wildCard();
+			}
 
-            @Override
-            public Param visitTypeParam(TypeParamContext ctx) {
-                TypeExtractor typeExtractor = new TypeExtractor(pc);
-                return Param.wildCard(typeExtractor.extract(ctx.type()));
-            }
+			@Override
+			public Param visitTypeParam(TypeParamContext ctx) {
+				TypeExtractor typeExtractor = new TypeExtractor(pc);
+				return Param.wildCard(typeExtractor.extract(ctx.type()));
+			}
 
-            @Override
-            public Param visitIntParam(IntParamContext ctx) {
-                return Param.nat(Integer.parseInt(ctx.INT().getText()));
-            }
+			@Override
+			public Param visitIntParam(IntParamContext ctx) {
+				return Param.nat(Integer.parseInt(ctx.INT().getText()));
+			}
 
-        });
-    }
+		});
+	}
 
-    public static Pair<FunctionSymbol, List<Var>> extractFunDeclaration(ParsingContext pc, FunDefLHSContext ctx,
-                                                                        boolean isNested) {
-        String name = ctx.ID().getText();
-        if (pc.symbolManager().hasConstructorSymbolWithName(name)) {
-            throw new RuntimeException("Cannot create a function with name of constructor: " + name);
-        }
-        if (isNested) {
-            AtomicInteger cnt = Util.lookupOrCreate(pc.nestedFunctionCounters(), name, AtomicInteger::new);
-            name += "$" + cnt.getAndIncrement();
-        }
-        TypeExtractor typeExtractor = new TypeExtractor(pc);
-        List<Type> argTypes = typeExtractor.extract(ctx.args.type());
-        Type retType = typeExtractor.extract(ctx.retType);
-        FunctionSymbol sym = pc.symbolManager().createFunctionSymbol(name, argTypes.size(),
-                new FunctorType(argTypes, retType));
-        List<Var> args = map(ctx.args.var(), x -> Var.fresh(x.getText()));
-        if (args.size() != new HashSet<>(args).size()) {
-            throw new RuntimeException(
-                    "Cannot use the same variable multiple times in a function declaration: " + name);
-        }
-        return new Pair<>(sym, args);
-    }
+	public static Pair<FunctionSymbol, List<Var>> extractFunDeclaration(ParsingContext pc, FunDefLHSContext ctx,
+			boolean isNested) {
+		String name = ctx.ID().getText();
+		if (pc.symbolManager().hasConstructorSymbolWithName(name)) {
+			throw new RuntimeException("Cannot create a function with name of constructor: " + name);
+		}
+		if (isNested) {
+			AtomicInteger cnt = Util.lookupOrCreate(pc.nestedFunctionCounters(), name, AtomicInteger::new);
+			name += "$" + cnt.getAndIncrement();
+		}
+		TypeExtractor typeExtractor = new TypeExtractor(pc);
+		List<Type> argTypes = typeExtractor.extract(ctx.args.type());
+		Type retType = typeExtractor.extract(ctx.retType);
+		FunctionSymbol sym = pc.symbolManager().createFunctionSymbol(name, argTypes.size(),
+				new FunctorType(argTypes, retType));
+		List<Var> args = map(ctx.args.var(), x -> Var.fresh(x.getText()));
+		if (args.size() != new HashSet<>(args).size()) {
+			throw new RuntimeException(
+					"Cannot use the same variable multiple times in a function declaration: " + name);
+		}
+		return new Pair<>(sym, args);
+	}
 
-    public static List<Pair<FunctionSymbol, List<Var>>> extractFunDeclarations(ParsingContext pc,
-                                                                               List<FunDefLHSContext> ctxs, boolean isNested) {
-        return map(ctxs, ctx -> extractFunDeclaration(pc, ctx, isNested));
-    }
+	public static List<Pair<FunctionSymbol, List<Var>>> extractFunDeclarations(ParsingContext pc,
+			List<FunDefLHSContext> ctxs, boolean isNested) {
+		return map(ctxs, ctx -> extractFunDeclaration(pc, ctx, isNested));
+	}
 
-    public static Map<String, Identifier> varsToIds(Iterable<Var> vars) {
-        Map<String, Identifier> m = new HashMap<>();
-        for (Var x : vars) {
-            m.put(x.getName(), Identifier.make(x));
-        }
-        return m;
-    }
+	public static Map<String, Identifier> varsToIds(Iterable<Var> vars) {
+		Map<String, Identifier> m = new HashMap<>();
+		for (Var x : vars) {
+			m.put(x.getName(), Identifier.make(x));
+		}
+		return m;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/TermExtractor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/TermExtractor.java
@@ -105,738 +105,738 @@ import edu.harvard.seas.pl.formulog.util.StackMap;
 
 class TermExtractor {
 
-    private final ParsingContext pc;
-    private final StackMap<String, Identifier> env = new StackMap<>();
+	private final ParsingContext pc;
+	private final StackMap<String, Identifier> env = new StackMap<>();
 
-    public TermExtractor(ParsingContext parsingContext) {
-        pc = parsingContext;
-        env.push(new HashMap<>());
-    }
+	public TermExtractor(ParsingContext parsingContext) {
+		pc = parsingContext;
+		env.push(new HashMap<>());
+	}
 
-    public synchronized Term extract(TermContext ctx) {
-        try {
-            Term t = visitor.visit(ctx);
-            return t;
-        } catch (UncheckedParseException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new UncheckedParseException(ctx.start.getLine(), e.getMessage());
-        }
-    }
+	public synchronized Term extract(TermContext ctx) {
+		try {
+			Term t = visitor.visit(ctx);
+			return t;
+		} catch (UncheckedParseException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new UncheckedParseException(ctx.start.getLine(), e.getMessage());
+		}
+	}
 
-    public synchronized List<Term> extractList(List<TermContext> ctxs) {
-        List<Term> terms = new ArrayList<>();
-        for (TermContext ctx : ctxs) {
-            terms.add(extract(ctx));
-        }
-        return terms;
-    }
+	public synchronized List<Term> extractList(List<TermContext> ctxs) {
+		List<Term> terms = new ArrayList<>();
+		for (TermContext ctx : ctxs) {
+			terms.add(extract(ctx));
+		}
+		return terms;
+	}
 
-    public synchronized Term[] extractArray(List<TermContext> ctxs) {
-        Term[] terms = new Term[ctxs.size()];
-        int i = 0;
-        for (TermContext ctx : ctxs) {
-            terms[i] = visitor.visit(ctx);
-            i++;
-        }
-        return terms;
-    }
+	public synchronized Term[] extractArray(List<TermContext> ctxs) {
+		Term[] terms = new Term[ctxs.size()];
+		int i = 0;
+		for (TermContext ctx : ctxs) {
+			terms[i] = visitor.visit(ctx);
+			i++;
+		}
+		return terms;
+	}
 
-    public synchronized void pushIds(Map<String, Identifier> ids) {
-        env.push(ids);
-    }
+	public synchronized void pushIds(Map<String, Identifier> ids) {
+		env.push(ids);
+	}
 
-    public synchronized Map<String, Identifier> popIds() {
-        return env.pop();
-    }
+	public synchronized Map<String, Identifier> popIds() {
+		return env.pop();
+	}
 
-    private final FormulogVisitor<Term> visitor = new FormulogBaseVisitor<Term>() {
+	private final FormulogVisitor<Term> visitor = new FormulogBaseVisitor<Term>() {
 
-        private boolean inFormula;
-        private boolean inPattern;
+		private boolean inFormula;
+		private boolean inPattern;
 
-        private void assertNotInFormula(int lineNo, String msg) {
-            if (inFormula) {
-                throw new UncheckedParseException(lineNo, msg);
-            }
-        }
+		private void assertNotInFormula(int lineNo, String msg) {
+			if (inFormula) {
+				throw new UncheckedParseException(lineNo, msg);
+			}
+		}
 
-        private void toggleInFormula() {
-            inFormula = !inFormula;
-        }
+		private void toggleInFormula() {
+			inFormula = !inFormula;
+		}
 
-        @Override
-        public Term visitHoleTerm(HoleTermContext ctx) {
-            return Var.makeHole();
-        }
+		@Override
+		public Term visitHoleTerm(HoleTermContext ctx) {
+			return Var.makeHole();
+		}
 
-        @Override
-        public Term visitVarTerm(VarTermContext ctx) {
-            String name = ctx.VAR().getText();
-            Identifier id = env.get(name);
-            if (id == null) {
-                id = Identifier.make(Var.fresh(name));
-                env.put(name, id);
-            }
-            assert id.isVar();
-            return id.asVar();
-        }
+		@Override
+		public Term visitVarTerm(VarTermContext ctx) {
+			String name = ctx.VAR().getText();
+			Identifier id = env.get(name);
+			if (id == null) {
+				id = Identifier.make(Var.fresh(name));
+				env.put(name, id);
+			}
+			assert id.isVar();
+			return id.asVar();
+		}
 
-        @Override
-        public Term visitStringTerm(StringTermContext ctx) {
-            String s = ctx.QSTRING().getText();
-            return StringTerm.make(s.substring(1, s.length() - 1));
-        }
+		@Override
+		public Term visitStringTerm(StringTermContext ctx) {
+			String s = ctx.QSTRING().getText();
+			return StringTerm.make(s.substring(1, s.length() - 1));
+		}
 
-        @Override
-        public Term visitConsTerm(ConsTermContext ctx) {
-            Term[] args = extractArray(ctx.term());
-            return Constructors.make(BuiltInConstructorSymbol.CONS, args);
-        }
+		@Override
+		public Term visitConsTerm(ConsTermContext ctx) {
+			Term[] args = extractArray(ctx.term());
+			return Constructors.make(BuiltInConstructorSymbol.CONS, args);
+		}
 
-        private boolean isSpecialFormulaCtor(String name) {
-            if (pc.symbolManager().hasName(name)) {
-                Symbol sym = pc.symbolManager().lookupSymbol(name);
-                return sym instanceof ConstructorSymbol && isSpecialFormulaCtor((ConstructorSymbol) sym);
-            }
-            return false;
-        }
+		private boolean isSpecialFormulaCtor(String name) {
+			if (pc.symbolManager().hasName(name)) {
+				Symbol sym = pc.symbolManager().lookupSymbol(name);
+				return sym instanceof ConstructorSymbol && isSpecialFormulaCtor((ConstructorSymbol) sym);
+			}
+			return false;
+		}
 
-        // For a couple constructors, we want to make sure that their arguments are
-        // forced to be non-formula types. For example, the constructor bv_const needs
-        // to take something of type i32, not i32 smt.
-        private boolean isSpecialFormulaCtor(ConstructorSymbol sym) {
-            if (sym instanceof ParameterizedConstructorSymbol) {
-                switch (((ParameterizedConstructorSymbol) sym).getBase()) {
-                    case BV_BIG_CONST:
-                    case BV_CONST:
-                    case BV_EXTRACT:
-                    case FP_BIG_CONST:
-                    case FP_CONST:
-                        return true;
-                    default:
-                        break;
-                }
-            } else if (sym instanceof BuiltInConstructorSymbol) {
-                switch ((BuiltInConstructorSymbol) sym) {
-                    case INT_BIG_CONST:
-                    case INT_CONST:
-                        return true;
-                    default:
-                        break;
-                }
-            }
-            return false;
-        }
+		// For a couple constructors, we want to make sure that their arguments are
+		// forced to be non-formula types. For example, the constructor bv_const needs
+		// to take something of type i32, not i32 smt.
+		private boolean isSpecialFormulaCtor(ConstructorSymbol sym) {
+			if (sym instanceof ParameterizedConstructorSymbol) {
+				switch (((ParameterizedConstructorSymbol) sym).getBase()) {
+				case BV_BIG_CONST:
+				case BV_CONST:
+				case BV_EXTRACT:
+				case FP_BIG_CONST:
+				case FP_CONST:
+					return true;
+				default:
+					break;
+				}
+			} else if (sym instanceof BuiltInConstructorSymbol) {
+				switch ((BuiltInConstructorSymbol) sym) {
+				case INT_BIG_CONST:
+				case INT_CONST:
+					return true;
+				default:
+					break;
+				}
+			}
+			return false;
+		}
 
-        @Override
-        public Term visitIndexedFunctor(IndexedFunctorContext ctx) {
-            String name = ctx.id.getText();
-            if (name.equals("true") || name.equals("false")) {
-                return parseBool(ctx);
-            }
-            boolean wasInFormula = inFormula;
-            boolean isSpecial = isSpecialFormulaCtor(name);
-            if (isSpecial) {
-                inFormula = false;
-            }
-            List<Param> params = ParsingUtil.extractParams(pc, ctx.parameterList());
-            Term[] args = extractArray(ctx.termArgs().term());
-            if (inPattern && args.length == 0 && !pc.symbolManager().hasConstructorSymbolWithName(name)) {
-                Var x = Var.fresh(name);
-                env.put(name, Identifier.make(x));
-            }
-            Identifier id = env.get(name);
-            if (id != null && id.isVar()) {
-                if (args.length > 0) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Cannot apply a variable " + name + " to arguments.");
-                }
-                return id.asVar();
-            }
-            if (name.charAt(0) == '#' && args.length == 0) {
-                if (params.size() != 1) {
-                    throw new IllegalArgumentException("Expected a single parameter to solver variable: " + name);
-                }
-                Type ty = params.get(0).getType();
-                return extractSolverSymbol(StringTerm.make(name.substring(1)), ty);
-            }
-            Symbol sym = id != null ? id.asFunctionSymbol() : pc.symbolManager().lookupSymbol(name);
-            if (sym instanceof ParameterizedSymbol) {
-                sym = ((ParameterizedSymbol) sym).copyWithNewArgs(params);
-            } else if (!params.isEmpty()) {
-                throw new UncheckedParseException(ctx.start.getLine(), "Symbol " + sym + " is not parametric.");
-            }
-            adjustFunctorArgs(sym, args);
-            Term t = makeFunctor(ctx.start.getLine(), sym, args);
-            if (isSpecial) {
-                t = makeExitFormula(t);
-            }
-            inFormula = wasInFormula;
-            return t;
-        }
+		@Override
+		public Term visitIndexedFunctor(IndexedFunctorContext ctx) {
+			String name = ctx.id.getText();
+			if (name.equals("true") || name.equals("false")) {
+				return parseBool(ctx);
+			}
+			boolean wasInFormula = inFormula;
+			boolean isSpecial = isSpecialFormulaCtor(name);
+			if (isSpecial) {
+				inFormula = false;
+			}
+			List<Param> params = ParsingUtil.extractParams(pc, ctx.parameterList());
+			Term[] args = extractArray(ctx.termArgs().term());
+			if (inPattern && args.length == 0 && !pc.symbolManager().hasConstructorSymbolWithName(name)) {
+				Var x = Var.fresh(name);
+				env.put(name, Identifier.make(x));
+			}
+			Identifier id = env.get(name);
+			if (id != null && id.isVar()) {
+				if (args.length > 0) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Cannot apply a variable " + name + " to arguments.");
+				}
+				return id.asVar();
+			}
+			if (name.charAt(0) == '#' && args.length == 0) {
+				if (params.size() != 1) {
+					throw new IllegalArgumentException("Expected a single parameter to solver variable: " + name);
+				}
+				Type ty = params.get(0).getType();
+				return extractSolverSymbol(StringTerm.make(name.substring(1)), ty);
+			}
+			Symbol sym = id != null ? id.asFunctionSymbol() : pc.symbolManager().lookupSymbol(name);
+			if (sym instanceof ParameterizedSymbol) {
+				sym = ((ParameterizedSymbol) sym).copyWithNewArgs(params);
+			} else if (!params.isEmpty()) {
+				throw new UncheckedParseException(ctx.start.getLine(), "Symbol " + sym + " is not parametric.");
+			}
+			adjustFunctorArgs(sym, args);
+			Term t = makeFunctor(ctx.start.getLine(), sym, args);
+			if (isSpecial) {
+				t = makeExitFormula(t);
+			}
+			inFormula = wasInFormula;
+			return t;
+		}
 
-        private void adjustFunctorArgs(Symbol sym, Term[] args) {
-            if (sym instanceof ParameterizedConstructorSymbol) {
-                switch (((ParameterizedConstructorSymbol) sym).getBase()) {
-                    case BV_EXTRACT:
-                        args[0] = makeEnterFormula(args[0]);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
+		private void adjustFunctorArgs(Symbol sym, Term[] args) {
+			if (sym instanceof ParameterizedConstructorSymbol) {
+				switch (((ParameterizedConstructorSymbol) sym).getBase()) {
+				case BV_EXTRACT:
+					args[0] = makeEnterFormula(args[0]);
+					break;
+				default:
+					break;
+				}
+			}
+		}
 
-        private Term parseBool(IndexedFunctorContext ctx) {
-            String name = ctx.id.getText();
-            assert name.equals("true") || name.equals("false");
-            boolean val = name.equals("true");
-            if (!ctx.parameterList().parameter().isEmpty()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Boolean value " + val + " cannot be parameterized");
-            }
-            if (!ctx.termArgs().term().isEmpty()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Boolean value " + val + " cannot be applied to arguments");
-            }
-            return BoolTerm.mk(val);
-        }
+		private Term parseBool(IndexedFunctorContext ctx) {
+			String name = ctx.id.getText();
+			assert name.equals("true") || name.equals("false");
+			boolean val = name.equals("true");
+			if (!ctx.parameterList().parameter().isEmpty()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Boolean value " + val + " cannot be parameterized");
+			}
+			if (!ctx.termArgs().term().isEmpty()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Boolean value " + val + " cannot be applied to arguments");
+			}
+			return BoolTerm.mk(val);
+		}
 
-        private Term makeFunctor(int lineNo, Symbol sym, Term[] args) {
-            if (sym.getArity() != args.length) {
-                throw new UncheckedParseException(lineNo, "Symbol " + sym + " has arity " + sym.getArity()
-                        + ", but applied to " + args.length + " arg(s): " + Arrays.toString(args));
-            }
-            if (sym instanceof RelationSymbol) {
-                FunctionSymbol newSym = pc.symbolManager()
-                        .createPredicateFunctionSymbolPlaceholder((RelationSymbol) sym);
-                return pc.functionCallFactory().make(newSym, args);
-            } else if (sym instanceof FunctionSymbol) {
-                Term t = pc.functionCallFactory().make((FunctionSymbol) sym, args);
-                if (sym.getArity() > 0) {
-                    assertNotInFormula(lineNo, "Cannot invoke a non-nullary function from within a formula: " + t);
-                }
-                return t;
-            } else if (sym instanceof ConstructorSymbol) {
-                ConstructorSymbol csym = (ConstructorSymbol) sym;
-                Term t = Constructors.make(csym, args);
-                return t;
-            } else {
-                throw new UncheckedParseException(lineNo,
-                        "Cannot create a term with non-constructor, non-function symbol " + sym + ".");
-            }
-        }
+		private Term makeFunctor(int lineNo, Symbol sym, Term[] args) {
+			if (sym.getArity() != args.length) {
+				throw new UncheckedParseException(lineNo, "Symbol " + sym + " has arity " + sym.getArity()
+						+ ", but applied to " + args.length + " arg(s): " + Arrays.toString(args));
+			}
+			if (sym instanceof RelationSymbol) {
+				FunctionSymbol newSym = pc.symbolManager()
+						.createPredicateFunctionSymbolPlaceholder((RelationSymbol) sym);
+				return pc.functionCallFactory().make(newSym, args);
+			} else if (sym instanceof FunctionSymbol) {
+				Term t = pc.functionCallFactory().make((FunctionSymbol) sym, args);
+				if (sym.getArity() > 0) {
+					assertNotInFormula(lineNo, "Cannot invoke a non-nullary function from within a formula: " + t);
+				}
+				return t;
+			} else if (sym instanceof ConstructorSymbol) {
+				ConstructorSymbol csym = (ConstructorSymbol) sym;
+				Term t = Constructors.make(csym, args);
+				return t;
+			} else {
+				throw new UncheckedParseException(lineNo,
+						"Cannot create a term with non-constructor, non-function symbol " + sym + ".");
+			}
+		}
 
-        @Override
-        public Term visitFoldTerm(FoldTermContext ctx) {
-            assertNotInFormula(ctx.start.getLine(), "Cannot invoke a fold from within a formula: " + ctx.getText());
-            String name = ctx.ID().getText();
-            Identifier id = env.get(name);
-            if (id != null && id.isVar()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot use a variable as the function to fold: " + name);
-            }
-            Symbol sym = id != null ? id.asFunctionSymbol() : pc.symbolManager().lookupSymbol(name);
-            if (!(sym instanceof FunctionSymbol)) {
-                throw new UncheckedParseException(ctx.start.getLine(), "Cannot fold over non-function: " + sym);
-            }
-            if (sym.getArity() != 2) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Can only fold over a binary function, but " + sym + " has arity " + sym.getArity());
-            }
-            Term[] args = extractArray(ctx.termArgs().term());
-            return Fold.mk((FunctionSymbol) sym, args, pc.functionCallFactory());
-        }
+		@Override
+		public Term visitFoldTerm(FoldTermContext ctx) {
+			assertNotInFormula(ctx.start.getLine(), "Cannot invoke a fold from within a formula: " + ctx.getText());
+			String name = ctx.ID().getText();
+			Identifier id = env.get(name);
+			if (id != null && id.isVar()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot use a variable as the function to fold: " + name);
+			}
+			Symbol sym = id != null ? id.asFunctionSymbol() : pc.symbolManager().lookupSymbol(name);
+			if (!(sym instanceof FunctionSymbol)) {
+				throw new UncheckedParseException(ctx.start.getLine(), "Cannot fold over non-function: " + sym);
+			}
+			if (sym.getArity() != 2) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Can only fold over a binary function, but " + sym + " has arity " + sym.getArity());
+			}
+			Term[] args = extractArray(ctx.termArgs().term());
+			return Fold.mk((FunctionSymbol) sym, args, pc.functionCallFactory());
+		}
 
-        @Override
-        public Term visitTupleTerm(TupleTermContext ctx) {
-            Term[] args = extractArray(ctx.tuple().term());
-            return Constructors.make(GlobalSymbolManager.lookupTupleSymbol(args.length), args);
-        }
+		@Override
+		public Term visitTupleTerm(TupleTermContext ctx) {
+			Term[] args = extractArray(ctx.tuple().term());
+			return Constructors.make(GlobalSymbolManager.lookupTupleSymbol(args.length), args);
+		}
 
-        private final Pattern hex = Pattern.compile("0x([0-9a-fA-F]+)[lL]?");
+		private final Pattern hex = Pattern.compile("0x([0-9a-fA-F]+)[lL]?");
 
-        @Override
-        public Term visitI32Term(I32TermContext ctx) {
-            Matcher m = hex.matcher(ctx.val.getText());
-            int n;
-            if (m.matches()) {
-                n = Integer.parseUnsignedInt(m.group(1).toUpperCase(), 16);
-            } else {
-                n = Integer.parseInt(ctx.val.getText());
-            }
-            return I32.make(n);
-        }
+		@Override
+		public Term visitI32Term(I32TermContext ctx) {
+			Matcher m = hex.matcher(ctx.val.getText());
+			int n;
+			if (m.matches()) {
+				n = Integer.parseUnsignedInt(m.group(1).toUpperCase(), 16);
+			} else {
+				n = Integer.parseInt(ctx.val.getText());
+			}
+			return I32.make(n);
+		}
 
-        @Override
-        public Term visitI64Term(I64TermContext ctx) {
-            Matcher m = hex.matcher(ctx.val.getText());
-            long n;
-            if (m.matches()) {
-                n = Long.parseUnsignedLong(m.group(1).toUpperCase(), 16);
-            } else {
-                // Long.parseLong does not allow trailing l or L.
-                String text = ctx.val.getText();
-                String sub = text.substring(0, text.length() - 1);
-                n = Long.parseLong(sub);
-            }
-            return I64.make(n);
-        }
+		@Override
+		public Term visitI64Term(I64TermContext ctx) {
+			Matcher m = hex.matcher(ctx.val.getText());
+			long n;
+			if (m.matches()) {
+				n = Long.parseUnsignedLong(m.group(1).toUpperCase(), 16);
+			} else {
+				// Long.parseLong does not allow trailing l or L.
+				String text = ctx.val.getText();
+				String sub = text.substring(0, text.length() - 1);
+				n = Long.parseLong(sub);
+			}
+			return I64.make(n);
+		}
 
-        @Override
-        public Term visitFloatTerm(FloatTermContext ctx) {
-            return FP32.make(Float.parseFloat(ctx.val.getText()));
-        }
+		@Override
+		public Term visitFloatTerm(FloatTermContext ctx) {
+			return FP32.make(Float.parseFloat(ctx.val.getText()));
+		}
 
-        @Override
-        public Term visitDoubleTerm(DoubleTermContext ctx) {
-            return FP64.make(Double.parseDouble(ctx.val.getText()));
-        }
+		@Override
+		public Term visitDoubleTerm(DoubleTermContext ctx) {
+			return FP64.make(Double.parseDouble(ctx.val.getText()));
+		}
 
-        @Override
-        public Term visitSpecialFPTerm(SpecialFPTermContext ctx) {
-            switch (ctx.val.getType()) {
-                case FormulogParser.FP32_NAN:
-                    return FP32.make(Float.NaN);
-                case FormulogParser.FP32_NEG_INFINITY:
-                    return FP32.make(Float.NEGATIVE_INFINITY);
-                case FormulogParser.FP32_POS_INFINITY:
-                    return FP32.make(Float.POSITIVE_INFINITY);
-                case FormulogParser.FP64_NAN:
-                    return FP64.make(Double.NaN);
-                case FormulogParser.FP64_NEG_INFINITY:
-                    return FP64.make(Double.NEGATIVE_INFINITY);
-                case FormulogParser.FP64_POS_INFINITY:
-                    return FP64.make(Double.POSITIVE_INFINITY);
-            }
-            throw new AssertionError();
-        }
+		@Override
+		public Term visitSpecialFPTerm(SpecialFPTermContext ctx) {
+			switch (ctx.val.getType()) {
+			case FormulogParser.FP32_NAN:
+				return FP32.make(Float.NaN);
+			case FormulogParser.FP32_NEG_INFINITY:
+				return FP32.make(Float.NEGATIVE_INFINITY);
+			case FormulogParser.FP32_POS_INFINITY:
+				return FP32.make(Float.POSITIVE_INFINITY);
+			case FormulogParser.FP64_NAN:
+				return FP64.make(Double.NaN);
+			case FormulogParser.FP64_NEG_INFINITY:
+				return FP64.make(Double.NEGATIVE_INFINITY);
+			case FormulogParser.FP64_POS_INFINITY:
+				return FP64.make(Double.POSITIVE_INFINITY);
+			}
+			throw new AssertionError();
+		}
 
-        @Override
-        public Term visitRecordTerm(RecordTermContext ctx) {
-            Pair<ConstructorSymbol, Map<Integer, Term>> p = handleRecordEntries(ctx.recordEntries().recordEntry());
-            ConstructorSymbol csym = p.fst();
-            Map<Integer, Term> argMap = p.snd();
-            Term[] args = new Term[csym.getArity()];
-            if (args.length != argMap.keySet().size()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Missing label(s) when creating record of type " + csym);
-            }
-            for (int i = 0; i < args.length; i++) {
-                args[i] = argMap.get(i);
-            }
-            return Constructors.make(csym, args);
-        }
+		@Override
+		public Term visitRecordTerm(RecordTermContext ctx) {
+			Pair<ConstructorSymbol, Map<Integer, Term>> p = handleRecordEntries(ctx.recordEntries().recordEntry());
+			ConstructorSymbol csym = p.fst();
+			Map<Integer, Term> argMap = p.snd();
+			Term[] args = new Term[csym.getArity()];
+			if (args.length != argMap.keySet().size()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Missing label(s) when creating record of type " + csym);
+			}
+			for (int i = 0; i < args.length; i++) {
+				args[i] = argMap.get(i);
+			}
+			return Constructors.make(csym, args);
+		}
 
-        @Override
-        public Term visitRecordUpdateTerm(RecordUpdateTermContext ctx) {
-            Pair<ConstructorSymbol, Map<Integer, Term>> p = handleRecordEntries(ctx.recordEntries().recordEntry());
-            ConstructorSymbol csym = p.fst();
-            Map<Integer, Term> argMap = p.snd();
-            Term[] args = new Term[csym.getArity()];
-            FunctionSymbol[] labels = pc.constructorLabels().get(csym);
-            Term orig = extract(ctx.term());
-            for (int i = 0; i < args.length; ++i) {
-                Term t = argMap.get(i);
-                if (t == null) {
-                    FunctionSymbol label = labels[i];
-                    t = pc.functionCallFactory().make(label, Terms.singletonArray(orig));
-                }
-                args[i] = t;
-            }
-            return Constructors.make(csym, args);
-        }
+		@Override
+		public Term visitRecordUpdateTerm(RecordUpdateTermContext ctx) {
+			Pair<ConstructorSymbol, Map<Integer, Term>> p = handleRecordEntries(ctx.recordEntries().recordEntry());
+			ConstructorSymbol csym = p.fst();
+			Map<Integer, Term> argMap = p.snd();
+			Term[] args = new Term[csym.getArity()];
+			FunctionSymbol[] labels = pc.constructorLabels().get(csym);
+			Term orig = extract(ctx.term());
+			for (int i = 0; i < args.length; ++i) {
+				Term t = argMap.get(i);
+				if (t == null) {
+					FunctionSymbol label = labels[i];
+					t = pc.functionCallFactory().make(label, Terms.singletonArray(orig));
+				}
+				args[i] = t;
+			}
+			return Constructors.make(csym, args);
+		}
 
-        private Pair<ConstructorSymbol, Map<Integer, Term>> handleRecordEntries(List<RecordEntryContext> entries) {
-            AlgebraicDataType type = null;
-            Map<Integer, Term> argMap = new HashMap<>();
-            for (RecordEntryContext entry : entries) {
-                Symbol label = pc.symbolManager().lookupSymbol(entry.ID().getText());
-                Pair<AlgebraicDataType, Integer> p = pc.recordLabels().get(label);
-                if (p == null) {
-                    throw new UncheckedParseException(entry.start.getLine(), label + " is not a record label");
-                }
-                AlgebraicDataType type2 = p.fst();
-                if (type == null) {
-                    type = type2;
-                } else if (!type.equals(type2)) {
-                    throw new UncheckedParseException(entry.start.getLine(),
-                            "Cannot use label " + label + " in a record of type " + type);
-                }
-                if (argMap.putIfAbsent(p.snd(), extract(entry.term())) != null) {
-                    throw new UncheckedParseException(entry.start.getLine(),
-                            "Cannot use the same label " + label + " multiple times when creating a record");
-                }
-            }
-            ConstructorSymbol csym = type.getConstructors().iterator().next().getSymbol();
-            return new Pair<>(csym, argMap);
-        }
+		private Pair<ConstructorSymbol, Map<Integer, Term>> handleRecordEntries(List<RecordEntryContext> entries) {
+			AlgebraicDataType type = null;
+			Map<Integer, Term> argMap = new HashMap<>();
+			for (RecordEntryContext entry : entries) {
+				Symbol label = pc.symbolManager().lookupSymbol(entry.ID().getText());
+				Pair<AlgebraicDataType, Integer> p = pc.recordLabels().get(label);
+				if (p == null) {
+					throw new UncheckedParseException(entry.start.getLine(), label + " is not a record label");
+				}
+				AlgebraicDataType type2 = p.fst();
+				if (type == null) {
+					type = type2;
+				} else if (!type.equals(type2)) {
+					throw new UncheckedParseException(entry.start.getLine(),
+							"Cannot use label " + label + " in a record of type " + type);
+				}
+				if (argMap.putIfAbsent(p.snd(), extract(entry.term())) != null) {
+					throw new UncheckedParseException(entry.start.getLine(),
+							"Cannot use the same label " + label + " multiple times when creating a record");
+				}
+			}
+			ConstructorSymbol csym = type.getConstructors().iterator().next().getSymbol();
+			return new Pair<>(csym, argMap);
+		}
 
-        @Override
-        public Term visitUnopTerm(UnopTermContext ctx) {
-            Term t = ctx.term().accept(this);
-            FunctionSymbol sym = tokenToUnopSym(ctx.op.getType());
-            if (sym == null) {
-                t = makeNonFunctionUnop(ctx.op.getType(), t);
-            } else {
-                t = pc.functionCallFactory().make(sym, new Term[]{t});
-            }
-            if (t == null) {
-                throw new AssertionError("Unrecognized unop: " + ctx.getText());
-            }
-            assertNotInFormula(ctx.start.getLine(), "Cannot invoke a unop from within a formula: " + ctx.getText());
-            return t;
-        }
+		@Override
+		public Term visitUnopTerm(UnopTermContext ctx) {
+			Term t = ctx.term().accept(this);
+			FunctionSymbol sym = tokenToUnopSym(ctx.op.getType());
+			if (sym == null) {
+				t = makeNonFunctionUnop(ctx.op.getType(), t);
+			} else {
+				t = pc.functionCallFactory().make(sym, new Term[] { t });
+			}
+			if (t == null) {
+				throw new AssertionError("Unrecognized unop: " + ctx.getText());
+			}
+			assertNotInFormula(ctx.start.getLine(), "Cannot invoke a unop from within a formula: " + ctx.getText());
+			return t;
+		}
 
-        private Term makeNonFunctionUnop(int tokenType, Term t) {
-            switch (tokenType) {
-                case FormulogParser.BANG:
-                    return pc.functionCallFactory().make(BuiltInFunctionSymbol.BNOT, new Term[]{t});
-                default:
-                    return null;
-            }
-        }
+		private Term makeNonFunctionUnop(int tokenType, Term t) {
+			switch (tokenType) {
+			case FormulogParser.BANG:
+				return pc.functionCallFactory().make(BuiltInFunctionSymbol.BNOT, new Term[] { t });
+			default:
+				return null;
+			}
+		}
 
-        private Term makeBoolMatch(Term matchee, Term ifTrue, Term ifFalse) {
-            MatchClause matchTrue = MatchClause.make(BoolTerm.mkTrue(), ifTrue);
-            MatchClause matchFalse = MatchClause.make(BoolTerm.mkFalse(), ifFalse);
-            return MatchExpr.make(matchee, Arrays.asList(matchTrue, matchFalse));
-        }
+		private Term makeBoolMatch(Term matchee, Term ifTrue, Term ifFalse) {
+			MatchClause matchTrue = MatchClause.make(BoolTerm.mkTrue(), ifTrue);
+			MatchClause matchFalse = MatchClause.make(BoolTerm.mkFalse(), ifFalse);
+			return MatchExpr.make(matchee, Arrays.asList(matchTrue, matchFalse));
+		}
 
-        private FunctionSymbol tokenToUnopSym(int tokenType) {
-            switch (tokenType) {
-                case FormulogParser.MINUS:
-                    return BuiltInFunctionSymbol.I32_NEG;
-                default:
-                    return null;
-            }
-        }
+		private FunctionSymbol tokenToUnopSym(int tokenType) {
+			switch (tokenType) {
+			case FormulogParser.MINUS:
+				return BuiltInFunctionSymbol.I32_NEG;
+			default:
+				return null;
+			}
+		}
 
-        private FunctionSymbol tokenToBinopSym(int tokenType) {
-            switch (tokenType) {
-                case FormulogParser.MUL:
-                    return BuiltInFunctionSymbol.I32_MUL;
-                case FormulogParser.DIV:
-                    return BuiltInFunctionSymbol.I32_SDIV;
-                case FormulogParser.REM:
-                    return BuiltInFunctionSymbol.I32_SREM;
-                case FormulogParser.PLUS:
-                    return BuiltInFunctionSymbol.I32_ADD;
-                case FormulogParser.MINUS:
-                    return BuiltInFunctionSymbol.I32_SUB;
-                case FormulogParser.AMP:
-                    return BuiltInFunctionSymbol.I32_AND;
-                case FormulogParser.CARET:
-                    return BuiltInFunctionSymbol.I32_XOR;
-                case FormulogParser.EQ:
-                    return BuiltInFunctionSymbol.BEQ;
-                case FormulogParser.NEQ:
-                    return BuiltInFunctionSymbol.BNEQ;
-                case FormulogParser.LT:
-                    return BuiltInFunctionSymbol.I32_LT;
-                case FormulogParser.LTE:
-                    return BuiltInFunctionSymbol.I32_LE;
-                case FormulogParser.GT:
-                    return BuiltInFunctionSymbol.I32_GT;
-                case FormulogParser.GTE:
-                    return BuiltInFunctionSymbol.I32_GE;
-                default:
-                    return null;
-            }
-        }
+		private FunctionSymbol tokenToBinopSym(int tokenType) {
+			switch (tokenType) {
+			case FormulogParser.MUL:
+				return BuiltInFunctionSymbol.I32_MUL;
+			case FormulogParser.DIV:
+				return BuiltInFunctionSymbol.I32_SDIV;
+			case FormulogParser.REM:
+				return BuiltInFunctionSymbol.I32_SREM;
+			case FormulogParser.PLUS:
+				return BuiltInFunctionSymbol.I32_ADD;
+			case FormulogParser.MINUS:
+				return BuiltInFunctionSymbol.I32_SUB;
+			case FormulogParser.AMP:
+				return BuiltInFunctionSymbol.I32_AND;
+			case FormulogParser.CARET:
+				return BuiltInFunctionSymbol.I32_XOR;
+			case FormulogParser.EQ:
+				return BuiltInFunctionSymbol.BEQ;
+			case FormulogParser.NEQ:
+				return BuiltInFunctionSymbol.BNEQ;
+			case FormulogParser.LT:
+				return BuiltInFunctionSymbol.I32_LT;
+			case FormulogParser.LTE:
+				return BuiltInFunctionSymbol.I32_LE;
+			case FormulogParser.GT:
+				return BuiltInFunctionSymbol.I32_GT;
+			case FormulogParser.GTE:
+				return BuiltInFunctionSymbol.I32_GE;
+			default:
+				return null;
+			}
+		}
 
-        private Term makeNonFunctionBinop(int tokenType, Term lhs, Term rhs) {
-            switch (tokenType) {
-                case FormulogParser.AMPAMP:
-                    return makeBoolMatch(lhs, rhs, BoolTerm.mkFalse());
-                case FormulogParser.BARBAR:
-                    return makeBoolMatch(lhs, BoolTerm.mkTrue(), rhs);
-                default:
-                    return null;
-            }
-        }
+		private Term makeNonFunctionBinop(int tokenType, Term lhs, Term rhs) {
+			switch (tokenType) {
+			case FormulogParser.AMPAMP:
+				return makeBoolMatch(lhs, rhs, BoolTerm.mkFalse());
+			case FormulogParser.BARBAR:
+				return makeBoolMatch(lhs, BoolTerm.mkTrue(), rhs);
+			default:
+				return null;
+			}
+		}
 
-        @Override
-        public Term visitBinopTerm(BinopTermContext ctx) {
-            Term[] args = {extract(ctx.term(0)), extract(ctx.term(1))};
-            FunctionSymbol sym = tokenToBinopSym(ctx.op.getType());
-            Term t;
-            if (sym == null) {
-                t = makeNonFunctionBinop(ctx.op.getType(), args[0], args[1]);
-            } else {
-                t = pc.functionCallFactory().make(sym, args);
-            }
-            if (t == null) {
-                throw new AssertionError("Unrecognized binop: " + ctx.getText());
-            }
-            assertNotInFormula(ctx.start.getLine(), "Cannot invoke a binop from within a formula: " + ctx.getText());
-            return t;
-        }
+		@Override
+		public Term visitBinopTerm(BinopTermContext ctx) {
+			Term[] args = { extract(ctx.term(0)), extract(ctx.term(1)) };
+			FunctionSymbol sym = tokenToBinopSym(ctx.op.getType());
+			Term t;
+			if (sym == null) {
+				t = makeNonFunctionBinop(ctx.op.getType(), args[0], args[1]);
+			} else {
+				t = pc.functionCallFactory().make(sym, args);
+			}
+			if (t == null) {
+				throw new AssertionError("Unrecognized binop: " + ctx.getText());
+			}
+			assertNotInFormula(ctx.start.getLine(), "Cannot invoke a binop from within a formula: " + ctx.getText());
+			return t;
+		}
 
-        @Override
-        public Term visitListTerm(ListTermContext ctx) {
-            Term t = Constructors.makeZeroAry(BuiltInConstructorSymbol.NIL);
-            List<TermContext> ctxs = new ArrayList<>(ctx.list().term());
-            Collections.reverse(ctxs);
-            for (TermContext tc : ctxs) {
-                t = Constructors.make(BuiltInConstructorSymbol.CONS, new Term[]{extract(tc), t});
-            }
-            return t;
-        }
+		@Override
+		public Term visitListTerm(ListTermContext ctx) {
+			Term t = Constructors.makeZeroAry(BuiltInConstructorSymbol.NIL);
+			List<TermContext> ctxs = new ArrayList<>(ctx.list().term());
+			Collections.reverse(ctxs);
+			for (TermContext tc : ctxs) {
+				t = Constructors.make(BuiltInConstructorSymbol.CONS, new Term[] { extract(tc), t });
+			}
+			return t;
+		}
 
-        @Override
-        public Term visitParensTerm(ParensTermContext ctx) {
-            return extract(ctx.term());
-        }
+		@Override
+		public Term visitParensTerm(ParensTermContext ctx) {
+			return extract(ctx.term());
+		}
 
-        private Term makeExitFormula(Term t) {
-            return Constructors.make(BuiltInConstructorSymbol.EXIT_FORMULA, Terms.singletonArray(t));
-        }
+		private Term makeExitFormula(Term t) {
+			return Constructors.make(BuiltInConstructorSymbol.EXIT_FORMULA, Terms.singletonArray(t));
+		}
 
-        private Term makeEnterFormula(Term t) {
-            return Constructors.make(BuiltInConstructorSymbol.ENTER_FORMULA, Terms.singletonArray(t));
-        }
+		private Term makeEnterFormula(Term t) {
+			return Constructors.make(BuiltInConstructorSymbol.ENTER_FORMULA, Terms.singletonArray(t));
+		}
 
-        @Override
-        public Term visitFormulaTerm(FormulaTermContext ctx) {
-            assertNotInFormula(ctx.start.getLine(), "Cannot nest a formula within a formula: " + ctx.getText());
-            toggleInFormula();
-            Term t = extract(ctx.term());
-            t = makeEnterFormula(t);
-            toggleInFormula();
-            return t;
-        }
+		@Override
+		public Term visitFormulaTerm(FormulaTermContext ctx) {
+			assertNotInFormula(ctx.start.getLine(), "Cannot nest a formula within a formula: " + ctx.getText());
+			toggleInFormula();
+			Term t = extract(ctx.term());
+			t = makeEnterFormula(t);
+			toggleInFormula();
+			return t;
+		}
 
-        @Override
-        public Term visitNotFormula(NotFormulaContext ctx) {
-            Term t = extract(ctx.term());
-            return Constructors.make(BuiltInConstructorSymbol.SMT_NOT, Terms.singletonArray(t));
-        }
+		@Override
+		public Term visitNotFormula(NotFormulaContext ctx) {
+			Term t = extract(ctx.term());
+			return Constructors.make(BuiltInConstructorSymbol.SMT_NOT, Terms.singletonArray(t));
+		}
 
-        @Override
-        public Term visitBinopFormula(BinopFormulaContext ctx) {
-            Term[] args = extractArray(ctx.term());
-            ConstructorSymbol sym;
-            switch (ctx.op.getType()) {
-                case FormulogParser.FORMULA_EQ:
-                case FormulogParser.IFF:
-                    sym = (ConstructorSymbol) pc.symbolManager()
-                            .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_EQ);
-                    break;
-                case FormulogParser.IMP:
-                    sym = BuiltInConstructorSymbol.SMT_IMP;
-                    break;
-                case FormulogParser.AND:
-                    sym = BuiltInConstructorSymbol.SMT_AND;
-                    break;
-                case FormulogParser.OR:
-                    sym = BuiltInConstructorSymbol.SMT_OR;
-                    break;
-                default:
-                    throw new AssertionError();
-            }
-            return Constructors.make(sym, args);
-        }
+		@Override
+		public Term visitBinopFormula(BinopFormulaContext ctx) {
+			Term[] args = extractArray(ctx.term());
+			ConstructorSymbol sym;
+			switch (ctx.op.getType()) {
+			case FormulogParser.FORMULA_EQ:
+			case FormulogParser.IFF:
+				sym = (ConstructorSymbol) pc.symbolManager()
+						.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_EQ);
+				break;
+			case FormulogParser.IMP:
+				sym = BuiltInConstructorSymbol.SMT_IMP;
+				break;
+			case FormulogParser.AND:
+				sym = BuiltInConstructorSymbol.SMT_AND;
+				break;
+			case FormulogParser.OR:
+				sym = BuiltInConstructorSymbol.SMT_OR;
+				break;
+			default:
+				throw new AssertionError();
+			}
+			return Constructors.make(sym, args);
+		}
 
-        @Override
-        public Term visitLetFormula(LetFormulaContext ctx) {
-            ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
-                    .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_LET);
-            boolean wasInFormula = inFormula;
-            inFormula = false;
-            Term[] args = extractArray(ctx.term());
-            inFormula = wasInFormula;
-            args[1] = makeEnterFormula(args[1]);
-            args[2] = makeEnterFormula(args[2]);
-            return makeExitFormula(Constructors.make(sym, args));
-        }
+		@Override
+		public Term visitLetFormula(LetFormulaContext ctx) {
+			ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
+					.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_LET);
+			boolean wasInFormula = inFormula;
+			inFormula = false;
+			Term[] args = extractArray(ctx.term());
+			inFormula = wasInFormula;
+			args[1] = makeEnterFormula(args[1]);
+			args[2] = makeEnterFormula(args[2]);
+			return makeExitFormula(Constructors.make(sym, args));
+		}
 
-        @Override
-        public Term visitQuantifiedFormula(QuantifiedFormulaContext ctx) {
-            Term[] args = new Term[3];
-            args[0] = parseFormulaVarList(ctx.variables);
-            args[1] = makeEnterFormula(extract(ctx.boundTerm));
-            args[2] = Constructors.nil();
-            if (ctx.pattern != null) {
-                args[2] = Constructors.make(BuiltInConstructorSymbol.CONS,
-                        new Term[]{(parsePatternList(ctx.pattern)), args[2]});
-            }
-            ConstructorSymbol sym;
-            switch (ctx.quantifier.getType()) {
-                case FormulogParser.FORALL:
-                    sym = BuiltInConstructorSymbol.SMT_FORALL;
-                    break;
-                case FormulogParser.EXISTS:
-                    sym = BuiltInConstructorSymbol.SMT_EXISTS;
-                    break;
-                default:
-                    throw new AssertionError("impossible");
-            }
-            return makeExitFormula(Constructors.make(sym, args));
-        }
+		@Override
+		public Term visitQuantifiedFormula(QuantifiedFormulaContext ctx) {
+			Term[] args = new Term[3];
+			args[0] = parseFormulaVarList(ctx.variables);
+			args[1] = makeEnterFormula(extract(ctx.boundTerm));
+			args[2] = Constructors.nil();
+			if (ctx.pattern != null) {
+				args[2] = Constructors.make(BuiltInConstructorSymbol.CONS,
+						new Term[] { (parsePatternList(ctx.pattern)), args[2] });
+			}
+			ConstructorSymbol sym;
+			switch (ctx.quantifier.getType()) {
+			case FormulogParser.FORALL:
+				sym = BuiltInConstructorSymbol.SMT_FORALL;
+				break;
+			case FormulogParser.EXISTS:
+				sym = BuiltInConstructorSymbol.SMT_EXISTS;
+				break;
+			default:
+				throw new AssertionError("impossible");
+			}
+			return makeExitFormula(Constructors.make(sym, args));
+		}
 
-        private Term parsePatternList(NonEmptyTermListContext ctx) {
-            return parseNonEmptyTermList(ctx, pat -> {
-                ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
-                        .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_PAT);
-                return Constructors.make(sym, Terms.singletonArray(makeEnterFormula(pat)));
-            });
-        }
+		private Term parsePatternList(NonEmptyTermListContext ctx) {
+			return parseNonEmptyTermList(ctx, pat -> {
+				ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
+						.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_PAT);
+				return Constructors.make(sym, Terms.singletonArray(makeEnterFormula(pat)));
+			});
+		}
 
-        private Term parseFormulaVarList(NonEmptyTermListContext ctx) {
-            return parseNonEmptyTermList(ctx, var -> {
-                ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
-                        .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_WRAP_VAR);
-                return Constructors.make(sym, Terms.singletonArray(var));
-            });
-        }
+		private Term parseFormulaVarList(NonEmptyTermListContext ctx) {
+			return parseNonEmptyTermList(ctx, var -> {
+				ConstructorSymbol sym = (ConstructorSymbol) pc.symbolManager()
+						.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_WRAP_VAR);
+				return Constructors.make(sym, Terms.singletonArray(var));
+			});
+		}
 
-        private Term parseNonEmptyTermList(NonEmptyTermListContext ctx, Function<Term, Term> transformer) {
-            Term acc = Constructors.nil();
-            List<TermContext> ctxs = new ArrayList<>(ctx.term());
-            Collections.reverse(ctxs);
-            for (TermContext tc : ctxs) {
-                Term t = transformer.apply(extract(tc));
-                acc = Constructors.make(BuiltInConstructorSymbol.CONS, new Term[]{t, acc});
-            }
-            return acc;
-        }
+		private Term parseNonEmptyTermList(NonEmptyTermListContext ctx, Function<Term, Term> transformer) {
+			Term acc = Constructors.nil();
+			List<TermContext> ctxs = new ArrayList<>(ctx.term());
+			Collections.reverse(ctxs);
+			for (TermContext tc : ctxs) {
+				Term t = transformer.apply(extract(tc));
+				acc = Constructors.make(BuiltInConstructorSymbol.CONS, new Term[] { t, acc });
+			}
+			return acc;
+		}
 
-        @Override
-        public Term visitIteTerm(IteTermContext ctx) {
-            Term[] args = extractArray(ctx.term());
-            if (inFormula) {
-                return Constructors.make(BuiltInConstructorSymbol.SMT_ITE, args);
-            } else {
-                return makeBoolMatch(args[0], args[1], args[2]);
-            }
-        }
+		@Override
+		public Term visitIteTerm(IteTermContext ctx) {
+			Term[] args = extractArray(ctx.term());
+			if (inFormula) {
+				return Constructors.make(BuiltInConstructorSymbol.SMT_ITE, args);
+			} else {
+				return makeBoolMatch(args[0], args[1], args[2]);
+			}
+		}
 
-        @Override
-        public Term visitTermSymFormula(TermSymFormulaContext ctx) {
-            Type type = ParsingUtil.extractParam(pc, ctx.parameter()).getType();
-            Term id = extract(ctx.term());
-            return extractSolverSymbol(id, type);
-        }
+		@Override
+		public Term visitTermSymFormula(TermSymFormulaContext ctx) {
+			Type type = ParsingUtil.extractParam(pc, ctx.parameter()).getType();
+			Term id = extract(ctx.term());
+			return extractSolverSymbol(id, type);
+		}
 
-        private Term extractSolverSymbol(Term id, Type type) {
-            ParameterizedConstructorSymbol sym = GlobalSymbolManager
-                    .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_VAR);
-            sym = sym.copyWithNewArgs(Param.wildCard(), new Param(type, ParamKind.PRE_SMT_TYPE));
-            return makeExitFormula(Constructors.make(sym, Terms.singletonArray(id)));
-        }
+		private Term extractSolverSymbol(Term id, Type type) {
+			ParameterizedConstructorSymbol sym = GlobalSymbolManager
+					.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_VAR);
+			sym = sym.copyWithNewArgs(Param.wildCard(), new Param(type, ParamKind.PRE_SMT_TYPE));
+			return makeExitFormula(Constructors.make(sym, Terms.singletonArray(id)));
+		}
 
-        public Term visitOutermostCtor(OutermostCtorContext ctx) {
-            Symbol sym = pc.symbolManager().lookupSymbol(ctx.ID().getText());
-            if (!(sym instanceof ConstructorSymbol)) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot use non-constructor symbol " + sym + " in a `not` term.");
-            }
+		public Term visitOutermostCtor(OutermostCtorContext ctx) {
+			Symbol sym = pc.symbolManager().lookupSymbol(ctx.ID().getText());
+			if (!(sym instanceof ConstructorSymbol)) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot use non-constructor symbol " + sym + " in a `not` term.");
+			}
 
-            Term[] vars = new Term[sym.getArity()];
-            for (int i = 0; i < vars.length; ++i) {
-                vars[i] = Var.fresh();
-            }
-            Term pat = Constructors.make((ConstructorSymbol) sym, vars);
-            List<MatchClause> clauses = new ArrayList<>();
-            clauses.add(MatchClause.make(pat, BoolTerm.mkFalse()));
-            clauses.add(MatchClause.make(Var.fresh(), BoolTerm.mkTrue()));
-            Term arg = extract(ctx.term());
-            return MatchExpr.make(arg, clauses);
-        }
+			Term[] vars = new Term[sym.getArity()];
+			for (int i = 0; i < vars.length; ++i) {
+				vars[i] = Var.fresh();
+			}
+			Term pat = Constructors.make((ConstructorSymbol) sym, vars);
+			List<MatchClause> clauses = new ArrayList<>();
+			clauses.add(MatchClause.make(pat, BoolTerm.mkFalse()));
+			clauses.add(MatchClause.make(Var.fresh(), BoolTerm.mkTrue()));
+			Term arg = extract(ctx.term());
+			return MatchExpr.make(arg, clauses);
+		}
 
-        @Override
-        public Term visitMatchExpr(MatchExprContext ctx) {
-            Term guard = ctx.term().accept(this);
-            List<MatchClause> matches = new ArrayList<>();
-            for (MatchClauseContext mcc : ctx.matchClause()) {
-                for (TermContext pc : mcc.patterns().term()) {
-                    env.push(new HashMap<>());
-                    inPattern = true;
-                    Term pattern = extract(pc);
-                    inPattern = false;
-                    Term rhs = extract(mcc.rhs);
-                    env.pop();
-                    MatchClause clause = MatchClause.make(pattern, rhs);
-                    matches.add(clause);
-                }
-            }
-            return MatchExpr.make(guard, matches);
-        }
+		@Override
+		public Term visitMatchExpr(MatchExprContext ctx) {
+			Term guard = ctx.term().accept(this);
+			List<MatchClause> matches = new ArrayList<>();
+			for (MatchClauseContext mcc : ctx.matchClause()) {
+				for (TermContext pc : mcc.patterns().term()) {
+					env.push(new HashMap<>());
+					inPattern = true;
+					Term pattern = extract(pc);
+					inPattern = false;
+					Term rhs = extract(mcc.rhs);
+					env.pop();
+					MatchClause clause = MatchClause.make(pattern, rhs);
+					matches.add(clause);
+				}
+			}
+			return MatchExpr.make(guard, matches);
+		}
 
-        @Override
-        public Term visitLetExpr(LetExprContext ctx) {
-            Term assign = ctx.assign.accept(this);
-            env.push(new HashMap<>());
-            inPattern = true;
-            List<Term> ts = new ArrayList<>();
-            for (TermContext termCtx : ctx.lhs.term()) {
-                ts.add(extract(termCtx));
-            }
-            Term t;
-            if (ts.size() > 1) {
-                t = Constructors.make(GlobalSymbolManager.lookupTupleSymbol(ts.size()), ts.toArray(Terms.emptyArray()));
-            } else {
-                t = ts.get(0);
-            }
-            inPattern = false;
-            Term body = ctx.body.accept(this);
-            env.pop();
+		@Override
+		public Term visitLetExpr(LetExprContext ctx) {
+			Term assign = ctx.assign.accept(this);
+			env.push(new HashMap<>());
+			inPattern = true;
+			List<Term> ts = new ArrayList<>();
+			for (TermContext termCtx : ctx.lhs.term()) {
+				ts.add(extract(termCtx));
+			}
+			Term t;
+			if (ts.size() > 1) {
+				t = Constructors.make(GlobalSymbolManager.lookupTupleSymbol(ts.size()), ts.toArray(Terms.emptyArray()));
+			} else {
+				t = ts.get(0);
+			}
+			inPattern = false;
+			Term body = ctx.body.accept(this);
+			env.pop();
 
-            MatchClause m = MatchClause.make(t, body);
-            return MatchExpr.make(assign, Collections.singletonList(m));
-        }
+			MatchClause m = MatchClause.make(t, body);
+			return MatchExpr.make(assign, Collections.singletonList(m));
+		}
 
-        @Override
-        public Term visitLetFunExpr(LetFunExprContext ctx) {
-            if (inFormula) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot define a function from within a formula:\n" + ctx.getText());
-            }
-            List<String> names = new ArrayList<>();
-            for (FunDefLHSContext f : ctx.funDefs().funDefLHS()) {
-                String name = f.ID().getText();
-                if (names.contains(name)) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Cannot use the same name more than once in a mutually-recursive function definition "
-                                    + name);
-                }
-                names.add(name);
-            }
-            List<Pair<FunctionSymbol, List<Var>>> signatures = ParsingUtil.extractFunDeclarations(pc,
-                    ctx.funDefs().funDefLHS(), true);
-            Iterator<Pair<FunctionSymbol, List<Var>>> sigIt = signatures.iterator();
-            HashMap<String, Identifier> m = new HashMap<>();
-            for (String name : names) {
-                m.put(name, Identifier.make(sigIt.next().fst()));
-            }
-            env.push(m);
-            sigIt = signatures.iterator();
-            Set<NestedFunctionDef> defs = new HashSet<>();
-            for (TermContext bodyCtx : ctx.funDefs().term()) {
-                Pair<FunctionSymbol, List<Var>> p = sigIt.next();
-                List<Var> params = p.snd();
-                env.push(ParsingUtil.varsToIds(params));
-                defs.add(NestedFunctionDef.make(p.fst(), params, extract(bodyCtx)));
-                env.pop();
-            }
-            Term letBody = extract(ctx.letFunBody);
-            env.pop();
-            return LetFunExpr.make(defs, letBody);
-        }
+		@Override
+		public Term visitLetFunExpr(LetFunExprContext ctx) {
+			if (inFormula) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot define a function from within a formula:\n" + ctx.getText());
+			}
+			List<String> names = new ArrayList<>();
+			for (FunDefLHSContext f : ctx.funDefs().funDefLHS()) {
+				String name = f.ID().getText();
+				if (names.contains(name)) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Cannot use the same name more than once in a mutually-recursive function definition "
+									+ name);
+				}
+				names.add(name);
+			}
+			List<Pair<FunctionSymbol, List<Var>>> signatures = ParsingUtil.extractFunDeclarations(pc,
+					ctx.funDefs().funDefLHS(), true);
+			Iterator<Pair<FunctionSymbol, List<Var>>> sigIt = signatures.iterator();
+			HashMap<String, Identifier> m = new HashMap<>();
+			for (String name : names) {
+				m.put(name, Identifier.make(sigIt.next().fst()));
+			}
+			env.push(m);
+			sigIt = signatures.iterator();
+			Set<NestedFunctionDef> defs = new HashSet<>();
+			for (TermContext bodyCtx : ctx.funDefs().term()) {
+				Pair<FunctionSymbol, List<Var>> p = sigIt.next();
+				List<Var> params = p.snd();
+				env.push(ParsingUtil.varsToIds(params));
+				defs.add(NestedFunctionDef.make(p.fst(), params, extract(bodyCtx)));
+				env.pop();
+			}
+			Term letBody = extract(ctx.letFunBody);
+			env.pop();
+			return LetFunExpr.make(defs, letBody);
+		}
 
-        @Override
-        public Term visitIfExpr(IfExprContext ctx) {
-            Term guard = ctx.guard.accept(this);
-            Term thenExpr = ctx.thenExpr.accept(this);
-            Term elseExpr = ctx.elseExpr.accept(this);
-            List<MatchClause> branches = new ArrayList<>();
-            branches.add(MatchClause.make(BoolTerm.mkTrue(), thenExpr));
-            branches.add(MatchClause.make(BoolTerm.mkFalse(), elseExpr));
-            return MatchExpr.make(guard, branches);
-        }
+		@Override
+		public Term visitIfExpr(IfExprContext ctx) {
+			Term guard = ctx.guard.accept(this);
+			Term thenExpr = ctx.thenExpr.accept(this);
+			Term elseExpr = ctx.elseExpr.accept(this);
+			List<MatchClause> branches = new ArrayList<>();
+			branches.add(MatchClause.make(BoolTerm.mkTrue(), thenExpr));
+			branches.add(MatchClause.make(BoolTerm.mkFalse(), elseExpr));
+			return MatchExpr.make(guard, branches);
+		}
 
-    };
+	};
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/TopLevelParser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/TopLevelParser.java
@@ -89,426 +89,426 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 class TopLevelParser {
 
-    private final ParsingContext pc;
+	private final ParsingContext pc;
 
-    public TopLevelParser(ParsingContext parsingContext) {
-        pc = parsingContext;
-    }
+	public TopLevelParser(ParsingContext parsingContext) {
+		pc = parsingContext;
+	}
 
-    public Pair<BasicProgram, Set<RelationSymbol>> parse(ProgContext ctx) throws ParseException {
-        TopLevelVisitor visitor = new TopLevelVisitor();
-        ctx.accept(visitor);
-        BasicProgram prog = visitor.program();
-        return new Pair<>(prog, visitor.externalEdbs);
-    }
+	public Pair<BasicProgram, Set<RelationSymbol>> parse(ProgContext ctx) throws ParseException {
+		TopLevelVisitor visitor = new TopLevelVisitor();
+		ctx.accept(visitor);
+		BasicProgram prog = visitor.program();
+		return new Pair<>(prog, visitor.externalEdbs);
+	}
 
-    private final class TopLevelVisitor extends FormulogBaseVisitor<Void> {
+	private final class TopLevelVisitor extends FormulogBaseVisitor<Void> {
 
-        private final VariableCheckPass varChecker = new VariableCheckPass(pc.symbolManager());
-        private final TermExtractor termExtractor = new TermExtractor(pc);
-        private final TypeExtractor typeExtractor = new TypeExtractor(pc);
-        private final Map<RelationSymbol, Set<Term[]>> initialFacts = new HashMap<>();
-        private final Map<RelationSymbol, Set<BasicRule>> rules = new HashMap<>();
-        private final Set<RelationSymbol> externalEdbs = new HashSet<>();
-        private final Set<ConstructorSymbol> uninterpFuncSymbols = new HashSet<>();
-        private UserPredicate query;
+		private final VariableCheckPass varChecker = new VariableCheckPass(pc.symbolManager());
+		private final TermExtractor termExtractor = new TermExtractor(pc);
+		private final TypeExtractor typeExtractor = new TypeExtractor(pc);
+		private final Map<RelationSymbol, Set<Term[]>> initialFacts = new HashMap<>();
+		private final Map<RelationSymbol, Set<BasicRule>> rules = new HashMap<>();
+		private final Set<RelationSymbol> externalEdbs = new HashSet<>();
+		private final Set<ConstructorSymbol> uninterpFuncSymbols = new HashSet<>();
+		private UserPredicate query;
 
-        @Override
-        public Void visitFunDecl(FunDeclContext ctx) {
-            var ps = ParsingUtil.extractFunDeclarations(pc, ctx.topLevelFunDefs().funDefLHS(), false);
-            if (ctx.topLevelFunDefs().intro.getType() == FormulogParser.CONST && !ps.get(0).snd().isEmpty()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot declare a function with 'const' if it takes arguments (use 'fun' instead): " +
-                                ps.get(0).fst());
-            }
-            Iterator<TermContext> bodies = ctx.topLevelFunDefs().term().iterator();
-            for (Pair<FunctionSymbol, List<Var>> p : ps) {
-                FunctionSymbol sym = p.fst();
-                List<Var> args = p.snd();
-                termExtractor.pushIds(ParsingUtil.varsToIds(args));
-                Term body = termExtractor.extract(bodies.next());
-                termExtractor.popIds();
-                try {
-                    Term newBody = varChecker.checkFunction(args, body);
-                    pc.functionDefManager().register(UserFunctionDef.get(sym, args, newBody));
-                } catch (VariableCheckPassException e) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Error in definition for function " + sym + ": " + e.getMessage() + "\n" + body);
-                }
-            }
-            return null;
-        }
+		@Override
+		public Void visitFunDecl(FunDeclContext ctx) {
+			var ps = ParsingUtil.extractFunDeclarations(pc, ctx.topLevelFunDefs().funDefLHS(), false);
+			if (ctx.topLevelFunDefs().intro.getType() == FormulogParser.CONST && !ps.get(0).snd().isEmpty()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot declare a function with 'const' if it takes arguments (use 'fun' instead): "
+								+ ps.get(0).fst());
+			}
+			Iterator<TermContext> bodies = ctx.topLevelFunDefs().term().iterator();
+			for (Pair<FunctionSymbol, List<Var>> p : ps) {
+				FunctionSymbol sym = p.fst();
+				List<Var> args = p.snd();
+				termExtractor.pushIds(ParsingUtil.varsToIds(args));
+				Term body = termExtractor.extract(bodies.next());
+				termExtractor.popIds();
+				try {
+					Term newBody = varChecker.checkFunction(args, body);
+					pc.functionDefManager().register(UserFunctionDef.get(sym, args, newBody));
+				} catch (VariableCheckPassException e) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Error in definition for function " + sym + ": " + e.getMessage() + "\n" + body);
+				}
+			}
+			return null;
+		}
 
-        @Override
-        public Void visitRelDecl(RelDeclContext ctx) {
-            String name = ctx.ID().getText();
-            List<Type> types = typeExtractor.extract(ctx.maybeAnnotatedTypeList().type());
-            if (!Types.getTypeVars(types).isEmpty()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot use type variables in the signature of a relation: " + name);
-            }
-            MutableRelationSymbol sym = pc.symbolManager().createRelationSymbol(name, types.size(),
-                    new FunctorType(types, BuiltInTypes.bool));
-            for (AnnotationContext actx : ctx.annotation()) {
-                switch (actx.getText()) {
-                    case "@bottomup":
-                        sym.setBottomUp();
-                        break;
-                    case "@topdown":
-                        sym.setTopDown();
-                        break;
-                    case "@disk":
-                        sym.setDisk();
-                        break;
-                    case "@edb":
-                        sym.setEdb();
-                        break;
-                    default:
-                        throw new UncheckedParseException(ctx.start.getLine(),
-                                "Unrecognized annotation for predicate " + sym + ": " + actx.getText());
-                }
-            }
-            if (sym.isEdbSymbol()) {
-                initialFacts.put(sym, Util.concurrentSet());
-                if (sym.isDisk()) {
-                    externalEdbs.add(sym);
-                }
-            } else {
-                rules.put(sym, new HashSet<>());
-            }
-            return null;
-        }
+		@Override
+		public Void visitRelDecl(RelDeclContext ctx) {
+			String name = ctx.ID().getText();
+			List<Type> types = typeExtractor.extract(ctx.maybeAnnotatedTypeList().type());
+			if (!Types.getTypeVars(types).isEmpty()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot use type variables in the signature of a relation: " + name);
+			}
+			MutableRelationSymbol sym = pc.symbolManager().createRelationSymbol(name, types.size(),
+					new FunctorType(types, BuiltInTypes.bool));
+			for (AnnotationContext actx : ctx.annotation()) {
+				switch (actx.getText()) {
+				case "@bottomup":
+					sym.setBottomUp();
+					break;
+				case "@topdown":
+					sym.setTopDown();
+					break;
+				case "@disk":
+					sym.setDisk();
+					break;
+				case "@edb":
+					sym.setEdb();
+					break;
+				default:
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Unrecognized annotation for predicate " + sym + ": " + actx.getText());
+				}
+			}
+			if (sym.isEdbSymbol()) {
+				initialFacts.put(sym, Util.concurrentSet());
+				if (sym.isDisk()) {
+					externalEdbs.add(sym);
+				}
+			} else {
+				rules.put(sym, new HashSet<>());
+			}
+			return null;
+		}
 
-        @Override
-        public Void visitTypeAlias(TypeAliasContext ctx) {
-            Pair<TypeSymbol, List<TypeVar>> p = parseTypeDefLHS(ctx.typeDefLHS(), TypeSymbolType.TYPE_ALIAS);
-            TypeSymbol sym = p.fst();
-            List<TypeVar> typeVars = p.snd();
-            Type type = typeExtractor.extract(ctx.type());
-            if (!typeVars.containsAll(Types.getTypeVars(type))) {
-                throw new UncheckedParseException(ctx.start.getLine(), "Unbound type variable in definition of " + sym);
-            }
-            pc.typeManager().registerAlias(new TypeAlias(sym, typeVars, type));
-            return null;
-        }
+		@Override
+		public Void visitTypeAlias(TypeAliasContext ctx) {
+			Pair<TypeSymbol, List<TypeVar>> p = parseTypeDefLHS(ctx.typeDefLHS(), TypeSymbolType.TYPE_ALIAS);
+			TypeSymbol sym = p.fst();
+			List<TypeVar> typeVars = p.snd();
+			Type type = typeExtractor.extract(ctx.type());
+			if (!typeVars.containsAll(Types.getTypeVars(type))) {
+				throw new UncheckedParseException(ctx.start.getLine(), "Unbound type variable in definition of " + sym);
+			}
+			pc.typeManager().registerAlias(new TypeAlias(sym, typeVars, type));
+			return null;
+		}
 
-        @Override
-        public Void visitTypeDecl(TypeDeclContext ctx) {
-            List<Pair<TypeSymbol, List<TypeVar>>> lhss = map(ctx.typeDefLHS(),
-                    lhs -> parseTypeDefLHS(lhs, TypeSymbolType.NORMAL_TYPE));
-            Iterator<TypeDefRHSContext> it = ctx.typeDefRHS().iterator();
-            for (Pair<TypeSymbol, List<TypeVar>> p : lhss) {
-                TypeSymbol sym = p.fst();
-                List<TypeVar> typeVars = p.snd();
-                AlgebraicDataType type = AlgebraicDataType.make(sym, new ArrayList<>(typeVars));
-                TypeDefRHSContext rhs = it.next();
-                if (rhs.adtDef() != null) {
-                    handleAdtDef(rhs.adtDef(), type, typeVars);
-                } else {
-                    handleRecordDef(rhs.recordDef(), type, typeVars);
-                }
-            }
-            return null;
-        }
+		@Override
+		public Void visitTypeDecl(TypeDeclContext ctx) {
+			List<Pair<TypeSymbol, List<TypeVar>>> lhss = map(ctx.typeDefLHS(),
+					lhs -> parseTypeDefLHS(lhs, TypeSymbolType.NORMAL_TYPE));
+			Iterator<TypeDefRHSContext> it = ctx.typeDefRHS().iterator();
+			for (Pair<TypeSymbol, List<TypeVar>> p : lhss) {
+				TypeSymbol sym = p.fst();
+				List<TypeVar> typeVars = p.snd();
+				AlgebraicDataType type = AlgebraicDataType.make(sym, new ArrayList<>(typeVars));
+				TypeDefRHSContext rhs = it.next();
+				if (rhs.adtDef() != null) {
+					handleAdtDef(rhs.adtDef(), type, typeVars);
+				} else {
+					handleRecordDef(rhs.recordDef(), type, typeVars);
+				}
+			}
+			return null;
+		}
 
-        private void handleAdtDef(AdtDefContext ctx, AlgebraicDataType type, List<TypeVar> typeVars) {
-            Set<ConstructorScheme> constructors = new HashSet<>();
-            for (ConstructorTypeContext ctc : ctx.constructorType()) {
-                List<Type> typeArgs = typeExtractor.extract(ctc.typeList().type());
-                ConstructorSymbol csym = pc.symbolManager().createConstructorSymbol(ctc.ID().getText(), typeArgs.size(),
-                        ConstructorSymbolType.VANILLA_CONSTRUCTOR, new FunctorType(typeArgs, type));
-                if (!typeVars.containsAll(Types.getTypeVars(typeArgs))) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Unbound type variable in definition of " + csym);
-                }
-                pc.symbolManager().createConstructorSymbol("#is_" + csym, 1,
-                        ConstructorSymbolType.SOLVER_CONSTRUCTOR_TESTER, new FunctorType(type, BuiltInTypes.bool));
-                List<ConstructorSymbol> getterSyms = new ArrayList<>();
-                for (int i = 0; i < csym.getArity(); ++i) {
-                    FunctorType t = new FunctorType(type, typeArgs.get(i));
-                    String name = "#" + csym + "_" + (i + 1);
-                    getterSyms.add(pc.symbolManager().createConstructorSymbol(name, 1,
-                            ConstructorSymbolType.SOLVER_CONSTRUCTOR_GETTER, t));
-                }
-                constructors.add(new ConstructorScheme(csym, typeArgs, getterSyms));
-            }
-            AlgebraicDataType.setConstructors(type.getSymbol(), typeVars, constructors);
-        }
+		private void handleAdtDef(AdtDefContext ctx, AlgebraicDataType type, List<TypeVar> typeVars) {
+			Set<ConstructorScheme> constructors = new HashSet<>();
+			for (ConstructorTypeContext ctc : ctx.constructorType()) {
+				List<Type> typeArgs = typeExtractor.extract(ctc.typeList().type());
+				ConstructorSymbol csym = pc.symbolManager().createConstructorSymbol(ctc.ID().getText(), typeArgs.size(),
+						ConstructorSymbolType.VANILLA_CONSTRUCTOR, new FunctorType(typeArgs, type));
+				if (!typeVars.containsAll(Types.getTypeVars(typeArgs))) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Unbound type variable in definition of " + csym);
+				}
+				pc.symbolManager().createConstructorSymbol("#is_" + csym, 1,
+						ConstructorSymbolType.SOLVER_CONSTRUCTOR_TESTER, new FunctorType(type, BuiltInTypes.bool));
+				List<ConstructorSymbol> getterSyms = new ArrayList<>();
+				for (int i = 0; i < csym.getArity(); ++i) {
+					FunctorType t = new FunctorType(type, typeArgs.get(i));
+					String name = "#" + csym + "_" + (i + 1);
+					getterSyms.add(pc.symbolManager().createConstructorSymbol(name, 1,
+							ConstructorSymbolType.SOLVER_CONSTRUCTOR_GETTER, t));
+				}
+				constructors.add(new ConstructorScheme(csym, typeArgs, getterSyms));
+			}
+			AlgebraicDataType.setConstructors(type.getSymbol(), typeVars, constructors);
+		}
 
-        private void handleRecordDef(RecordDefContext ctx, AlgebraicDataType type, List<TypeVar> typeVars) {
-            List<Type> entryTypes = new ArrayList<>();
-            List<ConstructorSymbol> getterSyms = new ArrayList<>();
-            List<FunctionSymbol> labels = new ArrayList<>();
-            int i = 0;
-            for (RecordEntryDefContext entry : ctx.recordEntryDef()) {
-                Type entryType = typeExtractor.extract(entry.type());
-                entryTypes.add(entryType);
-                FunctorType labelType = new FunctorType(type, entryType);
-                FunctionSymbol label = pc.symbolManager().createFunctionSymbol(entry.ID().getText(), 1, labelType);
-                labels.add(label);
-                final int j = i;
-                pc.functionDefManager().register(new RecordAccessor(label, j));
-                ConstructorSymbol getter = pc.symbolManager().createConstructorSymbol("#" + label, 1,
-                        ConstructorSymbolType.SOLVER_CONSTRUCTOR_GETTER, labelType);
-                getterSyms.add(getter);
-                pc.recordLabels().put(label, new Pair<>(type, i));
-                i++;
-            }
-            TypeSymbol sym = type.getSymbol();
-            if (!typeVars.containsAll(Types.getTypeVars(entryTypes))) {
-                throw new UncheckedParseException(ctx.start.getLine(), "Unbound type variable in definition of " + sym);
-            }
-            FunctorType ctype = new FunctorType(entryTypes, type);
-            RecordSymbol csym = pc.symbolManager().createRecordSymbol("_rec_" + sym, entryTypes.size(), ctype, labels);
-            ConstructorScheme ctor = new ConstructorScheme(csym, entryTypes, getterSyms);
-            AlgebraicDataType.setConstructors(sym, typeVars, Collections.singleton(ctor));
-            pc.constructorLabels().put(csym, labels.toArray(new FunctionSymbol[0]));
-        }
+		private void handleRecordDef(RecordDefContext ctx, AlgebraicDataType type, List<TypeVar> typeVars) {
+			List<Type> entryTypes = new ArrayList<>();
+			List<ConstructorSymbol> getterSyms = new ArrayList<>();
+			List<FunctionSymbol> labels = new ArrayList<>();
+			int i = 0;
+			for (RecordEntryDefContext entry : ctx.recordEntryDef()) {
+				Type entryType = typeExtractor.extract(entry.type());
+				entryTypes.add(entryType);
+				FunctorType labelType = new FunctorType(type, entryType);
+				FunctionSymbol label = pc.symbolManager().createFunctionSymbol(entry.ID().getText(), 1, labelType);
+				labels.add(label);
+				final int j = i;
+				pc.functionDefManager().register(new RecordAccessor(label, j));
+				ConstructorSymbol getter = pc.symbolManager().createConstructorSymbol("#" + label, 1,
+						ConstructorSymbolType.SOLVER_CONSTRUCTOR_GETTER, labelType);
+				getterSyms.add(getter);
+				pc.recordLabels().put(label, new Pair<>(type, i));
+				i++;
+			}
+			TypeSymbol sym = type.getSymbol();
+			if (!typeVars.containsAll(Types.getTypeVars(entryTypes))) {
+				throw new UncheckedParseException(ctx.start.getLine(), "Unbound type variable in definition of " + sym);
+			}
+			FunctorType ctype = new FunctorType(entryTypes, type);
+			RecordSymbol csym = pc.symbolManager().createRecordSymbol("_rec_" + sym, entryTypes.size(), ctype, labels);
+			ConstructorScheme ctor = new ConstructorScheme(csym, entryTypes, getterSyms);
+			AlgebraicDataType.setConstructors(sym, typeVars, Collections.singleton(ctor));
+			pc.constructorLabels().put(csym, labels.toArray(new FunctionSymbol[0]));
+		}
 
-        private Pair<TypeSymbol, List<TypeVar>> parseTypeDefLHS(TypeDefLHSContext ctx, TypeSymbolType symType) {
-            List<TypeVar> typeVars = map(ctx.TYPEVAR(), t -> TypeVar.get(t.getText()));
-            TypeSymbol sym = pc.symbolManager().createTypeSymbol(ctx.ID().getText(), typeVars.size(), symType);
-            if (typeVars.size() != (new HashSet<>(typeVars)).size()) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot use the same type variable multiple times in a type declaration: " + sym);
-            }
-            return new Pair<>(sym, typeVars);
-        }
+		private Pair<TypeSymbol, List<TypeVar>> parseTypeDefLHS(TypeDefLHSContext ctx, TypeSymbolType symType) {
+			List<TypeVar> typeVars = map(ctx.TYPEVAR(), t -> TypeVar.get(t.getText()));
+			TypeSymbol sym = pc.symbolManager().createTypeSymbol(ctx.ID().getText(), typeVars.size(), symType);
+			if (typeVars.size() != (new HashSet<>(typeVars)).size()) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot use the same type variable multiple times in a type declaration: " + sym);
+			}
+			return new Pair<>(sym, typeVars);
+		}
 
-        @Override
-        public Void visitUninterpSortDecl(UninterpSortDeclContext ctx) {
-            parseTypeDefLHS(ctx.typeDefLHS(), TypeSymbolType.UNINTERPRETED_SORT);
-            return null;
-        }
+		@Override
+		public Void visitUninterpSortDecl(UninterpSortDeclContext ctx) {
+			parseTypeDefLHS(ctx.typeDefLHS(), TypeSymbolType.UNINTERPRETED_SORT);
+			return null;
+		}
 
-        @Override
-        public Void visitUninterpFunDecl(UninterpFunDeclContext ctx) {
-            ConstructorTypeContext ctc = ctx.constructorType();
-            List<Type> typeArgs = typeExtractor.extract(ctc.typeList().type());
-            Type type = typeExtractor.extract(ctx.type());
-            ConstructorSymbol csym = pc.symbolManager().createConstructorSymbol(ctc.ID().getText(), typeArgs.size(),
-                    ConstructorSymbolType.SOLVER_UNINTERPRETED_FUNCTION, new FunctorType(typeArgs, type));
-            Set<Type> allTypes = new HashSet<>(typeArgs);
-            allTypes.add(type);
-            for (Type ty : allTypes) {
-                if (!hasSmtType(ty)) {
-                    throw new UncheckedParseException(ctx.start.getLine(), "Uninterpreted function must have an "
-                            + BuiltInTypeSymbol.SMT_TYPE + " type: " + csym);
-                }
-                if (!Types.getTypeVars(ty).isEmpty()) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Uninterpreted functions cannot have type variables: " + csym);
-                }
-            }
-            uninterpFuncSymbols.add(csym);
-            return null;
-        }
+		@Override
+		public Void visitUninterpFunDecl(UninterpFunDeclContext ctx) {
+			ConstructorTypeContext ctc = ctx.constructorType();
+			List<Type> typeArgs = typeExtractor.extract(ctc.typeList().type());
+			Type type = typeExtractor.extract(ctx.type());
+			ConstructorSymbol csym = pc.symbolManager().createConstructorSymbol(ctc.ID().getText(), typeArgs.size(),
+					ConstructorSymbolType.SOLVER_UNINTERPRETED_FUNCTION, new FunctorType(typeArgs, type));
+			Set<Type> allTypes = new HashSet<>(typeArgs);
+			allTypes.add(type);
+			for (Type ty : allTypes) {
+				if (!hasSmtType(ty)) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Uninterpreted function must have an " + BuiltInTypeSymbol.SMT_TYPE + " type: " + csym);
+				}
+				if (!Types.getTypeVars(ty).isEmpty()) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Uninterpreted functions cannot have type variables: " + csym);
+				}
+			}
+			uninterpFuncSymbols.add(csym);
+			return null;
+		}
 
-        private boolean hasSmtType(Type type) {
-            return (type instanceof AlgebraicDataType)
-                    && ((AlgebraicDataType) type).getSymbol().equals(BuiltInTypeSymbol.SMT_TYPE);
+		private boolean hasSmtType(Type type) {
+			return (type instanceof AlgebraicDataType)
+					&& ((AlgebraicDataType) type).getSymbol().equals(BuiltInTypeSymbol.SMT_TYPE);
 
-        }
+		}
 
-        @Override
-        public Void visitClauseStmt(ClauseStmtContext ctx) {
-            List<ComplexLiteral> head = termsToLiterals(ctx.clause().head.term());
-            List<ComplexLiteral> body = termsToLiterals(ctx.clause().body.term());
-            Set<BasicRule> newRules = makeRules(ctx.start.getLine(), head, body);
-            for (BasicRule rule : newRules) {
-                RelationSymbol sym = rule.getHead().getSymbol();
-                if (!sym.isIdbSymbol()) {
-                    throw new UncheckedParseException(ctx.start.getLine(),
-                            "Cannot define a rule for a non-IDB symbol: " + sym);
-                }
-                Util.lookupOrCreate(rules, sym, HashSet::new).add(rule);
-            }
-            return null;
-        }
+		@Override
+		public Void visitClauseStmt(ClauseStmtContext ctx) {
+			List<ComplexLiteral> head = termsToLiterals(ctx.clause().head.term());
+			List<ComplexLiteral> body = termsToLiterals(ctx.clause().body.term());
+			Set<BasicRule> newRules = makeRules(ctx.start.getLine(), head, body);
+			for (BasicRule rule : newRules) {
+				RelationSymbol sym = rule.getHead().getSymbol();
+				if (!sym.isIdbSymbol()) {
+					throw new UncheckedParseException(ctx.start.getLine(),
+							"Cannot define a rule for a non-IDB symbol: " + sym);
+				}
+				Util.lookupOrCreate(rules, sym, HashSet::new).add(rule);
+			}
+			return null;
+		}
 
-        private Set<BasicRule> makeRules(int lineNo, ComplexLiteral head) {
-            return makeRules(lineNo, Collections.singletonList(head), Collections.emptyList());
-        }
+		private Set<BasicRule> makeRules(int lineNo, ComplexLiteral head) {
+			return makeRules(lineNo, Collections.singletonList(head), Collections.emptyList());
+		}
 
-        private Set<BasicRule> makeRules(int lineNo, List<ComplexLiteral> heads, List<ComplexLiteral> body) {
-            List<UserPredicate> processedHeads = new ArrayList<>();
-            for (ComplexLiteral hd : heads) {
-                if (hd instanceof UserPredicate) {
-                    processedHeads.add((UserPredicate) hd);
-                } else {
-                    throw new UncheckedParseException(lineNo,
-                            "Cannot create rule with non-user predicate in head: " + hd);
-                }
-            }
-            try {
-                return varChecker.checkRule(processedHeads, body);
-            } catch (VariableCheckPassException e) {
-                throw new UncheckedParseException(lineNo, e.getMessage());
-            }
-        }
+		private Set<BasicRule> makeRules(int lineNo, List<ComplexLiteral> heads, List<ComplexLiteral> body) {
+			List<UserPredicate> processedHeads = new ArrayList<>();
+			for (ComplexLiteral hd : heads) {
+				if (hd instanceof UserPredicate) {
+					processedHeads.add((UserPredicate) hd);
+				} else {
+					throw new UncheckedParseException(lineNo,
+							"Cannot create rule with non-user predicate in head: " + hd);
+				}
+			}
+			try {
+				return varChecker.checkRule(processedHeads, body);
+			} catch (VariableCheckPassException e) {
+				throw new UncheckedParseException(lineNo, e.getMessage());
+			}
+		}
 
-        @Override
-        public Void visitFactStmt(FactStmtContext ctx) {
-            ComplexLiteral lit = termToLiteral(ctx.fact().term());
-            if (!(lit instanceof UserPredicate)) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Facts must be user-defined predicates: " + ctx.getText());
-            }
-            UserPredicate fact = (UserPredicate) lit;
-            RelationSymbol sym = fact.getSymbol();
-            if (sym.isIdbSymbol()) {
-                Set<BasicRule> rs = makeRules(ctx.start.getLine(), fact);
-                rules.get(sym).addAll(rs);
-            } else {
-                try {
-                    Term[] args = varChecker.checkFact(fact.getArgs());
-                    initialFacts.get(sym).add(args);
-                } catch (VariableCheckPassException e) {
-                    throw new UncheckedParseException(ctx.start.getLine(), e.getMessage());
-                }
-            }
-            return null;
-        }
+		@Override
+		public Void visitFactStmt(FactStmtContext ctx) {
+			ComplexLiteral lit = termToLiteral(ctx.fact().term());
+			if (!(lit instanceof UserPredicate)) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Facts must be user-defined predicates: " + ctx.getText());
+			}
+			UserPredicate fact = (UserPredicate) lit;
+			RelationSymbol sym = fact.getSymbol();
+			if (sym.isIdbSymbol()) {
+				Set<BasicRule> rs = makeRules(ctx.start.getLine(), fact);
+				rules.get(sym).addAll(rs);
+			} else {
+				try {
+					Term[] args = varChecker.checkFact(fact.getArgs());
+					initialFacts.get(sym).add(args);
+				} catch (VariableCheckPassException e) {
+					throw new UncheckedParseException(ctx.start.getLine(), e.getMessage());
+				}
+			}
+			return null;
+		}
 
-        @Override
-        public Void visitQueryStmt(QueryStmtContext ctx) {
-            ComplexLiteral a = termToLiteral(ctx.query().term());
-            if (!(a instanceof UserPredicate)) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Query must be for a user-defined predicate: " + a);
-            }
-            if (query != null) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Cannot have multiple queries in the same program: " + query + " and " + a);
-            }
-            UserPredicate q = (UserPredicate) a;
-            try {
-                query = UserPredicate.make(q.getSymbol(), varChecker.checkFact(q.getArgs()), q.isNegated());
-            } catch (VariableCheckPassException e) {
-                throw new UncheckedParseException(ctx.start.getLine(),
-                        "Problem with query " + query + ": " + e.getMessage());
-            }
-            return null;
-        }
+		@Override
+		public Void visitQueryStmt(QueryStmtContext ctx) {
+			ComplexLiteral a = termToLiteral(ctx.query().term());
+			if (!(a instanceof UserPredicate)) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Query must be for a user-defined predicate: " + a);
+			}
+			if (query != null) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Cannot have multiple queries in the same program: " + query + " and " + a);
+			}
+			UserPredicate q = (UserPredicate) a;
+			try {
+				query = UserPredicate.make(q.getSymbol(), varChecker.checkFact(q.getArgs()), q.isNegated());
+			} catch (VariableCheckPassException e) {
+				throw new UncheckedParseException(ctx.start.getLine(),
+						"Problem with query " + query + ": " + e.getMessage());
+			}
+			return null;
+		}
 
-        List<ComplexLiteral> termsToLiterals(Iterable<TermContext> ctxs) {
-            List<ComplexLiteral> l = new ArrayList<>();
-            for (TermContext ctx : ctxs) {
-                l.add(termToLiteral(ctx));
-            }
-            return l;
-        }
+		List<ComplexLiteral> termsToLiterals(Iterable<TermContext> ctxs) {
+			List<ComplexLiteral> l = new ArrayList<>();
+			for (TermContext ctx : ctxs) {
+				l.add(termToLiteral(ctx));
+			}
+			return l;
+		}
 
-        private ComplexLiteral termToLiteral(TermContext ctx) {
-            Term t = termExtractor.extract(ctx);
-            if (!(t instanceof FunctionCall)) {
-                return ComplexLiterals.unifyWithBool(t, true);
-            }
-            FunctionCall call = (FunctionCall) t;
-            FunctionSymbol sym = call.getSymbol();
-            boolean negated = false;
-            if (sym.equals(BuiltInFunctionSymbol.BNOT)) {
-                t = call.getArgs()[0];
-                if (!(t instanceof FunctionCall)) {
-                    return ComplexLiterals.unifyWithBool(t, false);
-                }
-                negated = true;
-                call = (FunctionCall) t;
-                sym = call.getSymbol();
-            }
-            if (sym instanceof PredicateFunctionSymbol) {
-                RelationSymbol predSym = ((PredicateFunctionSymbol) sym).getPredicateSymbol();
-                return UserPredicate.make(predSym, call.getArgs(), negated);
-            }
-            if (!negated && sym.equals(BuiltInFunctionSymbol.BEQ)) {
-                Term[] args = call.getArgs();
-                return UnificationPredicate.make(args[0], args[1], false);
-            }
-            if (!negated && sym.equals(BuiltInFunctionSymbol.BNEQ)) {
-                Term[] args = call.getArgs();
-                return UnificationPredicate.make(args[0], args[1], true);
-            }
-            return ComplexLiterals.unifyWithBool(t, !negated);
-        }
+		private ComplexLiteral termToLiteral(TermContext ctx) {
+			Term t = termExtractor.extract(ctx);
+			if (!(t instanceof FunctionCall)) {
+				return ComplexLiterals.unifyWithBool(t, true);
+			}
+			FunctionCall call = (FunctionCall) t;
+			FunctionSymbol sym = call.getSymbol();
+			boolean negated = false;
+			if (sym.equals(BuiltInFunctionSymbol.BNOT)) {
+				t = call.getArgs()[0];
+				if (!(t instanceof FunctionCall)) {
+					return ComplexLiterals.unifyWithBool(t, false);
+				}
+				negated = true;
+				call = (FunctionCall) t;
+				sym = call.getSymbol();
+			}
+			if (sym instanceof PredicateFunctionSymbol) {
+				RelationSymbol predSym = ((PredicateFunctionSymbol) sym).getPredicateSymbol();
+				return UserPredicate.make(predSym, call.getArgs(), negated);
+			}
+			if (!negated && sym.equals(BuiltInFunctionSymbol.BEQ)) {
+				Term[] args = call.getArgs();
+				return UnificationPredicate.make(args[0], args[1], false);
+			}
+			if (!negated && sym.equals(BuiltInFunctionSymbol.BNEQ)) {
+				Term[] args = call.getArgs();
+				return UnificationPredicate.make(args[0], args[1], true);
+			}
+			return ComplexLiterals.unifyWithBool(t, !negated);
+		}
 
-        public BasicProgram program() throws ParseException {
-            return new BasicProgram() {
+		public BasicProgram program() throws ParseException {
+			return new BasicProgram() {
 
-                @Override
-                public Set<FunctionSymbol> getFunctionSymbols() {
-                    return pc.functionDefManager().getFunctionSymbols();
-                }
+				@Override
+				public Set<FunctionSymbol> getFunctionSymbols() {
+					return pc.functionDefManager().getFunctionSymbols();
+				}
 
-                @Override
-                public Set<RelationSymbol> getFactSymbols() {
-                    return Set.copyOf(initialFacts.keySet());
-                }
+				@Override
+				public Set<RelationSymbol> getFactSymbols() {
+					return Set.copyOf(initialFacts.keySet());
+				}
 
-                @Override
-                public Set<RelationSymbol> getRuleSymbols() {
-                    return Set.copyOf(rules.keySet());
-                }
+				@Override
+				public Set<RelationSymbol> getRuleSymbols() {
+					return Set.copyOf(rules.keySet());
+				}
 
-                @Override
-                public FunctionDef getDef(FunctionSymbol sym) {
-                    return pc.functionDefManager().lookup(sym);
-                }
+				@Override
+				public FunctionDef getDef(FunctionSymbol sym) {
+					return pc.functionDefManager().lookup(sym);
+				}
 
-                @Override
-                public Set<Term[]> getFacts(RelationSymbol sym) {
-                    if (!sym.isEdbSymbol()) {
-                        throw new IllegalArgumentException();
-                    }
-                    if (!initialFacts.containsKey(sym)) {
-                        throw new IllegalArgumentException();
-                    }
-                    return initialFacts.get(sym);
-                }
+				@Override
+				public Set<Term[]> getFacts(RelationSymbol sym) {
+					if (!sym.isEdbSymbol()) {
+						throw new IllegalArgumentException();
+					}
+					if (!initialFacts.containsKey(sym)) {
+						throw new IllegalArgumentException();
+					}
+					return initialFacts.get(sym);
+				}
 
-                @Override
-                public Set<BasicRule> getRules(RelationSymbol sym) {
-                    if (!sym.isIdbSymbol()) {
-                        throw new IllegalArgumentException();
-                    }
-                    if (!rules.containsKey(sym)) {
-                        throw new IllegalArgumentException();
-                    }
-                    return rules.get(sym);
-                }
+				@Override
+				public Set<BasicRule> getRules(RelationSymbol sym) {
+					if (!sym.isIdbSymbol()) {
+						throw new IllegalArgumentException();
+					}
+					if (!rules.containsKey(sym)) {
+						throw new IllegalArgumentException();
+					}
+					return rules.get(sym);
+				}
 
-                @Override
-                public SymbolManager getSymbolManager() {
-                    return pc.symbolManager();
-                }
+				@Override
+				public SymbolManager getSymbolManager() {
+					return pc.symbolManager();
+				}
 
-                @Override
-                public boolean hasQuery() {
-                    return query != null;
-                }
+				@Override
+				public boolean hasQuery() {
+					return query != null;
+				}
 
-                @Override
-                public UserPredicate getQuery() {
-                    return query;
-                }
+				@Override
+				public UserPredicate getQuery() {
+					return query;
+				}
 
-                @Override
-                public FunctionCallFactory getFunctionCallFactory() {
-                    return pc.functionCallFactory();
-                }
+				@Override
+				public FunctionCallFactory getFunctionCallFactory() {
+					return pc.functionCallFactory();
+				}
 
-                @Override
-                public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
-                    return Collections.unmodifiableSet(uninterpFuncSymbols);
-                }
+				@Override
+				public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
+					return Collections.unmodifiableSet(uninterpFuncSymbols);
+				}
 
-                @Override
-                public Set<TypeSymbol> getTypeSymbols() {
-                    return pc.symbolManager().getTypeSymbols();
-                }
+				@Override
+				public Set<TypeSymbol> getTypeSymbols() {
+					return pc.symbolManager().getTypeSymbols();
+				}
 
-            };
-        }
+			};
+		}
 
-    }
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/UncheckedParseException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/UncheckedParseException.java
@@ -22,23 +22,22 @@ package edu.harvard.seas.pl.formulog.parsing;
 
 public class UncheckedParseException extends RuntimeException {
 
-	
 	private static final long serialVersionUID = 1L;
 	private final int lineNo;
 	private final String fileName;
-	
+
 	public UncheckedParseException(int lineNo, String message) {
 		super(message);
 		this.lineNo = lineNo;
 		this.fileName = null;
 	}
-	
+
 	public UncheckedParseException(int lineNo, Throwable cause) {
 		super(cause);
 		this.lineNo = lineNo;
 		this.fileName = null;
 	}
-	
+
 	public UncheckedParseException(ParseException e) {
 		super(e.getMessage());
 		this.lineNo = e.getLineNo();
@@ -48,9 +47,9 @@ public class UncheckedParseException extends RuntimeException {
 	public int getLineNo() {
 		return lineNo;
 	}
-	
+
 	public String getFileName() {
 		return fileName;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/VariableCheckPass.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/VariableCheckPass.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.parsing;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,7 +71,8 @@ public class VariableCheckPass {
 		return newBody;
 	}
 
-	public Set<BasicRule> checkRule(List<UserPredicate> heads, List<ComplexLiteral> body) throws VariableCheckPassException {
+	public Set<BasicRule> checkRule(List<UserPredicate> heads, List<ComplexLiteral> body)
+			throws VariableCheckPassException {
 		PassContext ctx = new PassContext();
 		Set<BasicRule> r = ctx.checkRule(heads, body);
 		try {
@@ -281,7 +281,8 @@ public class VariableCheckPass {
 				Var x = e.getKey();
 				int cnt = e.getValue();
 				if (looksLikeHole(x) && cnt > 0) {
-					throw new VariableCheckPassException("Can only use hole ?? as an argument to a predicate aggregate function.");
+					throw new VariableCheckPassException(
+							"Can only use hole ?? as an argument to a predicate aggregate function.");
 				} else if (looksLikeQuasiAnonymousVar(x) && cnt > 1) {
 					throw new VariableCheckPassException("Quasi-anonymous variable " + x + " occurs more than once.");
 				} else if (!looksAnonymous(x) && cnt == 1) {
@@ -289,7 +290,7 @@ public class VariableCheckPass {
 				}
 			}
 		}
-		
+
 	}
 
 	private static boolean looksLikeHole(Var x) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/VariableCheckPassException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/VariableCheckPassException.java
@@ -23,7 +23,7 @@ package edu.harvard.seas.pl.formulog.parsing;
 public class VariableCheckPassException extends Exception {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	public VariableCheckPassException(String message) {
 		super(message);
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/BestMatchSmtManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/BestMatchSmtManager.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.smt;
 
 import java.util.Collection;
 
-
 import java.util.Comparator;
 import java.util.PriorityQueue;
 import java.util.Set;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/CallAndResetSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/CallAndResetSolver.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.Collection;
 
 import edu.harvard.seas.pl.formulog.Configuration;
@@ -32,8 +31,8 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 public class CallAndResetSolver extends AbstractSmtLibSolver {
 
 	@Override
-	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(Collection<SmtLibTerm> assertions)
-			throws EvaluationException {
+	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(
+			Collection<SmtLibTerm> assertions) throws EvaluationException {
 		for (SmtLibTerm assertion : assertions) {
 			shim.makeAssertion(assertion);
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/CheckSatAssumingSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/CheckSatAssumingSolver.java
@@ -46,92 +46,92 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 
 public class CheckSatAssumingSolver extends AbstractSmtLibSolver {
 
-    private final Map<SmtLibTerm, SolverVariable> indicatorVars = new HashMap<>();
-    private int nextVarId;
+	private final Map<SmtLibTerm, SolverVariable> indicatorVars = new HashMap<>();
+	private int nextVarId;
 
-    private void clearCache() throws EvaluationException {
-        if (Configuration.timeSmt) {
-            Configuration.recordCsaCacheClear(solverId);
-        }
-        indicatorVars.clear();
-        nextVarId = 0;
-        if (Configuration.smtCacheHardResets) {
-            shim.reset();
-            start();
-        } else {
-            shim.pop();
-            shim.push();
-        }
-    }
+	private void clearCache() throws EvaluationException {
+		if (Configuration.timeSmt) {
+			Configuration.recordCsaCacheClear(solverId);
+		}
+		indicatorVars.clear();
+		nextVarId = 0;
+		if (Configuration.smtCacheHardResets) {
+			shim.reset();
+			start();
+		} else {
+			shim.pop();
+			shim.push();
+		}
+	}
 
-    public Set<SmtLibTerm> getCache() {
-        return indicatorVars.keySet();
-    }
+	public Set<SmtLibTerm> getCache() {
+		return indicatorVars.keySet();
+	}
 
-    @Override
-    protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(
-            Collection<SmtLibTerm> formula) throws EvaluationException {
-        int oldSize = indicatorVars.size();
-        int hits = 0;
-        int misses = 0;
-        Set<SolverVariable> onVars = new HashSet<>();
-        for (SmtLibTerm conjunct : formula) {
-            SolverVariable x = indicatorVars.get(conjunct);
-            if (x != null) {
-                hits++;
-            } else {
-                misses++;
-                x = makeIndicatorVar(conjunct);
-                indicatorVars.put(conjunct, x);
-                SmtLibTerm imp = makeImp(x, conjunct);
-                shim.makeAssertion(imp);
-            }
-            onVars.add(x);
-        }
-        if (Configuration.timeSmt) {
-            Configuration.recordCsaCacheStats(solverId, hits, misses, oldSize);
-        }
-        Collection<SolverVariable> offVars;
-        if (Configuration.smtUseNegativeLiterals) {
-            offVars = indicatorVars.values().stream().filter(x -> !onVars.contains(x)).collect(Collectors.toList());
-        } else {
-            offVars = Collections.emptySet();
-        }
-        return new Pair<>(onVars, offVars);
-    }
+	@Override
+	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(
+			Collection<SmtLibTerm> formula) throws EvaluationException {
+		int oldSize = indicatorVars.size();
+		int hits = 0;
+		int misses = 0;
+		Set<SolverVariable> onVars = new HashSet<>();
+		for (SmtLibTerm conjunct : formula) {
+			SolverVariable x = indicatorVars.get(conjunct);
+			if (x != null) {
+				hits++;
+			} else {
+				misses++;
+				x = makeIndicatorVar(conjunct);
+				indicatorVars.put(conjunct, x);
+				SmtLibTerm imp = makeImp(x, conjunct);
+				shim.makeAssertion(imp);
+			}
+			onVars.add(x);
+		}
+		if (Configuration.timeSmt) {
+			Configuration.recordCsaCacheStats(solverId, hits, misses, oldSize);
+		}
+		Collection<SolverVariable> offVars;
+		if (Configuration.smtUseNegativeLiterals) {
+			offVars = indicatorVars.values().stream().filter(x -> !onVars.contains(x)).collect(Collectors.toList());
+		} else {
+			offVars = Collections.emptySet();
+		}
+		return new Pair<>(onVars, offVars);
+	}
 
-    private SmtLibTerm makeImp(SolverVariable x, SmtLibTerm assertion) {
-        Term[] args = {x, assertion};
-        return Constructors.make(BuiltInConstructorSymbol.SMT_IMP, args);
-    }
+	private SmtLibTerm makeImp(SolverVariable x, SmtLibTerm assertion) {
+		Term[] args = { x, assertion };
+		return Constructors.make(BuiltInConstructorSymbol.SMT_IMP, args);
+	}
 
-    private SolverVariable makeIndicatorVar(SmtLibTerm assertion) {
-        Term[] args = Terms.singletonArray(Terms.makeDummyTerm(nextVarId++));
-        ParameterizedConstructorSymbol sym = GlobalSymbolManager
-                .getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_VAR);
-        sym = sym.copyWithNewArgs(Param.wildCard(), new Param(BuiltInTypes.bool, ParamKind.PRE_SMT_TYPE));
-        return (SolverVariable) Constructors.make(sym, args);
-    }
+	private SolverVariable makeIndicatorVar(SmtLibTerm assertion) {
+		Term[] args = Terms.singletonArray(Terms.makeDummyTerm(nextVarId++));
+		ParameterizedConstructorSymbol sym = GlobalSymbolManager
+				.getParameterizedSymbol(BuiltInConstructorSymbolBase.SMT_VAR);
+		sym = sym.copyWithNewArgs(Param.wildCard(), new Param(BuiltInTypes.bool, ParamKind.PRE_SMT_TYPE));
+		return (SolverVariable) Constructors.make(sym, args);
+	}
 
-    @Override
-    protected void cleanup() throws EvaluationException {
-        if (indicatorVars.size() > Configuration.smtCacheSize) {
-            clearCache();
-        }
-    }
+	@Override
+	protected void cleanup() throws EvaluationException {
+		if (indicatorVars.size() > Configuration.smtCacheSize) {
+			clearCache();
+		}
+	}
 
-    @Override
-    protected void start() throws EvaluationException {
-        shim.setLogic(Configuration.smtLogic);
-        shim.makeDeclarations();
-        if (!Configuration.smtCacheHardResets) {
-            shim.push();
-        }
-    }
+	@Override
+	protected void start() throws EvaluationException {
+		shim.setLogic(Configuration.smtLogic);
+		shim.makeDeclarations();
+		if (!Configuration.smtCacheHardResets) {
+			shim.push();
+		}
+	}
 
-    @Override
-    protected boolean isIncremental() {
-        return true;
-    }
+	@Override
+	protected boolean isIncremental() {
+		return true;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/Cvc4ProcessFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/Cvc4ProcessFactory.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/DoubleCheckingSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/DoubleCheckingSolver.java
@@ -31,7 +31,7 @@ public class DoubleCheckingSolver implements SmtLibSolver {
 
 	private final SmtLibSolver inner;
 	private final SmtLibSolver checker = new PushPopSolver();
-	
+
 	public DoubleCheckingSolver(SmtLibSolver inner) {
 		this.inner = inner;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/ExternalSolverProcessFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/ExternalSolverProcessFactory.java
@@ -20,11 +20,10 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.io.IOException;
 
 public interface ExternalSolverProcessFactory {
 
 	Process newProcess(boolean incremental) throws IOException;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/NotThreadSafeQueueSmtManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/NotThreadSafeQueueSmtManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.Collection;
 import java.util.function.Supplier;
 
@@ -43,8 +42,7 @@ public class NotThreadSafeQueueSmtManager implements SmtLibSolver {
 	}
 
 	@Override
-	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout)
-			throws EvaluationException {
+	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout) throws EvaluationException {
 		SmtLibSolver solver = solvers[pos];
 		SmtResult res = solver.check(conjuncts, getModel, timeout);
 		pos = (pos + 1) % solvers.length;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/PerThreadSmtManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/PerThreadSmtManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.Collection;
 import java.util.function.Supplier;
 
@@ -52,8 +51,7 @@ public class PerThreadSmtManager implements SmtLibSolver {
 	}
 
 	@Override
-	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout)
-			throws EvaluationException {
+	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout) throws EvaluationException {
 		try {
 			return subManager.get().check(conjuncts, getModel, timeout);
 		} catch (UncheckedEvaluationException e) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/PushPopSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/PushPopSolver.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
@@ -37,8 +36,8 @@ public class PushPopSolver extends AbstractSmtLibSolver {
 	private final Deque<SmtLibTerm> cache = new ArrayDeque<>();
 
 	@Override
-	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(Collection<SmtLibTerm> assertions)
-			throws EvaluationException {
+	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(
+			Collection<SmtLibTerm> assertions) throws EvaluationException {
 		int baseSize = cache.size();
 		int i = findDiffPos(assertions);
 		int pops = baseSize - i;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/QueueSmtManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/QueueSmtManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.function.Supplier;
@@ -43,8 +42,7 @@ public class QueueSmtManager implements SmtLibSolver {
 	}
 
 	@Override
-	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout)
-			throws EvaluationException {
+	public SmtResult check(Collection<SmtLibTerm> conjuncts, boolean getModel, int timeout) throws EvaluationException {
 		SmtLibSolver solver;
 		try {
 			solver = solvers.take();

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SingleShotSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SingleShotSolver.java
@@ -34,8 +34,8 @@ public class SingleShotSolver extends AbstractSmtLibSolver {
 	private Program<?, ?> prog;
 
 	@Override
-	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(Collection<SmtLibTerm> assertions)
-			throws EvaluationException {
+	protected Pair<Collection<SolverVariable>, Collection<SolverVariable>> makeAssertions(
+			Collection<SmtLibTerm> assertions) throws EvaluationException {
 		shim.setLogic(Configuration.smtLogic);
 		shim.makeDeclarations();
 		for (SmtLibTerm assertion : assertions) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibParser.java
@@ -53,476 +53,476 @@ import edu.harvard.seas.pl.formulog.types.Types.TypeIndex;
 
 public class SmtLibParser {
 
-    private final SymbolManager symbolManager;
-    private final Map<String, SolverVariable> variables;
+	private final SymbolManager symbolManager;
+	private final Map<String, SolverVariable> variables;
 
-    public SmtLibParser(SymbolManager symbolManager, Map<String, SolverVariable> variables) {
-        this.symbolManager = symbolManager;
-        this.variables = variables;
-    }
+	public SmtLibParser(SymbolManager symbolManager, Map<String, SolverVariable> variables) {
+		this.symbolManager = symbolManager;
+		this.variables = variables;
+	}
 
-    public Map<SolverVariable, Term> getModel(Reader r) throws IOException, SmtLibParseException {
-        Tokenizer t = new Tokenizer(r);
-        t.consume("(");
-        Map<SolverVariable, Term> m = new HashMap<>();
-        while (!t.peek().equals(")")) {
-            if (t.peek().equals(";")) {
-                consumeComment(t);
-            } else {
-                parseFunctionDef(m, t);
-            }
-        }
-        t.consume(")");
-        t.ignoreWhitespace(false);
-        // Remove EOL
-        t.next();
-        return m;
-    }
+	public Map<SolverVariable, Term> getModel(Reader r) throws IOException, SmtLibParseException {
+		Tokenizer t = new Tokenizer(r);
+		t.consume("(");
+		Map<SolverVariable, Term> m = new HashMap<>();
+		while (!t.peek().equals(")")) {
+			if (t.peek().equals(";")) {
+				consumeComment(t);
+			} else {
+				parseFunctionDef(m, t);
+			}
+		}
+		t.consume(")");
+		t.ignoreWhitespace(false);
+		// Remove EOL
+		t.next();
+		return m;
+	}
 
-    private void consumeComment(Tokenizer t) throws IOException, SmtLibParseException {
-        t.consume(";;");
-        t.ignoreWhitespace(false);
-        while (!t.next().equals("\n")) {
-            // do nothing
-        }
-        t.ignoreWhitespace(true);
-    }
+	private void consumeComment(Tokenizer t) throws IOException, SmtLibParseException {
+		t.consume(";;");
+		t.ignoreWhitespace(false);
+		while (!t.next().equals("\n")) {
+			// do nothing
+		}
+		t.ignoreWhitespace(true);
+	}
 
-    private void parseFunctionDef(Map<SolverVariable, Term> m, Tokenizer t) throws IOException, SmtLibParseException {
-        t.consume("(");
-        if (t.peek().equals("forall") || t.peek().equals("declare")) {
-            skipRestOfSExp(t);
-            return;
-        }
-        t.consume("define-fun");
-        if (t.peek().equals("-")) {
-            skipRestOfSExp(t);
-            return;
-        }
-        String id = parseIdentifier(t);
+	private void parseFunctionDef(Map<SolverVariable, Term> m, Tokenizer t) throws IOException, SmtLibParseException {
+		t.consume("(");
+		if (t.peek().equals("forall") || t.peek().equals("declare")) {
+			skipRestOfSExp(t);
+			return;
+		}
+		t.consume("define-fun");
+		if (t.peek().equals("-")) {
+			skipRestOfSExp(t);
+			return;
+		}
+		String id = parseIdentifier(t);
 
-        // Ignore args
-        t.consume("(");
-        skipRestOfSExp(t);
+		// Ignore args
+		t.consume("(");
+		skipRestOfSExp(t);
 
-        // Parse type
-        parseType(t);
+		// Parse type
+		parseType(t);
 
-        SolverVariable x = variables.get(id);
-        if (x != null) {
-            FunctorType ft = (FunctorType) x.getSymbol().getCompileTimeType();
-            AlgebraicDataType type = (AlgebraicDataType) ft.getRetType();
-            type = stripSymType(type);
+		SolverVariable x = variables.get(id);
+		if (x != null) {
+			FunctorType ft = (FunctorType) x.getSymbol().getCompileTimeType();
+			AlgebraicDataType type = (AlgebraicDataType) ft.getRetType();
+			type = stripSymType(type);
 
-            if (shouldRecord(type)) {
-                m.put(x, parseTerm(t, type));
-            }
-        }
-        skipRestOfSExp(t);
-    }
+			if (shouldRecord(type)) {
+				m.put(x, parseTerm(t, type));
+			}
+		}
+		skipRestOfSExp(t);
+	}
 
-    private static enum TermType {
-        BV32, BV64, FP32, FP64, STRING, ADT
-    }
+	private static enum TermType {
+		BV32, BV64, FP32, FP64, STRING, ADT
+	}
 
-    public static AlgebraicDataType stripSymType(AlgebraicDataType symType) {
-        assert symType.getSymbol().equals(BuiltInTypeSymbol.SYM_TYPE);
-        return (AlgebraicDataType) symType.getTypeArgs().get(0);
-    }
+	public static AlgebraicDataType stripSymType(AlgebraicDataType symType) {
+		assert symType.getSymbol().equals(BuiltInTypeSymbol.SYM_TYPE);
+		return (AlgebraicDataType) symType.getTypeArgs().get(0);
+	}
 
-    public static boolean shouldRecord(AlgebraicDataType type) throws SmtLibParseException {
-        Set<Symbol> seen = new HashSet<>();
-        boolean ok = shouldRecord1(type, seen);
-        for (Type arg : type.getTypeArgs()) {
-            if (arg instanceof AlgebraicDataType) {
-                ok &= shouldRecord1((AlgebraicDataType) arg, seen);
-            }
-        }
-        return ok;
-    }
+	public static boolean shouldRecord(AlgebraicDataType type) throws SmtLibParseException {
+		Set<Symbol> seen = new HashSet<>();
+		boolean ok = shouldRecord1(type, seen);
+		for (Type arg : type.getTypeArgs()) {
+			if (arg instanceof AlgebraicDataType) {
+				ok &= shouldRecord1((AlgebraicDataType) arg, seen);
+			}
+		}
+		return ok;
+	}
 
-    private static void die(String msg) throws SmtLibParseException {
-        throw new SmtLibParseException("INTERNAL ERROR: " + msg);
-    }
+	private static void die(String msg) throws SmtLibParseException {
+		throw new SmtLibParseException("INTERNAL ERROR: " + msg);
+	}
 
-    private static boolean shouldRecord1(AlgebraicDataType type, Set<Symbol> seen) throws SmtLibParseException {
-        TypeSymbol sym = type.getSymbol();
-        if (!seen.add(sym)) {
-            return true;
-        }
-        if (sym instanceof BuiltInTypeSymbol) {
-            switch ((BuiltInTypeSymbol) sym) {
-                case BOOL_TYPE:
-                case CMP_TYPE:
-                case LIST_TYPE:
-                case OPTION_TYPE:
-                case STRING_TYPE:
-                    return true;
-                case ARRAY_TYPE:
-                case INT_TYPE:
-                    return false;
-                case BV:
-                    TypeIndex idx = (TypeIndex) type.getTypeArgs().get(0);
-                    int w = idx.getIndex();
-                    return w == 32 || w == 64;
-                case FP:
-                    TypeIndex idx1 = (TypeIndex) type.getTypeArgs().get(0);
-                    int e = idx1.getIndex();
-                    TypeIndex idx2 = (TypeIndex) type.getTypeArgs().get(1);
-                    int s = idx2.getIndex();
-                    return (e == 8 && s == 24) || (e == 11 && s == 53);
-                case SMT_TYPE:
-                case MODEL_TYPE:
-                case SYM_TYPE:
-                default:
-                    die("unexpected built-in symbol: " + sym);
-            }
-        }
-        if (sym.isUninterpretedSort()) {
-            return false;
-        }
-        boolean ok = true;
-        if (type.hasConstructors()) {
-            for (ConstructorScheme cs : type.getConstructors()) {
-                for (Type ty : cs.getTypeArgs()) {
-                    if (ty instanceof AlgebraicDataType) {
-                        ok &= shouldRecord1((AlgebraicDataType) ty, seen);
-                    }
-                }
-            }
-        }
-        return ok;
-    }
+	private static boolean shouldRecord1(AlgebraicDataType type, Set<Symbol> seen) throws SmtLibParseException {
+		TypeSymbol sym = type.getSymbol();
+		if (!seen.add(sym)) {
+			return true;
+		}
+		if (sym instanceof BuiltInTypeSymbol) {
+			switch ((BuiltInTypeSymbol) sym) {
+			case BOOL_TYPE:
+			case CMP_TYPE:
+			case LIST_TYPE:
+			case OPTION_TYPE:
+			case STRING_TYPE:
+				return true;
+			case ARRAY_TYPE:
+			case INT_TYPE:
+				return false;
+			case BV:
+				TypeIndex idx = (TypeIndex) type.getTypeArgs().get(0);
+				int w = idx.getIndex();
+				return w == 32 || w == 64;
+			case FP:
+				TypeIndex idx1 = (TypeIndex) type.getTypeArgs().get(0);
+				int e = idx1.getIndex();
+				TypeIndex idx2 = (TypeIndex) type.getTypeArgs().get(1);
+				int s = idx2.getIndex();
+				return (e == 8 && s == 24) || (e == 11 && s == 53);
+			case SMT_TYPE:
+			case MODEL_TYPE:
+			case SYM_TYPE:
+			default:
+				die("unexpected built-in symbol: " + sym);
+			}
+		}
+		if (sym.isUninterpretedSort()) {
+			return false;
+		}
+		boolean ok = true;
+		if (type.hasConstructors()) {
+			for (ConstructorScheme cs : type.getConstructors()) {
+				for (Type ty : cs.getTypeArgs()) {
+					if (ty instanceof AlgebraicDataType) {
+						ok &= shouldRecord1((AlgebraicDataType) ty, seen);
+					}
+				}
+			}
+		}
+		return ok;
+	}
 
-    private TermType getTermType(AlgebraicDataType type) throws SmtLibParseException {
-        TypeSymbol sym = type.getSymbol();
-        if (sym instanceof BuiltInTypeSymbol) {
-            switch ((BuiltInTypeSymbol) sym) {
-                case BOOL_TYPE:
-                case CMP_TYPE:
-                case LIST_TYPE:
-                case OPTION_TYPE:
-                    return TermType.ADT;
-                case STRING_TYPE:
-                    return TermType.STRING;
-                case BV: {
-                    TypeIndex idx = (TypeIndex) type.getTypeArgs().get(0);
-                    int w = idx.getIndex();
-                    if (w == 32) {
-                        return TermType.BV32;
-                    } else if (w == 64) {
-                        return TermType.BV64;
-                    }
-                    die("unexpected BV width " + w);
-                }
-                case FP: {
-                    TypeIndex idx1 = (TypeIndex) type.getTypeArgs().get(0);
-                    int e = idx1.getIndex();
-                    TypeIndex idx2 = (TypeIndex) type.getTypeArgs().get(1);
-                    int s = idx2.getIndex();
-                    if (e == 8 && s == 24) {
-                        return TermType.FP32;
-                    } else if (e == 11 && s == 53) {
-                        return TermType.FP64;
-                    }
-                    die("unexpected FP dimensions " + e + "/" + s);
-                }
-                default:
-                    die("unexpected built-in symbol: " + sym);
-            }
-        }
-        return TermType.ADT;
-    }
+	private TermType getTermType(AlgebraicDataType type) throws SmtLibParseException {
+		TypeSymbol sym = type.getSymbol();
+		if (sym instanceof BuiltInTypeSymbol) {
+			switch ((BuiltInTypeSymbol) sym) {
+			case BOOL_TYPE:
+			case CMP_TYPE:
+			case LIST_TYPE:
+			case OPTION_TYPE:
+				return TermType.ADT;
+			case STRING_TYPE:
+				return TermType.STRING;
+			case BV: {
+				TypeIndex idx = (TypeIndex) type.getTypeArgs().get(0);
+				int w = idx.getIndex();
+				if (w == 32) {
+					return TermType.BV32;
+				} else if (w == 64) {
+					return TermType.BV64;
+				}
+				die("unexpected BV width " + w);
+			}
+			case FP: {
+				TypeIndex idx1 = (TypeIndex) type.getTypeArgs().get(0);
+				int e = idx1.getIndex();
+				TypeIndex idx2 = (TypeIndex) type.getTypeArgs().get(1);
+				int s = idx2.getIndex();
+				if (e == 8 && s == 24) {
+					return TermType.FP32;
+				} else if (e == 11 && s == 53) {
+					return TermType.FP64;
+				}
+				die("unexpected FP dimensions " + e + "/" + s);
+			}
+			default:
+				die("unexpected built-in symbol: " + sym);
+			}
+		}
+		return TermType.ADT;
+	}
 
-    private String parseIdentifier(Tokenizer t) throws IOException, SmtLibParseException {
-        String s = t.next();
-        if (s.equals("|")) {
-            s = "";
-            while (!t.peek().equals("|")) {
-                s += t.next();
-            }
-        } else {
-            if (t.peek().equals("!")) {
-                t.consume("!");
-                s += "!";
-                s += parseIdentifier(t);
-            }
-        }
-        return s;
-    }
+	private String parseIdentifier(Tokenizer t) throws IOException, SmtLibParseException {
+		String s = t.next();
+		if (s.equals("|")) {
+			s = "";
+			while (!t.peek().equals("|")) {
+				s += t.next();
+			}
+		} else {
+			if (t.peek().equals("!")) {
+				t.consume("!");
+				s += "!";
+				s += parseIdentifier(t);
+			}
+		}
+		return s;
+	}
 
-    private void parseType(Tokenizer t) throws IOException, SmtLibParseException {
-        String s = t.next();
-        if (s.equals("(")) {
-            skipRestOfSExp(t);
-        }
-    }
-    
-    private long parseBv(Tokenizer t) throws IOException, SmtLibParseException {
-        t.consume("#");
-        String tok = t.next();
-        String prefix = tok.substring(0, 1);
-        String num = tok.substring(1);
-        int base = 0;
-        if (prefix.equals("b")) {
-            base = 2;
-        } else {
-            assert(prefix.equals("x"));
-            base = 16;
-        }
-        return Long.parseUnsignedLong(num, base);
-    }
-    
-    private Term parseTerm(Tokenizer t, AlgebraicDataType type) throws IOException, SmtLibParseException {
-        switch (getTermType(type)) {
-            case ADT:
-                return parseADTTerm(t, type);
-            case BV32: {
-                return I32.make((int) parseBv(t));
-            }
-            case BV64: {
-                return I64.make(parseBv(t));
-            }
-            // FIXME I'm not sure if these conversions to floating point are 100%
-            // correct...
-            case FP32: {
-                float val = -1;
-                t.consume("(");
-                if (t.peek().equals("fp")) {
-                    t.consume("fp");
-                    long sign = parseBv(t);
-                    long exp = parseBv(t);
-                    long mant = parseBv(t);
-                    long bits = sign << 31;
-                    bits |= exp << 23;
-                    bits |= mant;
-                    val = Float.intBitsToFloat((int) bits);
-                } else {
-                    t.consume("_");
-                    String next = t.next();
-                    if (next.equals("NaN")) {
-                        val = Float.NaN;
-                    } else if (next.equals("+")) {
-                        if (t.peek().equals("oo")) {
-                            t.consume("oo");
-                            val = Float.POSITIVE_INFINITY;
-                        } else {
-                            t.consume("zero");
-                            val = +0.0f;
-                        }
-                    } else {
-                        assert next.equals("-");
-                        if (t.peek().equals("oo")) {
-                            t.consume("oo");
-                            val = Float.NEGATIVE_INFINITY;
-                        } else {
-                            t.consume("zero");
-                            val = -0.0f;
-                        }
-                    }
-                }
-                skipRestOfSExp(t);
-                return FP32.make(val);
-            }
-            case FP64: {
-                double val = -1;
-                t.consume("(");
-                if (t.peek().equals("fp")) {
-                    t.consume("fp");
-                    long sign = parseBv(t);
-                    long exp = parseBv(t);
-                    long mant = parseBv(t);
-                    long bits = sign << 63;
-                    bits |= exp << 52;
-                    bits |= mant;
-                    val = Double.longBitsToDouble(bits);
-                } else {
-                    t.consume("_");
-                    String next = t.next();
-                    if (next.equals("NaN")) {
-                        val = Double.NaN;
-                    } else if (next.equals("+")) {
-                        if (t.peek().equals("oo")) {
-                            t.consume("oo");
-                            val = Double.POSITIVE_INFINITY;
-                        } else {
-                            t.consume("zero");
-                            val = +0.0;
-                        }
-                    } else {
-                        assert next.equals("-");
-                        if (t.peek().equals("oo")) {
-                            t.consume("oo");
-                            val = Double.NEGATIVE_INFINITY;
-                        } else {
-                            t.consume("zero");
-                            val = -0.0;
-                        }
-                    }
-                }
-                skipRestOfSExp(t);
-                return FP64.make(val);
-            }
-            case STRING:
-                return parseString(t);
-        }
-        die("unexpected term type: " + getTermType(type));
-        return null;
-    }
+	private void parseType(Tokenizer t) throws IOException, SmtLibParseException {
+		String s = t.next();
+		if (s.equals("(")) {
+			skipRestOfSExp(t);
+		}
+	}
 
-    private Term parseString(Tokenizer t) throws IOException, SmtLibParseException {
-        t.consume("\"");
-        t.ignoreWhitespace(false);
-        StringBuilder sb = new StringBuilder();
-        while (true) {
-            String next = t.next();
-            if (next.equals("\"")) {
-                // SMT-LIB uses "" to represent the character "
-                if (!t.peek().equals("\"")) {
-                    break;
-                }
-                t.consume("\"");
-            }
-            sb.append(next);
-        }
-        t.ignoreWhitespace(true);
-        return StringTerm.make(sb.toString());
-    }
+	private long parseBv(Tokenizer t) throws IOException, SmtLibParseException {
+		t.consume("#");
+		String tok = t.next();
+		String prefix = tok.substring(0, 1);
+		String num = tok.substring(1);
+		int base = 0;
+		if (prefix.equals("b")) {
+			base = 2;
+		} else {
+			assert (prefix.equals("x"));
+			base = 16;
+		}
+		return Long.parseUnsignedLong(num, base);
+	}
 
-    private Term parseADTTerm(Tokenizer t, AlgebraicDataType type) throws IOException, SmtLibParseException {
-        String id = t.next();
-        if (id.equals("(")) {
-            id = t.next();
-            if (id.equals("as")) {
-                Term term = parseADTTerm(t, type);
-                skipRestOfSExp(t);
-                return term;
-            }
-        }
-        if (id.equals("true")) {
-            return BoolTerm.mkTrue();
-        }
-        if (id.equals("false")) {
-            return BoolTerm.mkFalse();
-        }
-        ConstructorSymbol sym = (ConstructorSymbol) symbolManager.lookupSymbol(id);
-        Term[] args = Terms.emptyArray();
-        if (sym.getArity() > 0) {
-            List<Type> argTypes = null;
-            for (ConstructorScheme cs : type.getConstructors()) {
-                if (cs.getSymbol().equals(sym)) {
-                    argTypes = cs.getTypeArgs();
-                    break;
-                }
-            }
-            assert argTypes != null;
-            args = new Term[argTypes.size()];
-            int i = 0;
-            for (Type ty : argTypes) {
-                Term arg = parseTerm(t, (AlgebraicDataType) ty);
-                args[i] = arg;
-                ++i;
-            }
-            skipRestOfSExp(t);
-        }
-        return Constructors.make(sym, args);
-    }
+	private Term parseTerm(Tokenizer t, AlgebraicDataType type) throws IOException, SmtLibParseException {
+		switch (getTermType(type)) {
+		case ADT:
+			return parseADTTerm(t, type);
+		case BV32: {
+			return I32.make((int) parseBv(t));
+		}
+		case BV64: {
+			return I64.make(parseBv(t));
+		}
+		// FIXME I'm not sure if these conversions to floating point are 100%
+		// correct...
+		case FP32: {
+			float val = -1;
+			t.consume("(");
+			if (t.peek().equals("fp")) {
+				t.consume("fp");
+				long sign = parseBv(t);
+				long exp = parseBv(t);
+				long mant = parseBv(t);
+				long bits = sign << 31;
+				bits |= exp << 23;
+				bits |= mant;
+				val = Float.intBitsToFloat((int) bits);
+			} else {
+				t.consume("_");
+				String next = t.next();
+				if (next.equals("NaN")) {
+					val = Float.NaN;
+				} else if (next.equals("+")) {
+					if (t.peek().equals("oo")) {
+						t.consume("oo");
+						val = Float.POSITIVE_INFINITY;
+					} else {
+						t.consume("zero");
+						val = +0.0f;
+					}
+				} else {
+					assert next.equals("-");
+					if (t.peek().equals("oo")) {
+						t.consume("oo");
+						val = Float.NEGATIVE_INFINITY;
+					} else {
+						t.consume("zero");
+						val = -0.0f;
+					}
+				}
+			}
+			skipRestOfSExp(t);
+			return FP32.make(val);
+		}
+		case FP64: {
+			double val = -1;
+			t.consume("(");
+			if (t.peek().equals("fp")) {
+				t.consume("fp");
+				long sign = parseBv(t);
+				long exp = parseBv(t);
+				long mant = parseBv(t);
+				long bits = sign << 63;
+				bits |= exp << 52;
+				bits |= mant;
+				val = Double.longBitsToDouble(bits);
+			} else {
+				t.consume("_");
+				String next = t.next();
+				if (next.equals("NaN")) {
+					val = Double.NaN;
+				} else if (next.equals("+")) {
+					if (t.peek().equals("oo")) {
+						t.consume("oo");
+						val = Double.POSITIVE_INFINITY;
+					} else {
+						t.consume("zero");
+						val = +0.0;
+					}
+				} else {
+					assert next.equals("-");
+					if (t.peek().equals("oo")) {
+						t.consume("oo");
+						val = Double.NEGATIVE_INFINITY;
+					} else {
+						t.consume("zero");
+						val = -0.0;
+					}
+				}
+			}
+			skipRestOfSExp(t);
+			return FP64.make(val);
+		}
+		case STRING:
+			return parseString(t);
+		}
+		die("unexpected term type: " + getTermType(type));
+		return null;
+	}
 
-    private void skipRestOfSExp(Tokenizer t) throws IOException, SmtLibParseException {
-        int depth = 0;
-        while (depth >= 0) {
-            switch (t.next()) {
-                case "(":
-                    depth++;
-                    break;
-                case ")":
-                    depth--;
-                    break;
-            }
-        }
-    }
+	private Term parseString(Tokenizer t) throws IOException, SmtLibParseException {
+		t.consume("\"");
+		t.ignoreWhitespace(false);
+		StringBuilder sb = new StringBuilder();
+		while (true) {
+			String next = t.next();
+			if (next.equals("\"")) {
+				// SMT-LIB uses "" to represent the character "
+				if (!t.peek().equals("\"")) {
+					break;
+				}
+				t.consume("\"");
+			}
+			sb.append(next);
+		}
+		t.ignoreWhitespace(true);
+		return StringTerm.make(sb.toString());
+	}
 
-    private static class Tokenizer {
+	private Term parseADTTerm(Tokenizer t, AlgebraicDataType type) throws IOException, SmtLibParseException {
+		String id = t.next();
+		if (id.equals("(")) {
+			id = t.next();
+			if (id.equals("as")) {
+				Term term = parseADTTerm(t, type);
+				skipRestOfSExp(t);
+				return term;
+			}
+		}
+		if (id.equals("true")) {
+			return BoolTerm.mkTrue();
+		}
+		if (id.equals("false")) {
+			return BoolTerm.mkFalse();
+		}
+		ConstructorSymbol sym = (ConstructorSymbol) symbolManager.lookupSymbol(id);
+		Term[] args = Terms.emptyArray();
+		if (sym.getArity() > 0) {
+			List<Type> argTypes = null;
+			for (ConstructorScheme cs : type.getConstructors()) {
+				if (cs.getSymbol().equals(sym)) {
+					argTypes = cs.getTypeArgs();
+					break;
+				}
+			}
+			assert argTypes != null;
+			args = new Term[argTypes.size()];
+			int i = 0;
+			for (Type ty : argTypes) {
+				Term arg = parseTerm(t, (AlgebraicDataType) ty);
+				args[i] = arg;
+				++i;
+			}
+			skipRestOfSExp(t);
+		}
+		return Constructors.make(sym, args);
+	}
 
-        private final StreamTokenizer t;
+	private void skipRestOfSExp(Tokenizer t) throws IOException, SmtLibParseException {
+		int depth = 0;
+		while (depth >= 0) {
+			switch (t.next()) {
+			case "(":
+				depth++;
+				break;
+			case ")":
+				depth--;
+				break;
+			}
+		}
+	}
 
-        public Tokenizer(Reader r) {
-            t = new StreamTokenizer(r);
-            t.ordinaryChar('.');
-            t.ordinaryChar('-');
-            t.ordinaryChars('0', '9');
-            t.ordinaryChar('"');
-            t.ordinaryChar('\'');
-            t.ordinaryChar('/');
-            t.wordChars('0', '9');
-            t.wordChars('_', '_');
-        }
+	private static class Tokenizer {
 
-        // FIXME This is almost certainly incomplete.
-        public void ignoreWhitespace(boolean ignore) {
-            if (ignore) {
-                t.whitespaceChars('\n', '\n');
-                t.whitespaceChars('\r', '\r');
-                t.whitespaceChars('\t', '\t');
-                t.whitespaceChars(' ', ' ');
-            } else {
-                t.ordinaryChar('\n');
-                t.ordinaryChar('\r');
-                t.ordinaryChar('\t');
-                t.ordinaryChar(' ');
-            }
-        }
+		private final StreamTokenizer t;
 
-        public String peek() throws IOException, SmtLibParseException {
-            String token = next();
-            t.pushBack();
-            return token;
-        }
+		public Tokenizer(Reader r) {
+			t = new StreamTokenizer(r);
+			t.ordinaryChar('.');
+			t.ordinaryChar('-');
+			t.ordinaryChars('0', '9');
+			t.ordinaryChar('"');
+			t.ordinaryChar('\'');
+			t.ordinaryChar('/');
+			t.wordChars('0', '9');
+			t.wordChars('_', '_');
+		}
 
-        public String next() throws IOException, SmtLibParseException {
-            int token = t.nextToken();
-            switch (t.ttype) {
-                case StreamTokenizer.TT_EOF:
-                    throw new SmtLibParseException("Unexpected EOF.");
-                case StreamTokenizer.TT_EOL:
-                    // This should only happen in the mode when whitespace is significant.
-                    return "\n";
-                case StreamTokenizer.TT_NUMBER:
-                    die("nothing should be tokenized as a number.");
-                case StreamTokenizer.TT_WORD:
-                    return t.sval;
-                default:
-                    return Character.toString((char) token);
-            }
-        }
+		// FIXME This is almost certainly incomplete.
+		public void ignoreWhitespace(boolean ignore) {
+			if (ignore) {
+				t.whitespaceChars('\n', '\n');
+				t.whitespaceChars('\r', '\r');
+				t.whitespaceChars('\t', '\t');
+				t.whitespaceChars(' ', ' ');
+			} else {
+				t.ordinaryChar('\n');
+				t.ordinaryChar('\r');
+				t.ordinaryChar('\t');
+				t.ordinaryChar(' ');
+			}
+		}
 
-        public boolean hasNext() throws IOException {
-            t.nextToken();
-            t.pushBack();
-            return t.ttype != StreamTokenizer.TT_EOF;
-        }
+		public String peek() throws IOException, SmtLibParseException {
+			String token = next();
+			t.pushBack();
+			return token;
+		}
 
-        public void consume(String s) throws IOException, SmtLibParseException {
-            Tokenizer t = new Tokenizer(new StringReader(s));
-            while (t.hasNext()) {
-                String expected = t.next();
-                String found = next();
-                if (!expected.equals(found)) {
-                    throw new SmtLibParseException(
-                            "Tried to consume \"" + expected + "\", but found \"" + found + "\".");
-                }
-            }
-        }
+		public String next() throws IOException, SmtLibParseException {
+			int token = t.nextToken();
+			switch (t.ttype) {
+			case StreamTokenizer.TT_EOF:
+				throw new SmtLibParseException("Unexpected EOF.");
+			case StreamTokenizer.TT_EOL:
+				// This should only happen in the mode when whitespace is significant.
+				return "\n";
+			case StreamTokenizer.TT_NUMBER:
+				die("nothing should be tokenized as a number.");
+			case StreamTokenizer.TT_WORD:
+				return t.sval;
+			default:
+				return Character.toString((char) token);
+			}
+		}
 
-    }
+		public boolean hasNext() throws IOException {
+			t.nextToken();
+			t.pushBack();
+			return t.ttype != StreamTokenizer.TT_EOF;
+		}
 
-    @SuppressWarnings("serial")
-    public static class SmtLibParseException extends Exception {
+		public void consume(String s) throws IOException, SmtLibParseException {
+			Tokenizer t = new Tokenizer(new StringReader(s));
+			while (t.hasNext()) {
+				String expected = t.next();
+				String found = next();
+				if (!expected.equals(found)) {
+					throw new SmtLibParseException(
+							"Tried to consume \"" + expected + "\", but found \"" + found + "\".");
+				}
+			}
+		}
 
-        public SmtLibParseException(String message) {
-            super(message);
-        }
+	}
 
-    }
+	@SuppressWarnings("serial")
+	public static class SmtLibParseException extends Exception {
+
+		public SmtLibParseException(String message) {
+			super(message);
+		}
+
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
@@ -174,7 +174,6 @@ public class SmtLibShim {
 		println("(reset)");
 		checkSuccess();
 	}
-	
 
 	public void resetAssertions() throws EvaluationException {
 		println("(reset-assertions)");
@@ -218,7 +217,7 @@ public class SmtLibShim {
 			checkSuccess();
 		}
 	}
-	
+
 	public SmtStatus checkSatAssuming(Collection<SolverVariable> onVars, Collection<SolverVariable> offVars,
 			int timeout) throws EvaluationException {
 		setTimeout(timeout);

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibSolver.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import java.util.Collection;
 
 import edu.harvard.seas.pl.formulog.ast.Program;
@@ -30,7 +29,7 @@ import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 public interface SmtLibSolver {
 
 	void start(Program<?, ?> prog) throws EvaluationException;
-	
+
 	SmtResult check(Collection<SmtLibTerm> t, boolean getModel, int timeout) throws EvaluationException;
 
 	void destroy();

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtResult.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtResult.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Model;
 
 public class SmtResult {
@@ -29,7 +28,7 @@ public class SmtResult {
 	public final Model model;
 	public final int solverId;
 	public final int taskId;
-	
+
 	public SmtResult(SmtStatus status, Model model, int solverId, int taskId) {
 		this.status = status;
 		this.model = model;

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtStatus.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtStatus.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 public enum SmtStatus {
 	SATISFIABLE, UNSATISFIABLE, UNKNOWN
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtStrategy.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtStrategy.java
@@ -20,30 +20,29 @@ package edu.harvard.seas.pl.formulog.smt;
  * #L%
  */
 
-
 public class SmtStrategy {
 
 	public enum Tag {
 		QUEUE,
-		
+
 		BEST_MATCH,
-		
+
 		NAIVE,
-		
+
 		PUSH_POP,
-		
+
 		PUSH_POP_NAIVE,
-		
+
 		PER_THREAD_QUEUE,
-		
+
 		PER_THREAD_BEST_MATCH,
-		
+
 		PER_THREAD_PUSH_POP,
-		
+
 		PER_THREAD_NAIVE,
-		
+
 		PER_THREAD_PUSH_POP_NAIVE,
-		
+
 		;
 	}
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 abstract class AbstractSymbol implements Symbol {
 
 	private final String name;

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractTypedSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractTypedSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 abstract class AbstractTypedSymbol extends AbstractSymbol implements TypedSymbol {

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractWrappedRelationSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/AbstractWrappedRelationSymbol.java
@@ -20,75 +20,74 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 public abstract class AbstractWrappedRelationSymbol<R extends RelationSymbol> implements WrappedRelationSymbol<R> {
 
-    private final R baseSymbol;
+	private final R baseSymbol;
 
-    public AbstractWrappedRelationSymbol(R baseSymbol) {
-        this.baseSymbol = baseSymbol;
-    }
+	public AbstractWrappedRelationSymbol(R baseSymbol) {
+		this.baseSymbol = baseSymbol;
+	}
 
-    @Override
-    public R getBaseSymbol() {
-        return baseSymbol;
-    }
+	@Override
+	public R getBaseSymbol() {
+		return baseSymbol;
+	}
 
-    @Override
-    public FunctorType getCompileTimeType() {
-        return baseSymbol.getCompileTimeType();
-    }
+	@Override
+	public FunctorType getCompileTimeType() {
+		return baseSymbol.getCompileTimeType();
+	}
 
-    @Override
-    public int getArity() {
-        return baseSymbol.getArity();
-    }
+	@Override
+	public int getArity() {
+		return baseSymbol.getArity();
+	}
 
-    @Override
-    public boolean isIdbSymbol() {
-        return baseSymbol.isIdbSymbol();
-    }
+	@Override
+	public boolean isIdbSymbol() {
+		return baseSymbol.isIdbSymbol();
+	}
 
-    @Override
-    public boolean isBottomUp() {
-        return baseSymbol.isEdbSymbol();
-    }
+	@Override
+	public boolean isBottomUp() {
+		return baseSymbol.isEdbSymbol();
+	}
 
-    @Override
-    public boolean isTopDown() {
-        return baseSymbol.isTopDown();
-    }
+	@Override
+	public boolean isTopDown() {
+		return baseSymbol.isTopDown();
+	}
 
-    @Override
-    public boolean isDisk() {
-        return false;
-    }
+	@Override
+	public boolean isDisk() {
+		return false;
+	}
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((baseSymbol == null) ? 0 : baseSymbol.hashCode());
-        return result;
-    }
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((baseSymbol == null) ? 0 : baseSymbol.hashCode());
+		return result;
+	}
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AbstractWrappedRelationSymbol<?> other = (AbstractWrappedRelationSymbol<?>) obj;
-        if (baseSymbol == null) {
-            if (other.baseSymbol != null)
-                return false;
-        } else if (!baseSymbol.equals(other.baseSymbol))
-            return false;
-        return true;
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AbstractWrappedRelationSymbol<?> other = (AbstractWrappedRelationSymbol<?>) obj;
+		if (baseSymbol == null) {
+			if (other.baseSymbol != null)
+				return false;
+		} else if (!baseSymbol.equals(other.baseSymbol))
+			return false;
+		return true;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorGetterSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorGetterSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.a;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.list;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.option;
@@ -36,17 +35,17 @@ import edu.harvard.seas.pl.formulog.types.Types.Type;
 public enum BuiltInConstructorGetterSymbol implements ConstructorSymbol {
 
 	CONS_1("#cons_1", list(a), smt(a)),
-	
+
 	CONS_2("#cons_2", list(a), smt(list(a))),
-	
+
 	SOME_1("#some_1", option(a), smt(a))
-	
+
 	;
 
 	private final String name;
 	private final FunctorType type;
-	
-	private BuiltInConstructorGetterSymbol(String name, Type...types) {
+
+	private BuiltInConstructorGetterSymbol(String name, Type... types) {
 		this.name = name;
 		List<Type> argTypes = new ArrayList<>(Arrays.asList(types));
 		Type retType = argTypes.remove(types.length - 1);
@@ -62,7 +61,7 @@ public enum BuiltInConstructorGetterSymbol implements ConstructorSymbol {
 	public FunctorType getCompileTimeType() {
 		return type;
 	}
-	
+
 	@Override
 	public String toString() {
 		return name;
@@ -72,5 +71,5 @@ public enum BuiltInConstructorGetterSymbol implements ConstructorSymbol {
 	public ConstructorSymbolType getConstructorSymbolType() {
 		return ConstructorSymbolType.SOLVER_CONSTRUCTOR_GETTER;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.symbols.ConstructorSymbolType.SOLVER_EXPR;
 import static edu.harvard.seas.pl.formulog.symbols.ConstructorSymbolType.VANILLA_CONSTRUCTOR;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.a;
@@ -44,43 +43,43 @@ import edu.harvard.seas.pl.formulog.types.Types.Type;
 public enum BuiltInConstructorSymbol implements ConstructorSymbol {
 
 	// Lists
-	
+
 	NIL("nil", 0, VANILLA_CONSTRUCTOR),
-	
+
 	CONS("cons", 2, VANILLA_CONSTRUCTOR),
-	
+
 	// Options
-	
+
 	NONE("none", 0, VANILLA_CONSTRUCTOR),
-	
+
 	SOME("some", 1, VANILLA_CONSTRUCTOR),
 
 	// Comparisons
-	
+
 	CMP_LT("cmp_lt", 0, VANILLA_CONSTRUCTOR),
-	
+
 	CMP_EQ("cmp_eq", 0, VANILLA_CONSTRUCTOR),
-	
+
 	CMP_GT("cmp_gt", 0, VANILLA_CONSTRUCTOR),
 
 	// Constraints
-	
+
 	SMT_NOT("smt_not", 1, SOLVER_EXPR),
-	
+
 	SMT_AND("smt_and", 2, SOLVER_EXPR),
-	
+
 	SMT_OR("smt_or", 2, SOLVER_EXPR),
-	
+
 	SMT_IMP("smt_imp", 2, SOLVER_EXPR),
-	
+
 	SMT_ITE("smt_ite", 3, SOLVER_EXPR),
-	
+
 	SMT_EXISTS("smt_exists", 3, SOLVER_EXPR),
-	
+
 	SMT_FORALL("smt_forall", 3, SOLVER_EXPR),
-	
+
 	// Bit vectors
-	
+
 	BV_NEG("bv_neg", 1, SOLVER_EXPR),
 
 	BV_ADD("bv_add", 2, SOLVER_EXPR),
@@ -92,7 +91,7 @@ public enum BuiltInConstructorSymbol implements ConstructorSymbol {
 	BV_SDIV("bv_sdiv", 2, SOLVER_EXPR),
 
 	BV_SREM("bv_srem", 2, SOLVER_EXPR),
-	
+
 	BV_UDIV("bv_udiv", 2, SOLVER_EXPR),
 
 	BV_UREM("bv_urem", 2, SOLVER_EXPR),
@@ -102,13 +101,13 @@ public enum BuiltInConstructorSymbol implements ConstructorSymbol {
 	BV_OR("bv_or", 2, SOLVER_EXPR),
 
 	BV_XOR("bv_xor", 2, SOLVER_EXPR),
-	
+
 	BV_SHL("bv_shl", 2, SOLVER_EXPR),
-	
+
 	BV_ASHR("bv_ashr", 2, SOLVER_EXPR),
-	
+
 	BV_LSHR("bv_lshr", 2, SOLVER_EXPR),
-	
+
 	// Floating point
 
 	FP_NEG("fp_neg", 1, SOLVER_EXPR),
@@ -122,73 +121,73 @@ public enum BuiltInConstructorSymbol implements ConstructorSymbol {
 	FP_DIV("fp_div", 2, SOLVER_EXPR),
 
 	FP_REM("fp_rem", 2, SOLVER_EXPR),
-	
+
 	// Arrays
 
 	ARRAY_STORE("array_store", 3, SOLVER_EXPR),
-	
+
 	ARRAY_CONST("array_const", 1, SOLVER_EXPR),
-	
+
 	// Strings
-	
+
 	STR_CONCAT("str_concat", 2, SOLVER_EXPR),
-	
+
 	STR_LEN("str_len", 1, SOLVER_EXPR),
-	
+
 	STR_SUBSTR("str_substr", 3, SOLVER_EXPR),
-	
+
 	STR_INDEXOF("str_indexof", 3, SOLVER_EXPR),
-	
+
 	STR_AT("str_at", 2, SOLVER_EXPR),
-	
+
 	STR_CONTAINS("str_contains", 2, SOLVER_EXPR),
-	
+
 	STR_PREFIXOF("str_prefixof", 2, SOLVER_EXPR),
-	
+
 	STR_SUFFIXOF("str_suffixof", 2, SOLVER_EXPR),
-	
+
 	STR_REPLACE("str_replace", 3, SOLVER_EXPR),
-	
+
 	// Ints
-	
+
 	INT_CONST("int_const", 1, SOLVER_EXPR),
-	
+
 	INT_BIG_CONST("int_big_const", 1, SOLVER_EXPR),
-	
+
 	INT_NEG("int_neg", 1, SOLVER_EXPR),
-	
+
 	INT_SUB("int_sub", 2, SOLVER_EXPR),
 
 	INT_ADD("int_add", 2, SOLVER_EXPR),
-	
+
 	INT_MUL("int_mul", 2, SOLVER_EXPR),
 
 	INT_DIV("int_div", 2, SOLVER_EXPR),
-	
+
 	INT_MOD("int_mod", 2, SOLVER_EXPR),
-	
+
 	INT_ABS("int_abs", 1, SOLVER_EXPR),
-	
+
 	INT_LE("int_le", 2, SOLVER_EXPR),
-	
+
 	INT_LT("int_lt", 2, SOLVER_EXPR),
-	
+
 	INT_GE("int_ge", 2, SOLVER_EXPR),
-	
+
 	INT_GT("int_gt", 2, SOLVER_EXPR),
-	
+
 	// Stuff for type checking formulas
-	
+
 	ENTER_FORMULA("enter_formula", 1, VANILLA_CONSTRUCTOR),
-	
-	EXIT_FORMULA("exit_formula", 1, VANILLA_CONSTRUCTOR),	
-	
+
+	EXIT_FORMULA("exit_formula", 1, VANILLA_CONSTRUCTOR),
+
 	;
 
 	private final String name;
 	private final int arity;
 	private final ConstructorSymbolType st;
-	
+
 	private BuiltInConstructorSymbol(String name, int arity, ConstructorSymbolType st) {
 		this.name = name;
 		this.arity = arity;
@@ -200,11 +199,11 @@ public enum BuiltInConstructorSymbol implements ConstructorSymbol {
 		return arity;
 	}
 
-	private FunctorType makeType(Type...types) {
+	private FunctorType makeType(Type... types) {
 		assert types.length == arity + 1;
 		return new FunctorType(types);
 	}
-	
+
 	@Override
 	public FunctorType getCompileTimeType() {
 		switch (this) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorTesterSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInConstructorTesterSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.a;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.bool;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.cmp;
@@ -38,31 +37,31 @@ import edu.harvard.seas.pl.formulog.types.Types.Type;
 public enum BuiltInConstructorTesterSymbol implements ConstructorSymbol {
 
 	IS_CMP_LT("#is_cmp_lt", cmp, smt(bool)),
-	
+
 	IS_CMP_EQ("#is_cmp_eq", cmp, smt(bool)),
-	
+
 	IS_CMP_GT("#is_cmp_gt", cmp, smt(bool)),
-	
+
 	IS_NIL("#is_nil", list(a), smt(bool)),
-	
+
 	IS_CONS("#is_cons", list(a), smt(bool)),
-	
+
 	IS_NONE("#is_none", option(a), smt(bool)),
-	
+
 	IS_SOME("#is_some", option(a), smt(bool)),
-	
+
 	;
 
 	private final FunctorType type;
 	private final String name;
 
-	private BuiltInConstructorTesterSymbol(String name, Type...types) {
+	private BuiltInConstructorTesterSymbol(String name, Type... types) {
 		this.name = name;
 		List<Type> argTypes = new ArrayList<>(Arrays.asList(types));
 		Type retType = argTypes.remove(types.length - 1);
 		type = new FunctorType(argTypes, retType);
 	}
-	
+
 	@Override
 	public int getArity() {
 		return 1;

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInFunctionSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInFunctionSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.a;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.bool;
 import static edu.harvard.seas.pl.formulog.types.BuiltInTypes.cmp;
@@ -41,429 +40,429 @@ import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 public enum BuiltInFunctionSymbol implements FunctionSymbol {
 
-    // i32 operations
+	// i32 operations
 
-    I32_ADD("i32_add", 2),
+	I32_ADD("i32_add", 2),
 
-    I32_SUB("i32_sub", 2),
+	I32_SUB("i32_sub", 2),
 
-    I32_MUL("i32_mul", 2),
+	I32_MUL("i32_mul", 2),
 
-    I32_SDIV("i32_sdiv", 2),
+	I32_SDIV("i32_sdiv", 2),
 
-    I32_SREM("i32_srem", 2),
+	I32_SREM("i32_srem", 2),
 
-    I32_UDIV("i32_udiv", 2),
+	I32_UDIV("i32_udiv", 2),
 
-    I32_UREM("i32_urem", 2),
+	I32_UREM("i32_urem", 2),
 
-    I32_NEG("i32_neg", 1),
+	I32_NEG("i32_neg", 1),
 
-    I32_LT("i32_lt", 2),
+	I32_LT("i32_lt", 2),
 
-    I32_LE("i32_le", 2),
+	I32_LE("i32_le", 2),
 
-    I32_GT("i32_gt", 2),
+	I32_GT("i32_gt", 2),
 
-    I32_GE("i32_ge", 2),
+	I32_GE("i32_ge", 2),
 
-    I32_AND("i32_and", 2),
+	I32_AND("i32_and", 2),
 
-    I32_OR("i32_or", 2),
+	I32_OR("i32_or", 2),
 
-    I32_XOR("i32_xor", 2),
+	I32_XOR("i32_xor", 2),
 
-    I32_SCMP("i32_scmp", 2),
+	I32_SCMP("i32_scmp", 2),
 
-    I32_UCMP("i32_ucmp", 2),
+	I32_UCMP("i32_ucmp", 2),
 
-    I32_SHL("i32_shl", 2),
+	I32_SHL("i32_shl", 2),
 
-    I32_ASHR("i32_ashr", 2),
+	I32_ASHR("i32_ashr", 2),
 
-    I32_LSHR("i32_lshr", 2),
+	I32_LSHR("i32_lshr", 2),
 
-    // i64 operations
+	// i64 operations
 
-    I64_ADD("i64_add", 2),
+	I64_ADD("i64_add", 2),
 
-    I64_SUB("i64_sub", 2),
+	I64_SUB("i64_sub", 2),
 
-    I64_MUL("i64_mul", 2),
+	I64_MUL("i64_mul", 2),
 
-    I64_SDIV("i64_sdiv", 2),
+	I64_SDIV("i64_sdiv", 2),
 
-    I64_SREM("i64_srem", 2),
+	I64_SREM("i64_srem", 2),
 
-    I64_UDIV("i64_udiv", 2),
+	I64_UDIV("i64_udiv", 2),
 
-    I64_UREM("i64_urem", 2),
+	I64_UREM("i64_urem", 2),
 
-    I64_NEG("i64_neg", 1),
+	I64_NEG("i64_neg", 1),
 
-    I64_LT("i64_lt", 2),
+	I64_LT("i64_lt", 2),
 
-    I64_LE("i64_le", 2),
+	I64_LE("i64_le", 2),
 
-    I64_GT("i64_gt", 2),
+	I64_GT("i64_gt", 2),
 
-    I64_GE("i64_ge", 2),
+	I64_GE("i64_ge", 2),
 
-    I64_AND("i64_and", 2),
+	I64_AND("i64_and", 2),
 
-    I64_OR("i64_or", 2),
+	I64_OR("i64_or", 2),
 
-    I64_XOR("i64_xor", 2),
+	I64_XOR("i64_xor", 2),
 
-    I64_SCMP("i64_scmp", 2),
+	I64_SCMP("i64_scmp", 2),
 
-    I64_UCMP("i64_ucmp", 2),
+	I64_UCMP("i64_ucmp", 2),
 
-    I64_SHL("i64_shl", 2),
+	I64_SHL("i64_shl", 2),
 
-    I64_ASHR("i64_ashr", 2),
+	I64_ASHR("i64_ashr", 2),
 
-    I64_LSHR("i64_lshr", 2),
+	I64_LSHR("i64_lshr", 2),
 
-    // fp32 operations
+	// fp32 operations
 
-    FP32_ADD("fp32_add", 2),
+	FP32_ADD("fp32_add", 2),
 
-    FP32_SUB("fp32_sub", 2),
+	FP32_SUB("fp32_sub", 2),
 
-    FP32_MUL("fp32_mul", 2),
+	FP32_MUL("fp32_mul", 2),
 
-    FP32_DIV("fp32_div", 2),
+	FP32_DIV("fp32_div", 2),
 
-    FP32_REM("fp32_rem", 2),
+	FP32_REM("fp32_rem", 2),
 
-    FP32_NEG("fp32_neg", 1),
+	FP32_NEG("fp32_neg", 1),
 
-    FP32_LT("fp32_lt", 2),
+	FP32_LT("fp32_lt", 2),
 
-    FP32_LE("fp32_le", 2),
+	FP32_LE("fp32_le", 2),
 
-    FP32_GT("fp32_gt", 2),
+	FP32_GT("fp32_gt", 2),
 
-    FP32_GE("fp32_ge", 2),
+	FP32_GE("fp32_ge", 2),
 
-    FP32_EQ("fp32_eq", 2),
+	FP32_EQ("fp32_eq", 2),
 
-    // fp64 operations
+	// fp64 operations
 
-    FP64_ADD("fp64_add", 2),
+	FP64_ADD("fp64_add", 2),
 
-    FP64_SUB("fp64_sub", 2),
+	FP64_SUB("fp64_sub", 2),
 
-    FP64_MUL("fp64_mul", 2),
+	FP64_MUL("fp64_mul", 2),
 
-    FP64_DIV("fp64_div", 2),
+	FP64_DIV("fp64_div", 2),
 
-    FP64_REM("fp64_rem", 2),
+	FP64_REM("fp64_rem", 2),
 
-    FP64_NEG("fp64_neg", 1),
+	FP64_NEG("fp64_neg", 1),
 
-    FP64_LT("fp64_lt", 2),
+	FP64_LT("fp64_lt", 2),
 
-    FP64_LE("fp64_le", 2),
+	FP64_LE("fp64_le", 2),
 
-    FP64_GT("fp64_gt", 2),
+	FP64_GT("fp64_gt", 2),
 
-    FP64_GE("fp64_ge", 2),
+	FP64_GE("fp64_ge", 2),
 
-    FP64_EQ("fp64_eq", 2),
+	FP64_EQ("fp64_eq", 2),
 
-    // Boolean operations
+	// Boolean operations
 
-    BEQ("beq", 2),
+	BEQ("beq", 2),
 
-    BNEQ("bneq", 2),
+	BNEQ("bneq", 2),
 
-    BNOT("bnot", 1),
+	BNOT("bnot", 1),
 
-    // String operations
+	// String operations
 
-    STRING_CMP("string_cmp", 2),
+	STRING_CMP("string_cmp", 2),
 
-    STRING_CONCAT("string_concat", 2),
+	STRING_CONCAT("string_concat", 2),
 
-    STRING_MATCHES("string_matches", 2),
+	STRING_MATCHES("string_matches", 2),
 
-    STRING_STARTS_WITH("string_starts_with", 2),
+	STRING_STARTS_WITH("string_starts_with", 2),
 
-    TO_STRING("to_string", 1),
+	TO_STRING("to_string", 1),
 
-    STRING_TO_LIST("string_to_list", 1),
+	STRING_TO_LIST("string_to_list", 1),
 
-    LIST_TO_STRING("list_to_string", 1),
+	LIST_TO_STRING("list_to_string", 1),
 
-    CHAR_AT("char_at", 2),
+	CHAR_AT("char_at", 2),
 
-    SUBSTRING("substring", 3),
+	SUBSTRING("substring", 3),
 
-    STRING_LENGTH("string_length", 1),
+	STRING_LENGTH("string_length", 1),
 
-    // Constraint solving
+	// Constraint solving
 
-    IS_SAT("is_sat", 1),
+	IS_SAT("is_sat", 1),
 
-    IS_VALID("is_valid", 1),
+	IS_VALID("is_valid", 1),
 
-    IS_SAT_OPT("is_sat_opt", 2),
+	IS_SAT_OPT("is_sat_opt", 2),
 
-    GET_MODEL("get_model", 2),
+	GET_MODEL("get_model", 2),
 
-    QUERY_MODEL("query_model", 2),
+	QUERY_MODEL("query_model", 2),
 
-    IS_SET_SAT("is_set_sat", 2),
+	IS_SET_SAT("is_set_sat", 2),
 
-    // Opaque datatypes
+	// Opaque datatypes
 
-    OPAQUE_SET_EMPTY("opaque_set_empty", 0),
+	OPAQUE_SET_EMPTY("opaque_set_empty", 0),
 
-    OPAQUE_SET_PLUS("opaque_set_plus", 2),
+	OPAQUE_SET_PLUS("opaque_set_plus", 2),
 
-    OPAQUE_SET_MINUS("opaque_set_minus", 2),
+	OPAQUE_SET_MINUS("opaque_set_minus", 2),
 
-    OPAQUE_SET_UNION("opaque_set_union", 2),
+	OPAQUE_SET_UNION("opaque_set_union", 2),
 
-    OPAQUE_SET_DIFF("opaque_set_diff", 2),
+	OPAQUE_SET_DIFF("opaque_set_diff", 2),
 
-    OPAQUE_SET_CHOOSE("opaque_set_choose", 1),
+	OPAQUE_SET_CHOOSE("opaque_set_choose", 1),
 
-    OPAQUE_SET_SIZE("opaque_set_size", 1),
+	OPAQUE_SET_SIZE("opaque_set_size", 1),
 
-    OPAQUE_SET_MEMBER("opaque_set_member", 2),
+	OPAQUE_SET_MEMBER("opaque_set_member", 2),
 
-    OPAQUE_SET_SINGLETON("opaque_set_singleton", 1),
+	OPAQUE_SET_SINGLETON("opaque_set_singleton", 1),
 
-    OPAQUE_SET_SUBSET("opaque_set_subset", 2),
+	OPAQUE_SET_SUBSET("opaque_set_subset", 2),
 
-    OPAQUE_SET_FROM_LIST("opaque_set_from_list", 1),
+	OPAQUE_SET_FROM_LIST("opaque_set_from_list", 1),
 
-    // Primitive conversion
+	// Primitive conversion
 
-    i32ToI64("i32_to_i64", 1),
+	i32ToI64("i32_to_i64", 1),
 
-    i32ToFp32("i32_to_fp32", 1),
+	i32ToFp32("i32_to_fp32", 1),
 
-    i32ToFp64("i32_to_fp64", 1),
+	i32ToFp64("i32_to_fp64", 1),
 
-    i64ToI32("i64_to_i32", 1),
+	i64ToI32("i64_to_i32", 1),
 
-    i64ToFp32("i64_to_fp32", 1),
+	i64ToFp32("i64_to_fp32", 1),
 
-    i64ToFp64("i64_to_fp64", 1),
+	i64ToFp64("i64_to_fp64", 1),
 
-    fp32ToI32("fp32_to_i32", 1),
+	fp32ToI32("fp32_to_i32", 1),
 
-    fp32ToI64("fp32_to_i64", 1),
+	fp32ToI64("fp32_to_i64", 1),
 
-    fp32ToFp64("fp32_to_fp64", 1),
+	fp32ToFp64("fp32_to_fp64", 1),
 
-    fp64ToI32("fp64_to_i32", 1),
+	fp64ToI32("fp64_to_i32", 1),
 
-    fp64ToI64("fp64_to_i64", 1),
+	fp64ToI64("fp64_to_i64", 1),
 
-    fp64ToFp32("fp64_to_fp32", 1),
+	fp64ToFp32("fp64_to_fp32", 1),
 
-    stringToI32("string_to_i32", 1),
+	stringToI32("string_to_i32", 1),
 
-    stringToI64("string_to_i64", 1),
+	stringToI64("string_to_i64", 1),
 
-    // Debugging
+	// Debugging
 
-    PRINT("print", 1),
+	PRINT("print", 1),
 
-    ;
+	;
 
-    private final String name;
-    private final int arity;
+	private final String name;
+	private final int arity;
 
-    BuiltInFunctionSymbol(String name, int arity) {
-        this.name = name;
-        this.arity = arity;
-    }
+	BuiltInFunctionSymbol(String name, int arity) {
+		this.name = name;
+		this.arity = arity;
+	}
 
-    @Override
-    public int getArity() {
-        return arity;
-    }
+	@Override
+	public int getArity() {
+		return arity;
+	}
 
-    @Override
-    public FunctorType getCompileTimeType() {
-        switch (this) {
-            case BEQ:
-            case BNEQ:
-                return new FunctorType(a, a, bool);
-            case BNOT:
-                return new FunctorType(bool, bool);
-            case FP32_NEG:
-                return new FunctorType(fp32, fp32);
-            case FP32_ADD:
-            case FP32_DIV:
-            case FP32_MUL:
-            case FP32_REM:
-            case FP32_SUB:
-                return new FunctorType(fp32, fp32, fp32);
-            case FP32_EQ:
-            case FP32_GE:
-            case FP32_GT:
-            case FP32_LE:
-            case FP32_LT:
-                return new FunctorType(fp32, fp32, bool);
-            case FP64_NEG:
-                return new FunctorType(fp64, fp64);
-            case FP64_ADD:
-            case FP64_DIV:
-            case FP64_MUL:
-            case FP64_REM:
-            case FP64_SUB:
-                return new FunctorType(fp64, fp64, fp64);
-            case FP64_EQ:
-            case FP64_GE:
-            case FP64_GT:
-            case FP64_LE:
-            case FP64_LT:
-                return new FunctorType(fp64, fp64, bool);
-            case GET_MODEL:
-                return new FunctorType(list(smt(bool)), option(i32), option(model));
-            case I32_NEG:
-                return new FunctorType(i32, i32);
-            case I32_ADD:
-            case I32_AND:
-            case I32_SDIV:
-            case I32_MUL:
-            case I32_OR:
-            case I32_SREM:
-            case I32_UDIV:
-            case I32_UREM:
-            case I32_SUB:
-            case I32_XOR:
-            case I32_SHL:
-            case I32_ASHR:
-            case I32_LSHR:
-                return new FunctorType(i32, i32, i32);
-            case I32_GE:
-            case I32_GT:
-            case I32_LE:
-            case I32_LT:
-                return new FunctorType(i32, i32, bool);
-            case I32_SCMP:
-            case I32_UCMP:
-                return new FunctorType(i32, i32, cmp);
-            case I64_NEG:
-                return new FunctorType(i64, i64);
-            case I64_ADD:
-            case I64_AND:
-            case I64_SDIV:
-            case I64_MUL:
-            case I64_OR:
-            case I64_SREM:
-            case I64_UDIV:
-            case I64_UREM:
-            case I64_SUB:
-            case I64_XOR:
-            case I64_SHL:
-            case I64_ASHR:
-            case I64_LSHR:
-                return new FunctorType(i64, i64, i64);
-            case I64_GE:
-            case I64_GT:
-            case I64_LE:
-            case I64_LT:
-                return new FunctorType(i64, i64, bool);
-            case I64_SCMP:
-            case I64_UCMP:
-                return new FunctorType(i64, i64, cmp);
-            case IS_SAT:
-            case IS_VALID:
-                return new FunctorType(smt(bool), bool);
-            case IS_SET_SAT:
-                return new FunctorType(opaqueSet(smt(bool)), option(i32), option(bool));
-            case IS_SAT_OPT:
-                return new FunctorType(list(smt(bool)), option(i32), option(bool));
-            case PRINT:
-                return new FunctorType(a, bool);
-            case QUERY_MODEL:
-                return new FunctorType(sym(a), model, option(a));
-            case STRING_CONCAT:
-                return new FunctorType(string, string, string);
-            case STRING_CMP:
-                return new FunctorType(string, string, cmp);
-            case STRING_MATCHES:
-                return new FunctorType(string, string, bool);
-            case TO_STRING:
-                return new FunctorType(a, string);
-            case STRING_STARTS_WITH:
-                return new FunctorType(string, string, bool);
-            case STRING_TO_LIST:
-                return new FunctorType(string, list(i32));
-            case LIST_TO_STRING:
-                return new FunctorType(list(i32), string);
-            case CHAR_AT:
-                return new FunctorType(string, i32, option(i32));
-            case SUBSTRING:
-                return new FunctorType(string, i32, i32, option(string));
-            case STRING_LENGTH:
-                return new FunctorType(string, i32);
-            case fp32ToFp64:
-                return new FunctorType(fp32, fp64);
-            case fp32ToI32:
-                return new FunctorType(fp32, i32);
-            case fp32ToI64:
-                return new FunctorType(fp32, i64);
-            case fp64ToFp32:
-                return new FunctorType(fp64, fp32);
-            case fp64ToI32:
-                return new FunctorType(fp64, i32);
-            case fp64ToI64:
-                return new FunctorType(fp64, i64);
-            case i32ToFp32:
-                return new FunctorType(i32, fp32);
-            case i32ToFp64:
-                return new FunctorType(i32, fp64);
-            case i32ToI64:
-                return new FunctorType(i32, i64);
-            case i64ToFp32:
-                return new FunctorType(i64, fp32);
-            case i64ToFp64:
-                return new FunctorType(i64, fp64);
-            case i64ToI32:
-                return new FunctorType(i64, i32);
-            case stringToI32:
-                return new FunctorType(string, option(i32));
-            case stringToI64:
-                return new FunctorType(string, option(i64));
-            case OPAQUE_SET_CHOOSE:
-                return new FunctorType(opaqueSet(a), option(pair(a, opaqueSet(a))));
-            case OPAQUE_SET_DIFF:
-                return new FunctorType(opaqueSet(a), opaqueSet(a), opaqueSet(a));
-            case OPAQUE_SET_EMPTY:
-                return new FunctorType(opaqueSet(a));
-            case OPAQUE_SET_PLUS:
-                return new FunctorType(a, opaqueSet(a), opaqueSet(a));
-            case OPAQUE_SET_MINUS:
-                return new FunctorType(a, opaqueSet(a), opaqueSet(a));
-            case OPAQUE_SET_UNION:
-                return new FunctorType(opaqueSet(a), opaqueSet(a), opaqueSet(a));
-            case OPAQUE_SET_SIZE:
-                return new FunctorType(opaqueSet(a), i32);
-            case OPAQUE_SET_MEMBER:
-                return new FunctorType(a, opaqueSet(a), bool);
-            case OPAQUE_SET_SINGLETON:
-                return new FunctorType(a, opaqueSet(a));
-            case OPAQUE_SET_SUBSET:
-                return new FunctorType(opaqueSet(a), opaqueSet(a), bool);
-            case OPAQUE_SET_FROM_LIST:
-                return new FunctorType(list(a), opaqueSet(a));
-        }
-        throw new AssertionError("impossible");
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
+	@Override
+	public FunctorType getCompileTimeType() {
+		switch (this) {
+		case BEQ:
+		case BNEQ:
+			return new FunctorType(a, a, bool);
+		case BNOT:
+			return new FunctorType(bool, bool);
+		case FP32_NEG:
+			return new FunctorType(fp32, fp32);
+		case FP32_ADD:
+		case FP32_DIV:
+		case FP32_MUL:
+		case FP32_REM:
+		case FP32_SUB:
+			return new FunctorType(fp32, fp32, fp32);
+		case FP32_EQ:
+		case FP32_GE:
+		case FP32_GT:
+		case FP32_LE:
+		case FP32_LT:
+			return new FunctorType(fp32, fp32, bool);
+		case FP64_NEG:
+			return new FunctorType(fp64, fp64);
+		case FP64_ADD:
+		case FP64_DIV:
+		case FP64_MUL:
+		case FP64_REM:
+		case FP64_SUB:
+			return new FunctorType(fp64, fp64, fp64);
+		case FP64_EQ:
+		case FP64_GE:
+		case FP64_GT:
+		case FP64_LE:
+		case FP64_LT:
+			return new FunctorType(fp64, fp64, bool);
+		case GET_MODEL:
+			return new FunctorType(list(smt(bool)), option(i32), option(model));
+		case I32_NEG:
+			return new FunctorType(i32, i32);
+		case I32_ADD:
+		case I32_AND:
+		case I32_SDIV:
+		case I32_MUL:
+		case I32_OR:
+		case I32_SREM:
+		case I32_UDIV:
+		case I32_UREM:
+		case I32_SUB:
+		case I32_XOR:
+		case I32_SHL:
+		case I32_ASHR:
+		case I32_LSHR:
+			return new FunctorType(i32, i32, i32);
+		case I32_GE:
+		case I32_GT:
+		case I32_LE:
+		case I32_LT:
+			return new FunctorType(i32, i32, bool);
+		case I32_SCMP:
+		case I32_UCMP:
+			return new FunctorType(i32, i32, cmp);
+		case I64_NEG:
+			return new FunctorType(i64, i64);
+		case I64_ADD:
+		case I64_AND:
+		case I64_SDIV:
+		case I64_MUL:
+		case I64_OR:
+		case I64_SREM:
+		case I64_UDIV:
+		case I64_UREM:
+		case I64_SUB:
+		case I64_XOR:
+		case I64_SHL:
+		case I64_ASHR:
+		case I64_LSHR:
+			return new FunctorType(i64, i64, i64);
+		case I64_GE:
+		case I64_GT:
+		case I64_LE:
+		case I64_LT:
+			return new FunctorType(i64, i64, bool);
+		case I64_SCMP:
+		case I64_UCMP:
+			return new FunctorType(i64, i64, cmp);
+		case IS_SAT:
+		case IS_VALID:
+			return new FunctorType(smt(bool), bool);
+		case IS_SET_SAT:
+			return new FunctorType(opaqueSet(smt(bool)), option(i32), option(bool));
+		case IS_SAT_OPT:
+			return new FunctorType(list(smt(bool)), option(i32), option(bool));
+		case PRINT:
+			return new FunctorType(a, bool);
+		case QUERY_MODEL:
+			return new FunctorType(sym(a), model, option(a));
+		case STRING_CONCAT:
+			return new FunctorType(string, string, string);
+		case STRING_CMP:
+			return new FunctorType(string, string, cmp);
+		case STRING_MATCHES:
+			return new FunctorType(string, string, bool);
+		case TO_STRING:
+			return new FunctorType(a, string);
+		case STRING_STARTS_WITH:
+			return new FunctorType(string, string, bool);
+		case STRING_TO_LIST:
+			return new FunctorType(string, list(i32));
+		case LIST_TO_STRING:
+			return new FunctorType(list(i32), string);
+		case CHAR_AT:
+			return new FunctorType(string, i32, option(i32));
+		case SUBSTRING:
+			return new FunctorType(string, i32, i32, option(string));
+		case STRING_LENGTH:
+			return new FunctorType(string, i32);
+		case fp32ToFp64:
+			return new FunctorType(fp32, fp64);
+		case fp32ToI32:
+			return new FunctorType(fp32, i32);
+		case fp32ToI64:
+			return new FunctorType(fp32, i64);
+		case fp64ToFp32:
+			return new FunctorType(fp64, fp32);
+		case fp64ToI32:
+			return new FunctorType(fp64, i32);
+		case fp64ToI64:
+			return new FunctorType(fp64, i64);
+		case i32ToFp32:
+			return new FunctorType(i32, fp32);
+		case i32ToFp64:
+			return new FunctorType(i32, fp64);
+		case i32ToI64:
+			return new FunctorType(i32, i64);
+		case i64ToFp32:
+			return new FunctorType(i64, fp32);
+		case i64ToFp64:
+			return new FunctorType(i64, fp64);
+		case i64ToI32:
+			return new FunctorType(i64, i32);
+		case stringToI32:
+			return new FunctorType(string, option(i32));
+		case stringToI64:
+			return new FunctorType(string, option(i64));
+		case OPAQUE_SET_CHOOSE:
+			return new FunctorType(opaqueSet(a), option(pair(a, opaqueSet(a))));
+		case OPAQUE_SET_DIFF:
+			return new FunctorType(opaqueSet(a), opaqueSet(a), opaqueSet(a));
+		case OPAQUE_SET_EMPTY:
+			return new FunctorType(opaqueSet(a));
+		case OPAQUE_SET_PLUS:
+			return new FunctorType(a, opaqueSet(a), opaqueSet(a));
+		case OPAQUE_SET_MINUS:
+			return new FunctorType(a, opaqueSet(a), opaqueSet(a));
+		case OPAQUE_SET_UNION:
+			return new FunctorType(opaqueSet(a), opaqueSet(a), opaqueSet(a));
+		case OPAQUE_SET_SIZE:
+			return new FunctorType(opaqueSet(a), i32);
+		case OPAQUE_SET_MEMBER:
+			return new FunctorType(a, opaqueSet(a), bool);
+		case OPAQUE_SET_SINGLETON:
+			return new FunctorType(a, opaqueSet(a));
+		case OPAQUE_SET_SUBSET:
+			return new FunctorType(opaqueSet(a), opaqueSet(a), bool);
+		case OPAQUE_SET_FROM_LIST:
+			return new FunctorType(list(a), opaqueSet(a));
+		}
+		throw new AssertionError("impossible");
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInTypeSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/BuiltInTypeSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public enum BuiltInTypeSymbol implements TypeSymbol {
 
 	BOOL_TYPE("bool", 0),
@@ -30,29 +29,29 @@ public enum BuiltInTypeSymbol implements TypeSymbol {
 	OPTION_TYPE("option", 1),
 
 	CMP_TYPE("cmp", 0),
-	
+
 	STRING_TYPE("string", 0),
-	
+
 	SMT_TYPE("smt", 1),
-	
+
 	SYM_TYPE("sym", 1),
-	
+
 	ARRAY_TYPE("array", 2),
-	
+
 	MODEL_TYPE("model", 0),
-	
+
 	INT_TYPE("int", 0),
-	
+
 	BV("bv", 1),
-	
+
 	FP("fp", 2),
-	
+
 	OPAQUE_SET("opaque_set", 1),
-	
+
 	SMT_PATTERN_TYPE("smt_pattern", 0),
-	
+
 	SMT_WRAPPED_VAR_TYPE("smt_wrapped_var", 0),
-	
+
 	;
 
 	private final String name;

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface ConstructorSymbol extends TypedSymbol {
 
 	ConstructorSymbolType getConstructorSymbolType();
@@ -37,5 +36,5 @@ public interface ConstructorSymbol extends TypedSymbol {
 		}
 		throw new AssertionError("impossible");
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbolImpl.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbolImpl.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 class ConstructorSymbolImpl extends AbstractTypedSymbol implements ConstructorSymbol {

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbolType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/ConstructorSymbolType.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public enum ConstructorSymbolType {
 
 	SOLVER_UNINTERPRETED_FUNCTION,

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/FunctionSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/FunctionSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface FunctionSymbol extends TypedSymbol {
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/GlobalSymbolManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/GlobalSymbolManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -78,8 +77,9 @@ public final class GlobalSymbolManager {
 		}
 		return sym;
 	}
-	
-	public static ParameterizedConstructorSymbol getParameterizedSymbol(BuiltInConstructorSymbolBase base, List<Param> params) {
+
+	public static ParameterizedConstructorSymbol getParameterizedSymbol(BuiltInConstructorSymbolBase base,
+			List<Param> params) {
 		return getParameterizedSymbol(base).copyWithNewArgs(params);
 	}
 
@@ -153,7 +153,7 @@ public final class GlobalSymbolManager {
 		initialize();
 		return Collections.unmodifiableSet(typeSymbols);
 	}
-	
+
 	private static final Map<Integer, TupleSymbol> tupleSymbolMemo = new ConcurrentHashMap<>();
 	private static final Map<Integer, TypeSymbol> tupleTypeSymbolMemo = new ConcurrentHashMap<>();
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/MutableRelationSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/MutableRelationSymbol.java
@@ -20,15 +20,14 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface MutableRelationSymbol extends RelationSymbol {
 
-    void setTopDown();
+	void setTopDown();
 
-    void setBottomUp();
+	void setBottomUp();
 
-    void setDisk();
+	void setDisk();
 
-    void setEdb();
+	void setEdb();
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/PredicateFunctionSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/PredicateFunctionSymbol.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.symbols;
 
 import java.util.ArrayList;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/RecordSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/RecordSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import java.util.List;
 
 public interface RecordSymbol extends ConstructorSymbol {

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/RelationSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/RelationSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface RelationSymbol extends TypedSymbol {
 
 	boolean isIdbSymbol();
@@ -28,11 +27,11 @@ public interface RelationSymbol extends TypedSymbol {
 	default boolean isEdbSymbol() {
 		return !isIdbSymbol();
 	}
-	
+
 	boolean isDisk();
 
 	boolean isBottomUp();
 
 	boolean isTopDown();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/Symbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/Symbol.java
@@ -20,9 +20,8 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface Symbol {
-	
+
 	int getArity();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/SymbolComparator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/SymbolComparator.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import java.util.Comparator;
 
 public enum SymbolComparator implements Comparator<Symbol> {
 
 	INSTANCE;
-	
+
 	@Override
 	public int compare(Symbol o1, Symbol o2) {
 		return o1.toString().compareTo(o2.toString());

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/SymbolManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/SymbolManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -41,222 +40,224 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 public class SymbolManager {
 
-    private final Map<String, Symbol> memo = new ConcurrentHashMap<>();
-    private final Set<TypeSymbol> typeSymbols = Util.concurrentSet();
+	private final Map<String, Symbol> memo = new ConcurrentHashMap<>();
+	private final Set<TypeSymbol> typeSymbols = Util.concurrentSet();
 
-    public TypeSymbol createTypeSymbol(String name, int arity, TypeSymbolType st) {
-        checkNotUsed(name);
-        TypeSymbol sym = new TypeSymbolImpl(name, arity, st);
-        registerSymbol(sym);
-        return sym;
-    }
+	public TypeSymbol createTypeSymbol(String name, int arity, TypeSymbolType st) {
+		checkNotUsed(name);
+		TypeSymbol sym = new TypeSymbolImpl(name, arity, st);
+		registerSymbol(sym);
+		return sym;
+	}
 
-    public ConstructorSymbol createConstructorSymbol(String name, int arity, ConstructorSymbolType st,
-                                                     FunctorType type) {
-        checkNotUsed(name);
-        ConstructorSymbol sym = new ConstructorSymbolImpl(name, arity, st, type);
-        registerSymbol(sym);
-        return sym;
-    }
+	public ConstructorSymbol createConstructorSymbol(String name, int arity, ConstructorSymbolType st,
+			FunctorType type) {
+		checkNotUsed(name);
+		ConstructorSymbol sym = new ConstructorSymbolImpl(name, arity, st, type);
+		registerSymbol(sym);
+		return sym;
+	}
 
-    public RecordSymbol createRecordSymbol(String name, int arity, FunctorType type, List<FunctionSymbol> labels) {
-        checkNotUsed(name);
-        RecordSymbol sym = new RecordSymbolImpl(name, arity, type, labels);
-        registerSymbol(sym);
-        return sym;
-    }
+	public RecordSymbol createRecordSymbol(String name, int arity, FunctorType type, List<FunctionSymbol> labels) {
+		checkNotUsed(name);
+		RecordSymbol sym = new RecordSymbolImpl(name, arity, type, labels);
+		registerSymbol(sym);
+		return sym;
+	}
 
-    public FunctionSymbol createFunctionSymbol(String name, int arity, FunctorType type) {
-        checkNotUsed(name);
-        FunctionSymbol sym = new FunctionSymbolImpl(name, arity, type);
-        registerSymbol(sym);
-        return sym;
-    }
+	public FunctionSymbol createFunctionSymbol(String name, int arity, FunctorType type) {
+		checkNotUsed(name);
+		FunctionSymbol sym = new FunctionSymbolImpl(name, arity, type);
+		registerSymbol(sym);
+		return sym;
+	}
 
-    public MutableRelationSymbol createRelationSymbol(String name, int arity, FunctorType type) {
-        checkNotUsed(name);
-        MutableRelationSymbol sym = new RelationSymbolImpl(name, arity, type);
-        registerSymbol(sym);
-        return sym;
-    }
+	public MutableRelationSymbol createRelationSymbol(String name, int arity, FunctorType type) {
+		checkNotUsed(name);
+		MutableRelationSymbol sym = new RelationSymbolImpl(name, arity, type);
+		registerSymbol(sym);
+		return sym;
+	}
 
-    public void checkNotUsed(String name) {
-        if (hasName(name)) {
-            throw new IllegalArgumentException(
-                    "Cannot create symbol " + name + "; a symbol already exists with that name.");
-        }
-    }
+	public void checkNotUsed(String name) {
+		if (hasName(name)) {
+			throw new IllegalArgumentException(
+					"Cannot create symbol " + name + "; a symbol already exists with that name.");
+		}
+	}
 
-    public boolean hasName(String name) {
-        return memo.containsKey(name) || GlobalSymbolManager.hasName(name);
-    }
+	public boolean hasName(String name) {
+		return memo.containsKey(name) || GlobalSymbolManager.hasName(name);
+	}
 
-    public boolean hasConstructorSymbolWithName(String name) {
-        if (!hasName(name)) {
-            return false;
-        }
-        return lookupSymbol(name) instanceof ConstructorSymbol;
-    }
+	public boolean hasConstructorSymbolWithName(String name) {
+		if (!hasName(name)) {
+			return false;
+		}
+		return lookupSymbol(name) instanceof ConstructorSymbol;
+	}
 
-    public Symbol lookupSymbol(String name) {
-        return lookupSymbol(name, Collections.emptyList());
-    }
+	public Symbol lookupSymbol(String name) {
+		return lookupSymbol(name, Collections.emptyList());
+	}
 
-    public ParameterizedSymbol getParameterizedSymbol(SymbolBase base) {
-        if (base instanceof BuiltInConstructorSymbolBase) {
-            return GlobalSymbolManager.getParameterizedSymbol((BuiltInConstructorSymbolBase) base);
-        }
-        throw new TodoException();
-    }
+	public ParameterizedSymbol getParameterizedSymbol(SymbolBase base) {
+		if (base instanceof BuiltInConstructorSymbolBase) {
+			return GlobalSymbolManager.getParameterizedSymbol((BuiltInConstructorSymbolBase) base);
+		}
+		throw new TodoException();
+	}
 
-    public Symbol lookupSymbol(String name, List<Param> params) {
-        if (GlobalSymbolManager.hasName(name)) {
-            return GlobalSymbolManager.lookup(name, params);
-        }
-        if (!hasName(name)) {
-            throw new IllegalArgumentException("No symbol exists with name " + name + ".");
-        }
-        Symbol sym = memo.get(name);
-        assert sym != null;
-        if (sym instanceof ParameterizedSymbol) {
-            return ((ParameterizedSymbol) sym).copyWithNewArgs(params);
-        } else if (!params.isEmpty()) {
-            throw new IllegalArgumentException("Cannot supply parameters to non-parameterized symbol: " + sym);
-        }
-        return sym;
-    }
+	public Symbol lookupSymbol(String name, List<Param> params) {
+		if (GlobalSymbolManager.hasName(name)) {
+			return GlobalSymbolManager.lookup(name, params);
+		}
+		if (!hasName(name)) {
+			throw new IllegalArgumentException("No symbol exists with name " + name + ".");
+		}
+		Symbol sym = memo.get(name);
+		assert sym != null;
+		if (sym instanceof ParameterizedSymbol) {
+			return ((ParameterizedSymbol) sym).copyWithNewArgs(params);
+		} else if (!params.isEmpty()) {
+			throw new IllegalArgumentException("Cannot supply parameters to non-parameterized symbol: " + sym);
+		}
+		return sym;
+	}
 
-    public PredicateFunctionSymbol createPredicateFunctionSymbol(RelationSymbol sym, BindingType[] bindings) {
-        return PredicateFunctionSymbol.create(sym, bindings, this);
-    }
+	public PredicateFunctionSymbol createPredicateFunctionSymbol(RelationSymbol sym, BindingType[] bindings) {
+		return PredicateFunctionSymbol.create(sym, bindings, this);
+	}
 
-    public PredicateFunctionSymbol createPredicateFunctionSymbolPlaceholder(RelationSymbol sym) {
-        return PredicateFunctionSymbol.createPlaceholder(sym, this);
-    }
+	public PredicateFunctionSymbol createPredicateFunctionSymbolPlaceholder(RelationSymbol sym) {
+		return PredicateFunctionSymbol.createPlaceholder(sym, this);
+	}
 
-    public ConstructorSymbol lookupIndexConstructorSymbol(int index) {
-        String name = "index$" + index;
-        ConstructorSymbol sym = (ConstructorSymbol) memo.get(name);
-        if (sym == null) {
-            sym = createConstructorSymbol(name, 1, ConstructorSymbolType.INDEX_CONSTRUCTOR,
-                    new FunctorType(BuiltInTypes.i32, TypeIndex.make(index)));
-            registerSymbol(sym);
-        }
-        return sym;
-    }
+	public ConstructorSymbol lookupIndexConstructorSymbol(int index) {
+		String name = "index$" + index;
+		ConstructorSymbol sym = (ConstructorSymbol) memo.get(name);
+		if (sym == null) {
+			sym = createConstructorSymbol(name, 1, ConstructorSymbolType.INDEX_CONSTRUCTOR,
+					new FunctorType(BuiltInTypes.i32, TypeIndex.make(index)));
+			registerSymbol(sym);
+		}
+		return sym;
+	}
 
-    private static class FunctionSymbolImpl extends AbstractTypedSymbol implements FunctionSymbol {
+	private static class FunctionSymbolImpl extends AbstractTypedSymbol implements FunctionSymbol {
 
-        public FunctionSymbolImpl(String name, int arity, FunctorType type) {
-            super(name, arity, type);
-        }
+		public FunctionSymbolImpl(String name, int arity, FunctorType type) {
+			super(name, arity, type);
+		}
 
-    }
+	}
 
-    private static class RecordSymbolImpl extends AbstractTypedSymbol implements RecordSymbol {
+	private static class RecordSymbolImpl extends AbstractTypedSymbol implements RecordSymbol {
 
-        private final List<FunctionSymbol> labels;
+		private final List<FunctionSymbol> labels;
 
-        public RecordSymbolImpl(String name, int arity, FunctorType type, List<FunctionSymbol> labels) {
-            super(name, arity, type);
-            this.labels = labels;
-        }
+		public RecordSymbolImpl(String name, int arity, FunctorType type, List<FunctionSymbol> labels) {
+			super(name, arity, type);
+			this.labels = labels;
+		}
 
-        @Override
-        public ConstructorSymbolType getConstructorSymbolType() {
-            return ConstructorSymbolType.VANILLA_CONSTRUCTOR;
-        }
+		@Override
+		public ConstructorSymbolType getConstructorSymbolType() {
+			return ConstructorSymbolType.VANILLA_CONSTRUCTOR;
+		}
 
-        @Override
-        public List<FunctionSymbol> getLabels() {
-            return labels;
-        }
+		@Override
+		public List<FunctionSymbol> getLabels() {
+			return labels;
+		}
 
-    }
+	}
 
-    private static class RelationSymbolImpl extends AbstractTypedSymbol implements MutableRelationSymbol {
+	private static class RelationSymbolImpl extends AbstractTypedSymbol implements MutableRelationSymbol {
 
-        private enum Mode {vanillaIdb, topDownIdb, bottomUpIdb, edb}
+		private enum Mode {
+			vanillaIdb, topDownIdb, bottomUpIdb, edb
+		}
 
-        private boolean disk;
+		private boolean disk;
 
-        private Mode mode = Mode.vanillaIdb;
+		private Mode mode = Mode.vanillaIdb;
 
-        public RelationSymbolImpl(String name, int arity, FunctorType type) {
-            super(name, arity, type);
-        }
+		public RelationSymbolImpl(String name, int arity, FunctorType type) {
+			super(name, arity, type);
+		}
 
-        @Override
-        public boolean isIdbSymbol() {
-            return !isEdbSymbol();
-        }
+		@Override
+		public boolean isIdbSymbol() {
+			return !isEdbSymbol();
+		}
 
-        @Override
-        public boolean isEdbSymbol() {
-            return mode == Mode.edb;
-        }
+		@Override
+		public boolean isEdbSymbol() {
+			return mode == Mode.edb;
+		}
 
-        @Override
-        public boolean isDisk() {
-            return disk;
-        }
+		@Override
+		public boolean isDisk() {
+			return disk;
+		}
 
-        @Override
-        public synchronized boolean isBottomUp() {
-            return mode == Mode.bottomUpIdb;
-        }
+		@Override
+		public synchronized boolean isBottomUp() {
+			return mode == Mode.bottomUpIdb;
+		}
 
-        @Override
-        public synchronized boolean isTopDown() {
-            return mode == Mode.topDownIdb;
-        }
+		@Override
+		public synchronized boolean isTopDown() {
+			return mode == Mode.topDownIdb;
+		}
 
-        @Override
-        public synchronized void setTopDown() {
-            if (mode == Mode.bottomUpIdb) {
-                throw new IllegalStateException("Relation cannot be both top-down and bottom-up");
-            }
-            mode = Mode.topDownIdb;
-        }
+		@Override
+		public synchronized void setTopDown() {
+			if (mode == Mode.bottomUpIdb) {
+				throw new IllegalStateException("Relation cannot be both top-down and bottom-up");
+			}
+			mode = Mode.topDownIdb;
+		}
 
-        @Override
-        public synchronized void setBottomUp() {
-            if (mode == Mode.topDownIdb) {
-                throw new IllegalStateException("Relation cannot be both top-down and bottom-up");
-            }
-            mode = Mode.bottomUpIdb;
-        }
+		@Override
+		public synchronized void setBottomUp() {
+			if (mode == Mode.topDownIdb) {
+				throw new IllegalStateException("Relation cannot be both top-down and bottom-up");
+			}
+			mode = Mode.bottomUpIdb;
+		}
 
-        @Override
-        public synchronized void setDisk() {
-            disk = true;
-        }
+		@Override
+		public synchronized void setDisk() {
+			disk = true;
+		}
 
-        @Override
-        public void setEdb() {
-            if (mode != Mode.edb && mode != Mode.vanillaIdb) {
-                throw new IllegalStateException("Relation cannot be an EDB relation with other qualifier: " + mode);
-            }
-            mode = Mode.edb;
-        }
+		@Override
+		public void setEdb() {
+			if (mode != Mode.edb && mode != Mode.vanillaIdb) {
+				throw new IllegalStateException("Relation cannot be an EDB relation with other qualifier: " + mode);
+			}
+			mode = Mode.edb;
+		}
 
-    }
+	}
 
-    public void registerSymbol(Symbol sym) {
-        if (sym instanceof TypeSymbol) {
-            typeSymbols.add((TypeSymbol) sym);
-        }
-        Symbol sym2 = memo.putIfAbsent(sym.toString(), sym);
-        if (sym2 != null && !sym2.equals(sym)) {
-            throw new IllegalArgumentException(
-                    "Cannot register symbol " + sym + "; a different symbol is already registered with that name.");
-        }
-    }
+	public void registerSymbol(Symbol sym) {
+		if (sym instanceof TypeSymbol) {
+			typeSymbols.add((TypeSymbol) sym);
+		}
+		Symbol sym2 = memo.putIfAbsent(sym.toString(), sym);
+		if (sym2 != null && !sym2.equals(sym)) {
+			throw new IllegalArgumentException(
+					"Cannot register symbol " + sym + "; a different symbol is already registered with that name.");
+		}
+	}
 
-    public Set<TypeSymbol> getTypeSymbols() {
-        Set<TypeSymbol> syms = new HashSet<>(typeSymbols);
-        syms.addAll(GlobalSymbolManager.getTypeSymbols());
-        return Collections.unmodifiableSet(syms);
-    }
+	public Set<TypeSymbol> getTypeSymbols() {
+		Set<TypeSymbol> syms = new HashSet<>(typeSymbols);
+		syms.addAll(GlobalSymbolManager.getTypeSymbols());
+		return Collections.unmodifiableSet(syms);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface TypeSymbol extends Symbol {
 
 	TypeSymbolType getTypeSymbolType();
@@ -28,11 +27,11 @@ public interface TypeSymbol extends Symbol {
 	default boolean isNormalType() {
 		return getTypeSymbolType().equals(TypeSymbolType.NORMAL_TYPE);
 	}
-	
+
 	default boolean isAlias() {
 		return getTypeSymbolType().equals(TypeSymbolType.TYPE_ALIAS);
 	}
-	
+
 	default boolean isUninterpretedSort() {
 		return getTypeSymbolType().equals(TypeSymbolType.UNINTERPRETED_SORT);
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbolImpl.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbolImpl.java
@@ -20,11 +20,10 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 class TypeSymbolImpl extends AbstractSymbol implements TypeSymbol {
 
 	private final TypeSymbolType symType;
-	
+
 	public TypeSymbolImpl(String name, int arity, TypeSymbolType symType) {
 		super(name, arity);
 		this.symType = symType;

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbolType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypeSymbolType.java
@@ -20,15 +20,14 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public enum TypeSymbolType {
 
 	NORMAL_TYPE,
-	
+
 	TYPE_ALIAS,
-	
+
 	UNINTERPRETED_SORT,
-	
+
 	;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypedSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/TypedSymbol.java
@@ -20,11 +20,10 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.types.FunctorType;
 
 public interface TypedSymbol extends Symbol {
-	
+
 	FunctorType getCompileTimeType();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/WrappedRelationSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/WrappedRelationSymbol.java
@@ -20,9 +20,8 @@ package edu.harvard.seas.pl.formulog.symbols;
  * #L%
  */
 
-
 public interface WrappedRelationSymbol<R extends RelationSymbol> extends RelationSymbol {
 
 	R getBaseSymbol();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/AbstractParameterizedSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/AbstractParameterizedSymbol.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +43,7 @@ public abstract class AbstractParameterizedSymbol<B extends SymbolBase> implemen
 			this.args.add(param);
 		}
 	}
-	
+
 	@Override
 	public int getArity() {
 		return base.getArity();
@@ -72,7 +71,7 @@ public abstract class AbstractParameterizedSymbol<B extends SymbolBase> implemen
 	public List<Param> getArgs() {
 		return args;
 	}
-	
+
 	@Override
 	public boolean isGround() {
 		for (Param arg : args) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/BuiltInConstructorSymbolBase.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/BuiltInConstructorSymbolBase.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,7 +36,7 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	BV_SGT("bv_sgt", 2, ParamKind.NAT),
 
 	BV_SGE("bv_sge", 2, ParamKind.NAT),
-	
+
 	BV_ULT("bv_ult", 2, ParamKind.NAT),
 
 	BV_ULE("bv_ule", 2, ParamKind.NAT),
@@ -45,13 +44,13 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	BV_UGT("bv_ugt", 2, ParamKind.NAT),
 
 	BV_UGE("bv_uge", 2, ParamKind.NAT),
-	
+
 	BV_CONST("bv_const", 1, ParamKind.NAT),
 
 	BV_BIG_CONST("bv_big_const", 1, ParamKind.NAT),
-	
+
 	BV_EXTRACT("bv_extract", 3, ParamKind.NAT, ParamKind.NAT),
-	
+
 	BV_CONCAT("bv_concat", 2, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT),
 
 	BV_TO_BV_SIGNED("bv_to_bv_signed", 1, ParamKind.NAT, ParamKind.NAT),
@@ -59,17 +58,17 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	BV_TO_BV_UNSIGNED("bv_to_bv_unsigned", 1, ParamKind.NAT, ParamKind.NAT),
 
 	FP_TO_SBV("fp_to_sbv", 1, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT),
-	
+
 	FP_TO_UBV("fp_to_ubv", 1, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT),
-	
+
 	INT_TO_BV("int_to_bv", 1, ParamKind.NAT),
-	
+
 	BV_TO_INT("bv_to_int", 1, ParamKind.NAT),
-	
+
 	// Floating point
-	
+
 	FP_EQ("fp_eq", 2, ParamKind.NAT, ParamKind.NAT),
-	
+
 	FP_LT("fp_lt", 2, ParamKind.NAT, ParamKind.NAT),
 
 	FP_LE("fp_le", 2, ParamKind.NAT, ParamKind.NAT),
@@ -79,37 +78,37 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	FP_GE("fp_ge", 2, ParamKind.NAT, ParamKind.NAT),
 
 	FP_IS_NAN("fp_is_nan", 1, ParamKind.NAT, ParamKind.NAT),
-	
+
 	FP_CONST("fp_const", 1, ParamKind.NAT, ParamKind.NAT),
 
 	FP_BIG_CONST("fp_big_const", 1, ParamKind.NAT, ParamKind.NAT),
 
 	FP_TO_FP("fp_to_fp", 1, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT),
-	
+
 	BV_TO_FP("bv_to_fp", 1, ParamKind.NAT, ParamKind.NAT, ParamKind.NAT),
-	
+
 	// Logical connectives
 
 	SMT_PAT("smt_pat", 1, ParamKind.SMT_REPRESENTABLE_TYPE),
-	
+
 	SMT_WRAP_VAR("smt_wrap_var", 1, ParamKind.SMT_REPRESENTABLE_TYPE),
-	
+
 	SMT_EQ("smt_eq", 2, ParamKind.PRE_SMT_TYPE),
-	
+
 	SMT_LET("smt_let", 3, ParamKind.PRE_SMT_TYPE),
 
 	// Arrays
-	
+
 	ARRAY_SELECT("array_select", 2, ParamKind.PRE_SMT_TYPE),
-	
+
 	ARRAY_DEFAULT("array_default", 1, ParamKind.PRE_SMT_TYPE),
-	
+
 	// Solver variables
-	
+
 	SMT_VAR("smt_var", 1, ParamKind.ANY_TYPE, ParamKind.PRE_SMT_TYPE),
-	
+
 	;
-	
+
 	private final String name;
 	private final int arity;
 	private final List<ParamKind> paramTypes;
@@ -124,7 +123,7 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	public int getArity() {
 		return arity;
 	}
-	
+
 	@Override
 	public String toString() {
 		return name;
@@ -134,9 +133,9 @@ public enum BuiltInConstructorSymbolBase implements FunctorBase {
 	public List<ParamKind> getParamKinds() {
 		return paramTypes;
 	}
-	
+
 	public ConstructorSymbolType getConstructorSymbolType() {
 		return ConstructorSymbolType.SOLVER_EXPR;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/FunctorBase.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/FunctorBase.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 public interface FunctorBase extends SymbolBase {
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/Param.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/Param.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,7 @@ public class Param {
 			throw new IllegalArgumentException("Cannot instantiate parameter of kind " + kind + " with type " + type);
 		}
 	}
-	
+
 	private boolean check() {
 		if (type.isVar()) {
 			return true;
@@ -77,19 +76,19 @@ public class Param {
 		}
 		throw new AssertionError("impossible");
 	}
-	
+
 	public Type getType() {
 		return type;
 	}
-	
+
 	public ParamKind getKind() {
 		return kind;
 	}
-	
+
 	boolean isGround() {
 		return !Types.containsTypeVarOrOpaqueType(getType());
 	}
-	
+
 	public static List<Param> wildCards(int howMany) {
 		List<Param> params = new ArrayList<>();
 		for (int i = 0; i < howMany; ++i) {
@@ -97,7 +96,7 @@ public class Param {
 		}
 		return params;
 	}
-	
+
 	public static List<Param> applySubst(Iterable<Param> params, Map<TypeVar, Type> subst) {
 		List<Param> newParams = new ArrayList<>();
 		for (Param param : params) {
@@ -109,15 +108,15 @@ public class Param {
 	public static Param nat(int index) {
 		return new Param(TypeIndex.make(index), ParamKind.NAT);
 	}
-	
+
 	public static Param nat(Type type) {
 		return new Param(type, ParamKind.NAT);
 	}
-	
+
 	public static Param wildCard() {
 		return new Param(TypeVar.fresh(), ParamKind.WILD_CARD);
 	}
-	
+
 	public static Param wildCard(Type type) {
 		return new Param(type, ParamKind.WILD_CARD);
 	}
@@ -154,5 +153,5 @@ public class Param {
 	public String toString() {
 		return type + ":" + kind;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParamKind.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParamKind.java
@@ -20,21 +20,20 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 public enum ParamKind {
 
 	NAT,
-	
+
 	ANY_TYPE,
-	
+
 	SMT_REPRESENTABLE_TYPE,
-	
+
 	SMT_VAR,
-	
+
 	SMT_VARS,
-	
+
 	PRE_SMT_TYPE,
-	
+
 	WILD_CARD;
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParameterizedConstructorSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParameterizedConstructorSymbol.java
@@ -51,251 +51,251 @@ import edu.harvard.seas.pl.formulog.util.Pair;
 import edu.harvard.seas.pl.formulog.util.Util;
 
 public class ParameterizedConstructorSymbol extends AbstractParameterizedSymbol<BuiltInConstructorSymbolBase>
-        implements ConstructorSymbol {
+		implements ConstructorSymbol {
 
-    private final FunctorType type;
-    private static final Map<Pair<BuiltInConstructorSymbolBase, List<Param>>, ParameterizedConstructorSymbol> memo = new ConcurrentHashMap<>();
+	private final FunctorType type;
+	private static final Map<Pair<BuiltInConstructorSymbolBase, List<Param>>, ParameterizedConstructorSymbol> memo = new ConcurrentHashMap<>();
 
-    private ParameterizedConstructorSymbol(BuiltInConstructorSymbolBase base, List<Param> args) {
-        super(base, args);
-        this.type = makeType();
-    }
+	private ParameterizedConstructorSymbol(BuiltInConstructorSymbolBase base, List<Param> args) {
+		super(base, args);
+		this.type = makeType();
+	}
 
-    public static ParameterizedConstructorSymbol mk(BuiltInConstructorSymbolBase base, List<Param> args) {
-        switch (base) {
-            case ARRAY_DEFAULT:
-            case ARRAY_SELECT:
-            case BV_BIG_CONST:
-            case BV_CONST:
-            case BV_SGE:
-            case BV_SGT:
-            case BV_SLE:
-            case BV_SLT:
-            case BV_TO_BV_SIGNED:
-            case BV_TO_BV_UNSIGNED:
-            case BV_UGE:
-            case BV_UGT:
-            case BV_ULE:
-            case BV_ULT:
-            case BV_CONCAT:
-            case BV_EXTRACT:
-            case SMT_EQ:
-            case SMT_LET:
-            case SMT_PAT:
-            case SMT_WRAP_VAR:
-            case SMT_VAR:
-            case BV_TO_INT:
-            case INT_TO_BV:
-                break;
-            case FP_BIG_CONST:
-            case FP_CONST:
-            case FP_EQ:
-            case FP_GE:
-            case FP_GT:
-            case FP_IS_NAN:
-            case FP_LE:
-            case FP_LT:
-                if (args.size() == 1) {
-                    args = new ArrayList<>(expandAsFpAlias(args.get(0)));
-                }
-                break;
-            case FP_TO_SBV:
-            case FP_TO_UBV:
-                if (args.size() == 2) {
-                    Param bv = args.get(1);
-                    args = new ArrayList<>(expandAsFpAlias(args.get(0)));
-                    args.add(bv);
-                }
-                break;
-            case FP_TO_FP:
-                if (args.size() == 2) {
-                    Param fp1 = args.get(0);
-                    Param fp2 = args.get(1);
-                    args = new ArrayList<>(expandAsFpAlias(fp1));
-                    args.addAll(expandAsFpAlias(fp2));
-                }
-                break;
-            case BV_TO_FP:
-                if (args.size() == 2) {
-                    List<Param> newArgs = new ArrayList<>();
-                    newArgs.add(args.get(0));
-                    newArgs.addAll(expandAsFpAlias(args.get(1)));
-                    args = newArgs;
-                }
-                break;
-            default:
-                throw new AssertionError("Unexpected symbol: " + base);
-        }
-        if (args.isEmpty()) {
-            args = Param.wildCards(base.getNumParams());
-        }
-        List<Param> args2 = List.copyOf(args);
-        return new ParameterizedConstructorSymbol(base, args2);
-    }
+	public static ParameterizedConstructorSymbol mk(BuiltInConstructorSymbolBase base, List<Param> args) {
+		switch (base) {
+		case ARRAY_DEFAULT:
+		case ARRAY_SELECT:
+		case BV_BIG_CONST:
+		case BV_CONST:
+		case BV_SGE:
+		case BV_SGT:
+		case BV_SLE:
+		case BV_SLT:
+		case BV_TO_BV_SIGNED:
+		case BV_TO_BV_UNSIGNED:
+		case BV_UGE:
+		case BV_UGT:
+		case BV_ULE:
+		case BV_ULT:
+		case BV_CONCAT:
+		case BV_EXTRACT:
+		case SMT_EQ:
+		case SMT_LET:
+		case SMT_PAT:
+		case SMT_WRAP_VAR:
+		case SMT_VAR:
+		case BV_TO_INT:
+		case INT_TO_BV:
+			break;
+		case FP_BIG_CONST:
+		case FP_CONST:
+		case FP_EQ:
+		case FP_GE:
+		case FP_GT:
+		case FP_IS_NAN:
+		case FP_LE:
+		case FP_LT:
+			if (args.size() == 1) {
+				args = new ArrayList<>(expandAsFpAlias(args.get(0)));
+			}
+			break;
+		case FP_TO_SBV:
+		case FP_TO_UBV:
+			if (args.size() == 2) {
+				Param bv = args.get(1);
+				args = new ArrayList<>(expandAsFpAlias(args.get(0)));
+				args.add(bv);
+			}
+			break;
+		case FP_TO_FP:
+			if (args.size() == 2) {
+				Param fp1 = args.get(0);
+				Param fp2 = args.get(1);
+				args = new ArrayList<>(expandAsFpAlias(fp1));
+				args.addAll(expandAsFpAlias(fp2));
+			}
+			break;
+		case BV_TO_FP:
+			if (args.size() == 2) {
+				List<Param> newArgs = new ArrayList<>();
+				newArgs.add(args.get(0));
+				newArgs.addAll(expandAsFpAlias(args.get(1)));
+				args = newArgs;
+			}
+			break;
+		default:
+			throw new AssertionError("Unexpected symbol: " + base);
+		}
+		if (args.isEmpty()) {
+			args = Param.wildCards(base.getNumParams());
+		}
+		List<Param> args2 = List.copyOf(args);
+		return new ParameterizedConstructorSymbol(base, args2);
+	}
 
-    private static List<Param> expandAsFpAlias(Param param) {
-        if (!param.getKind().equals(ParamKind.NAT) || !param.isGround()) {
-            return Collections.singletonList(param);
-        }
-        TypeIndex nat = (TypeIndex) param.getType();
-        List<TypeIndex> indices = nat.expandAsFpIndex();
-        List<Param> params = new ArrayList<>();
-        for (TypeIndex index : indices) {
-            params.add(Param.nat(index.getIndex()));
-        }
-        return params;
-    }
+	private static List<Param> expandAsFpAlias(Param param) {
+		if (!param.getKind().equals(ParamKind.NAT) || !param.isGround()) {
+			return Collections.singletonList(param);
+		}
+		TypeIndex nat = (TypeIndex) param.getType();
+		List<TypeIndex> indices = nat.expandAsFpIndex();
+		List<Param> params = new ArrayList<>();
+		for (TypeIndex index : indices) {
+			params.add(Param.nat(index.getIndex()));
+		}
+		return params;
+	}
 
-    @Override
-    public ParameterizedConstructorSymbol copyWithNewArgs(List<Param> args) {
-        return mk(getBase(), args);
-    }
+	@Override
+	public ParameterizedConstructorSymbol copyWithNewArgs(List<Param> args) {
+		return mk(getBase(), args);
+	}
 
-    @Override
-    public ParameterizedConstructorSymbol copyWithNewArgs(Param... args) {
-        return copyWithNewArgs(Arrays.asList(args));
-    }
+	@Override
+	public ParameterizedConstructorSymbol copyWithNewArgs(Param... args) {
+		return copyWithNewArgs(Arrays.asList(args));
+	}
 
-    public ConstructorSymbolType getConstructorSymbolType() {
-        return ConstructorSymbolType.SOLVER_EXPR;
-    }
+	public ConstructorSymbolType getConstructorSymbolType() {
+		return ConstructorSymbolType.SOLVER_EXPR;
+	}
 
-    private FunctorType makeType() {
-        List<Type> types = new ArrayList<>();
-        for (Param param : getArgs()) {
-            types.add(param.getType());
-        }
-        switch (getBase()) {
-            case ARRAY_DEFAULT: {
-                Type a = types.get(0);
-                Type b = TypeVar.fresh();
-                return mkType(smt(array(a, b)), smt(b));
-            }
-            case ARRAY_SELECT: {
-                Type a = types.get(0);
-                Type b = TypeVar.fresh();
-                return mkType(smt(array(a, b)), smt(a), smt(b));
-            }
-            case BV_BIG_CONST: {
-                Type width = types.get(0);
-                return mkType(i64, smt(bv(width)));
-            }
-            case BV_CONST: {
-                Type width = types.get(0);
-                return mkType(i32, smt(bv(width)));
-            }
-            case BV_CONCAT: {
-                Type w1 = types.get(0);
-                Type w2 = types.get(1);
-                Type w3 = types.get(2);
-                return mkType(smt(bv(w1)), smt(bv(w2)), smt(bv(w3)));
-            }
-            case BV_EXTRACT: {
-                Type w1 = types.get(0);
-                Type w2 = types.get(1);
-                return mkType(smt(bv(w1)), i32, i32, smt(bv(w2)));
-            }
-            case INT_TO_BV:
-                return mkType(smt(int_), smt(bv(types.get(0))));
-            case BV_TO_INT:
-                return mkType(smt(bv(types.get(0))), smt(int_));
-            case BV_SGE:
-            case BV_SGT:
-            case BV_SLE:
-            case BV_SLT:
-            case BV_UGE:
-            case BV_UGT:
-            case BV_ULE:
-            case BV_ULT: {
-                Type width = types.get(0);
-                return mkType(smt(bv(width)), smt(bv(width)), smt(bool));
-            }
-            case BV_TO_BV_SIGNED:
-            case BV_TO_BV_UNSIGNED: {
-                Type fromWidth = types.get(0);
-                Type toWidth = types.get(1);
-                return mkType(smt(bv(fromWidth)), smt(bv(toWidth)));
-            }
-            case BV_TO_FP: {
-                Type width = types.get(0);
-                Type exponent = types.get(1);
-                Type significand = types.get(2);
-                return mkType(smt(bv(width)), smt(fp(exponent, significand)));
-            }
-            case FP_BIG_CONST: {
-                Type exponent = types.get(0);
-                Type significand = types.get(1);
-                return mkType(fp64, smt(fp(exponent, significand)));
-            }
-            case FP_CONST: {
-                Type exponent = types.get(0);
-                Type significand = types.get(1);
-                return mkType(fp32, smt(fp(exponent, significand)));
-            }
-            case FP_EQ:
-            case FP_GE:
-            case FP_GT:
-            case FP_LE:
-            case FP_LT: {
-                Type exponent = types.get(0);
-                Type significand = types.get(1);
-                Type fp = fp(exponent, significand);
-                return mkType(smt(fp), smt(fp), smt(bool));
-            }
-            case FP_IS_NAN: {
-                Type exponent = types.get(0);
-                Type significand = types.get(1);
-                return mkType(smt(fp(exponent, significand)), smt(bool));
-            }
-            case FP_TO_SBV:
-            case FP_TO_UBV: {
-                Type exponent = types.get(0);
-                Type significand = types.get(1);
-                Type width = types.get(2);
-                return mkType(smt(fp(exponent, significand)), smt(bv(width)));
-            }
-            case FP_TO_FP: {
-                Type exp1 = types.get(0);
-                Type sig1 = types.get(1);
-                Type exp2 = types.get(2);
-                Type sig2 = types.get(3);
-                return mkType(smt(fp(exp1, sig1)), smt(fp(exp2, sig2)));
-            }
-            case SMT_EQ: {
-                Type ty = types.get(0);
-                return mkType(smt(ty), smt(ty), smt(bool));
-            }
-            case SMT_LET: {
-                Type a = types.get(0);
-                Type b = TypeVar.fresh();
-                return mkType(sym(a), smt(a), smt(b), smt(b));
-            }
-            case SMT_PAT: {
-                return mkType(types.get(0), smtPattern);
-            }
-            case SMT_WRAP_VAR: {
-                return mkType(sym(types.get(0)), smtWrappedVar);
-            }
-            case SMT_VAR: {
-                return mkType(types.get(0), sym(types.get(1)));
-            }
-        }
-        throw new AssertionError("impossible");
-    }
+	private FunctorType makeType() {
+		List<Type> types = new ArrayList<>();
+		for (Param param : getArgs()) {
+			types.add(param.getType());
+		}
+		switch (getBase()) {
+		case ARRAY_DEFAULT: {
+			Type a = types.get(0);
+			Type b = TypeVar.fresh();
+			return mkType(smt(array(a, b)), smt(b));
+		}
+		case ARRAY_SELECT: {
+			Type a = types.get(0);
+			Type b = TypeVar.fresh();
+			return mkType(smt(array(a, b)), smt(a), smt(b));
+		}
+		case BV_BIG_CONST: {
+			Type width = types.get(0);
+			return mkType(i64, smt(bv(width)));
+		}
+		case BV_CONST: {
+			Type width = types.get(0);
+			return mkType(i32, smt(bv(width)));
+		}
+		case BV_CONCAT: {
+			Type w1 = types.get(0);
+			Type w2 = types.get(1);
+			Type w3 = types.get(2);
+			return mkType(smt(bv(w1)), smt(bv(w2)), smt(bv(w3)));
+		}
+		case BV_EXTRACT: {
+			Type w1 = types.get(0);
+			Type w2 = types.get(1);
+			return mkType(smt(bv(w1)), i32, i32, smt(bv(w2)));
+		}
+		case INT_TO_BV:
+			return mkType(smt(int_), smt(bv(types.get(0))));
+		case BV_TO_INT:
+			return mkType(smt(bv(types.get(0))), smt(int_));
+		case BV_SGE:
+		case BV_SGT:
+		case BV_SLE:
+		case BV_SLT:
+		case BV_UGE:
+		case BV_UGT:
+		case BV_ULE:
+		case BV_ULT: {
+			Type width = types.get(0);
+			return mkType(smt(bv(width)), smt(bv(width)), smt(bool));
+		}
+		case BV_TO_BV_SIGNED:
+		case BV_TO_BV_UNSIGNED: {
+			Type fromWidth = types.get(0);
+			Type toWidth = types.get(1);
+			return mkType(smt(bv(fromWidth)), smt(bv(toWidth)));
+		}
+		case BV_TO_FP: {
+			Type width = types.get(0);
+			Type exponent = types.get(1);
+			Type significand = types.get(2);
+			return mkType(smt(bv(width)), smt(fp(exponent, significand)));
+		}
+		case FP_BIG_CONST: {
+			Type exponent = types.get(0);
+			Type significand = types.get(1);
+			return mkType(fp64, smt(fp(exponent, significand)));
+		}
+		case FP_CONST: {
+			Type exponent = types.get(0);
+			Type significand = types.get(1);
+			return mkType(fp32, smt(fp(exponent, significand)));
+		}
+		case FP_EQ:
+		case FP_GE:
+		case FP_GT:
+		case FP_LE:
+		case FP_LT: {
+			Type exponent = types.get(0);
+			Type significand = types.get(1);
+			Type fp = fp(exponent, significand);
+			return mkType(smt(fp), smt(fp), smt(bool));
+		}
+		case FP_IS_NAN: {
+			Type exponent = types.get(0);
+			Type significand = types.get(1);
+			return mkType(smt(fp(exponent, significand)), smt(bool));
+		}
+		case FP_TO_SBV:
+		case FP_TO_UBV: {
+			Type exponent = types.get(0);
+			Type significand = types.get(1);
+			Type width = types.get(2);
+			return mkType(smt(fp(exponent, significand)), smt(bv(width)));
+		}
+		case FP_TO_FP: {
+			Type exp1 = types.get(0);
+			Type sig1 = types.get(1);
+			Type exp2 = types.get(2);
+			Type sig2 = types.get(3);
+			return mkType(smt(fp(exp1, sig1)), smt(fp(exp2, sig2)));
+		}
+		case SMT_EQ: {
+			Type ty = types.get(0);
+			return mkType(smt(ty), smt(ty), smt(bool));
+		}
+		case SMT_LET: {
+			Type a = types.get(0);
+			Type b = TypeVar.fresh();
+			return mkType(sym(a), smt(a), smt(b), smt(b));
+		}
+		case SMT_PAT: {
+			return mkType(types.get(0), smtPattern);
+		}
+		case SMT_WRAP_VAR: {
+			return mkType(sym(types.get(0)), smtWrappedVar);
+		}
+		case SMT_VAR: {
+			return mkType(types.get(0), sym(types.get(1)));
+		}
+		}
+		throw new AssertionError("impossible");
+	}
 
-    @Override
-    public FunctorType getCompileTimeType() {
-        return type;
-    }
+	@Override
+	public FunctorType getCompileTimeType() {
+		return type;
+	}
 
-    private static FunctorType mkType(Type... types) {
-        return new FunctorType(types);
-    }
+	private static FunctorType mkType(Type... types) {
+		return new FunctorType(types);
+	}
 
-    @Override
-    public ParameterizedSymbol makeFinal() {
-        return Util.lookupOrCreate(memo, new Pair<>(getBase(), getArgs()),
-                () -> new ParameterizedConstructorSymbol(getBase(), getArgs()));
-    }
+	@Override
+	public ParameterizedSymbol makeFinal() {
+		return Util.lookupOrCreate(memo, new Pair<>(getBase(), getArgs()),
+				() -> new ParameterizedConstructorSymbol(getBase(), getArgs()));
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParameterizedSymbol.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/ParameterizedSymbol.java
@@ -24,19 +24,18 @@ import java.util.List;
 
 import edu.harvard.seas.pl.formulog.symbols.Symbol;
 
-
 public interface ParameterizedSymbol extends Symbol {
 
 	SymbolBase getBase();
-	
+
 	List<Param> getArgs();
-	
+
 	ParameterizedSymbol copyWithNewArgs(List<Param> args);
 
 	ParameterizedSymbol copyWithNewArgs(Param... args);
-	
+
 	ParameterizedSymbol makeFinal();
-	
+
 	boolean isGround();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/SymbolBase.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/symbols/parameterized/SymbolBase.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.symbols.parameterized;
  * #L%
  */
 
-
 import java.util.List;
 
 public interface SymbolBase {
@@ -32,5 +31,5 @@ public interface SymbolBase {
 	default int getNumParams() {
 		return getParamKinds().size();
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/BuiltInTypes.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/BuiltInTypes.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import static edu.harvard.seas.pl.formulog.symbols.BuiltInConstructorSymbol.CMP_EQ;
 import static edu.harvard.seas.pl.formulog.symbols.BuiltInConstructorSymbol.CMP_GT;
 import static edu.harvard.seas.pl.formulog.symbols.BuiltInConstructorSymbol.CMP_LT;
@@ -125,15 +124,15 @@ public final class BuiltInTypes {
 	public static AlgebraicDataType sym(Type a) {
 		return AlgebraicDataType.make(SYM_TYPE, Collections.singletonList(a));
 	}
-	
+
 	public static AlgebraicDataType bv(Type a) {
 		return AlgebraicDataType.make(BV, a);
 	}
-	
+
 	public static AlgebraicDataType bv(int width) {
 		return bv(TypeIndex.make(width));
 	}
-	
+
 	public static AlgebraicDataType fp(Type a, Type b) {
 		return AlgebraicDataType.make(FP, a, b);
 	}
@@ -145,11 +144,11 @@ public final class BuiltInTypes {
 	public static AlgebraicDataType array(Type a, Type b) {
 		return AlgebraicDataType.make(ARRAY_TYPE, Arrays.asList(a, b));
 	}
-	
+
 	public static AlgebraicDataType opaqueSet(Type a) {
 		return AlgebraicDataType.make(OPAQUE_SET, a);
 	}
-	
+
 	public static AlgebraicDataType pair(Type a, Type b) {
 		return AlgebraicDataType.make(GlobalSymbolManager.lookupTupleTypeSymbol(2), a, b);
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/FunctorType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/FunctorType.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,123 +37,123 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 public class FunctorType implements Type {
 
-    private final List<Type> argTypes;
-    private final Type retType;
+	private final List<Type> argTypes;
+	private final Type retType;
 
-    public FunctorType(List<Type> argTypes, Type retType) {
-        this.argTypes = argTypes;
-        this.retType = retType;
-    }
+	public FunctorType(List<Type> argTypes, Type retType) {
+		this.argTypes = argTypes;
+		this.retType = retType;
+	}
 
-    public FunctorType(Type... types) {
-        assert types.length > 0;
-        argTypes = new ArrayList<>(Arrays.asList(types));
-        retType = this.argTypes.remove(types.length - 1);
-    }
+	public FunctorType(Type... types) {
+		assert types.length > 0;
+		argTypes = new ArrayList<>(Arrays.asList(types));
+		retType = this.argTypes.remove(types.length - 1);
+	}
 
-    public List<Type> getArgTypes() {
-        return argTypes;
-    }
+	public List<Type> getArgTypes() {
+		return argTypes;
+	}
 
-    public Type getRetType() {
-        return retType;
-    }
+	public Type getRetType() {
+		return retType;
+	}
 
-    public FunctorType freshen() {
-        Map<TypeVar, TypeVar> subst = new HashMap<>();
-        TypeVisitor<Void, Type> visitor = new TypeVisitor<Void, Type>() {
+	public FunctorType freshen() {
+		Map<TypeVar, TypeVar> subst = new HashMap<>();
+		TypeVisitor<Void, Type> visitor = new TypeVisitor<Void, Type>() {
 
-            @Override
-            public Type visit(TypeVar typeVar, Void in) {
-                return Util.lookupOrCreate(subst, typeVar, () -> TypeVar.fresh());
-            }
+			@Override
+			public Type visit(TypeVar typeVar, Void in) {
+				return Util.lookupOrCreate(subst, typeVar, () -> TypeVar.fresh());
+			}
 
-            @Override
-            public Type visit(OpaqueType opaqueType, Void in) {
-                throw new AssertionError();
-            }
+			@Override
+			public Type visit(OpaqueType opaqueType, Void in) {
+				throw new AssertionError();
+			}
 
-            private List<Type> processTypeList(List<Type> types) {
-                List<Type> newTypes = new ArrayList<>();
-                for (Type t : types) {
-                    newTypes.add(t.accept(this, null));
-                }
-                return newTypes;
-            }
+			private List<Type> processTypeList(List<Type> types) {
+				List<Type> newTypes = new ArrayList<>();
+				for (Type t : types) {
+					newTypes.add(t.accept(this, null));
+				}
+				return newTypes;
+			}
 
-            @Override
-            public Type visit(AlgebraicDataType namedType, Void in) {
-                return AlgebraicDataType.make(namedType.getSymbol(), processTypeList(namedType.getTypeArgs()));
-            }
+			@Override
+			public Type visit(AlgebraicDataType namedType, Void in) {
+				return AlgebraicDataType.make(namedType.getSymbol(), processTypeList(namedType.getTypeArgs()));
+			}
 
-            @Override
-            public Type visit(TypeIndex typeIndex, Void in) {
-                return typeIndex;
-            }
+			@Override
+			public Type visit(TypeIndex typeIndex, Void in) {
+				return typeIndex;
+			}
 
-        };
-        List<Type> newArgTypes = new ArrayList<>();
-        for (Type t : argTypes) {
-            newArgTypes.add(t.accept(visitor, null));
-        }
-        Type newRetType = retType.accept(visitor, null);
-        return new FunctorType(newArgTypes, newRetType);
-    }
+		};
+		List<Type> newArgTypes = new ArrayList<>();
+		for (Type t : argTypes) {
+			newArgTypes.add(t.accept(visitor, null));
+		}
+		Type newRetType = retType.accept(visitor, null);
+		return new FunctorType(newArgTypes, newRetType);
+	}
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((argTypes == null) ? 0 : argTypes.hashCode());
-        result = prime * result + ((retType == null) ? 0 : retType.hashCode());
-        return result;
-    }
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((argTypes == null) ? 0 : argTypes.hashCode());
+		result = prime * result + ((retType == null) ? 0 : retType.hashCode());
+		return result;
+	}
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        FunctorType other = (FunctorType) obj;
-        if (argTypes == null) {
-            if (other.argTypes != null)
-                return false;
-        } else if (!argTypes.equals(other.argTypes))
-            return false;
-        if (retType == null) {
-            if (other.retType != null)
-                return false;
-        } else if (!retType.equals(other.retType))
-            return false;
-        return true;
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		FunctorType other = (FunctorType) obj;
+		if (argTypes == null) {
+			if (other.argTypes != null)
+				return false;
+		} else if (!argTypes.equals(other.argTypes))
+			return false;
+		if (retType == null) {
+			if (other.retType != null)
+				return false;
+		} else if (!retType.equals(other.retType))
+			return false;
+		return true;
+	}
 
-    @Override
-    public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
+		throw new UnsupportedOperationException();
+	}
 
-    @Override
-    public Type applySubst(Map<TypeVar, ? extends Type> subst) {
-        List<Type> newArgTypes = Util.map(argTypes, t -> t.applySubst(subst));
-        Type newRetType = retType.applySubst(subst);
-        return new FunctorType(newArgTypes, newRetType);
-    }
+	@Override
+	public Type applySubst(Map<TypeVar, ? extends Type> subst) {
+		List<Type> newArgTypes = Util.map(argTypes, t -> t.applySubst(subst));
+		Type newRetType = retType.applySubst(subst);
+		return new FunctorType(newArgTypes, newRetType);
+	}
 
-    @Override
-    public String toString() {
-        String s = "(";
-        for (Iterator<Type> it = argTypes.iterator(); it.hasNext(); ) {
-            s += it.next();
-            if (it.hasNext()) {
-                s += ", ";
-            }
-        }
-        s += ") -> " + retType;
-        return s;
-    }
+	@Override
+	public String toString() {
+		String s = "(";
+		for (Iterator<Type> it = argTypes.iterator(); it.hasNext();) {
+			s += it.next();
+			if (it.hasNext()) {
+				s += ", ";
+			}
+		}
+		s += ") -> " + retType;
+		return s;
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/IndexedType.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/IndexedType.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import java.util.List;
 
 import edu.harvard.seas.pl.formulog.types.Types.Type;
@@ -28,5 +27,5 @@ import edu.harvard.seas.pl.formulog.types.Types.Type;
 public interface IndexedType {
 
 	Type instantiate(List<Integer> indices);
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/TypeAlias.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/TypeAlias.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/TypeChecker.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/TypeChecker.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.Main;
 import edu.harvard.seas.pl.formulog.ast.*;
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralExnVisitor;
@@ -49,878 +48,881 @@ import java.util.stream.Collectors;
 
 public class TypeChecker {
 
-    private final Program<UserPredicate, BasicRule> prog;
-    private WellTypedProgram outputProgram;
-
-    public TypeChecker(Program<UserPredicate, BasicRule> prog2) {
-        this.prog = prog2;
-    }
-
-    public synchronized WellTypedProgram typeCheck() throws TypeException {
-        if (outputProgram != null) {
-            return outputProgram;
-        }
-        ExecutorService exec = Executors.newFixedThreadPool(Main.parallelism);
-        Map<RelationSymbol, Set<Term[]>> newFacts = typeCheckFacts(exec);
-        Map<FunctionSymbol, FunctionDef> newFuncs = typeCheckFunctions(exec);
-        FunctionDefManager dm = prog.getFunctionCallFactory().getDefManager();
-        for (FunctionDef func : newFuncs.values()) {
-            dm.reregister(func);
-        }
-        Map<RelationSymbol, Set<BasicRule>> newRules = typeCheckRules(exec);
-        UserPredicate newQuery = typeCheckQuery();
-        exec.shutdown();
-        outputProgram = new WellTypedProgram() {
-
-            @Override
-            public Set<FunctionSymbol> getFunctionSymbols() {
-                return dm.getFunctionSymbols();
-            }
-
-            @Override
-            public Set<RelationSymbol> getFactSymbols() {
-                return Collections.unmodifiableSet(newFacts.keySet());
-            }
-
-            @Override
-            public Set<RelationSymbol> getRuleSymbols() {
-                return Collections.unmodifiableSet(newRules.keySet());
-            }
-
-            @Override
-            public FunctionDef getDef(FunctionSymbol sym) {
-                return dm.lookup(sym);
-            }
-
-            @Override
-            public Set<Term[]> getFacts(RelationSymbol sym) {
-                if (!sym.isEdbSymbol()) {
-                    throw new IllegalArgumentException();
-                }
-                if (!newFacts.containsKey(sym)) {
-                    throw new IllegalArgumentException();
-                }
-                return newFacts.get(sym);
-            }
-
-            @Override
-            public Set<BasicRule> getRules(RelationSymbol sym) {
-                if (!sym.isIdbSymbol()) {
-                    throw new IllegalArgumentException();
-                }
-                if (!newRules.containsKey(sym)) {
-                    throw new IllegalArgumentException();
-                }
-                return newRules.get(sym);
-            }
-
-            @Override
-            public SymbolManager getSymbolManager() {
-                return prog.getSymbolManager();
-            }
-
-            @Override
-            public boolean hasQuery() {
-                return newQuery != null;
-            }
-
-            @Override
-            public UserPredicate getQuery() {
-                return newQuery;
-            }
-
-            @Override
-            public FunctionCallFactory getFunctionCallFactory() {
-                return prog.getFunctionCallFactory();
-            }
-
-            @Override
-            public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
-                return prog.getUninterpretedFunctionSymbols();
-            }
-
-            @Override
-            public Set<TypeSymbol> getTypeSymbols() {
-                return prog.getTypeSymbols();
-            }
-
-        };
-        return outputProgram;
-    }
-
-    private UserPredicate typeCheckQuery() throws TypeException {
-        if (prog.hasQuery()) {
-            TypeCheckerContext ctx = new TypeCheckerContext();
-            return ctx.typeCheckQuery(prog.getQuery());
-        }
-        return null;
-    }
-
-    private static <K, V> Map<K, V> mapFromFutures(Map<K, Future<V>> futures) throws TypeException {
-        try {
-            return Util.fillMapWithFutures(futures, new HashMap<>());
-        } catch (InterruptedException | ExecutionException e) {
-            throw new TypeException(e);
-        }
-    }
-
-    private Map<RelationSymbol, Set<Term[]>> typeCheckFacts(ExecutorService exec) throws TypeException {
-        Map<RelationSymbol, Future<Set<Term[]>>> futures = new HashMap<>();
-        for (RelationSymbol sym : prog.getFactSymbols()) {
-            Future<Set<Term[]>> fut = exec.submit(new Callable<Set<Term[]>>() {
-
-                @Override
-                public Set<Term[]> call() throws Exception {
-                    Set<Term[]> s = new HashSet<>();
-                    TypeCheckerContext ctx = new TypeCheckerContext();
-                    for (Term[] args : prog.getFacts(sym)) {
-                        s.add(ctx.typeCheckFact(sym, args));
-                    }
-                    return s;
-                }
-
-            });
-            futures.put(sym, fut);
-        }
-        return mapFromFutures(futures);
-    }
-
-    private Map<RelationSymbol, Set<BasicRule>> typeCheckRules(ExecutorService exec) throws TypeException {
-        Map<RelationSymbol, Future<Set<BasicRule>>> futures = new HashMap<>();
-        for (RelationSymbol sym : prog.getRuleSymbols()) {
-            Future<Set<BasicRule>> fut = exec.submit(new Callable<Set<BasicRule>>() {
-
-                @Override
-                public Set<BasicRule> call() throws Exception {
-                    Set<BasicRule> s = new HashSet<>();
-                    for (BasicRule r : prog.getRules(sym)) {
-                        TypeCheckerContext ctx = new TypeCheckerContext();
-                        s.add(ctx.typeCheckRule(r));
-                    }
-                    return s;
-                }
-
-            });
-            futures.put(sym, fut);
-        }
-        return mapFromFutures(futures);
-    }
-
-    private Map<FunctionSymbol, FunctionDef> typeCheckFunctions(ExecutorService exec) throws TypeException {
-        Map<FunctionSymbol, Future<FunctionDef>> futures = new HashMap<>();
-        List<FunctionDef> nonUserFunctions = new ArrayList<>();
-        for (FunctionSymbol sym : prog.getFunctionSymbols()) {
-            FunctionDef def = prog.getDef(sym);
-            if (def instanceof UserFunctionDef) {
-                Future<FunctionDef> fut = exec.submit(() -> {
-                    TypeCheckerContext ctx = new TypeCheckerContext();
-                    try {
-                        return ctx.typeCheckFunction((UserFunctionDef) def);
-                    } catch (Throwable e) {
-                        throw new TypeException("Problem type checking function: " + sym + "\n" + e.getMessage());
-                    }
-                });
-                futures.put(sym, fut);
-            } else {
-                nonUserFunctions.add(def);
-            }
-        }
-        Map<FunctionSymbol, FunctionDef> m = mapFromFutures(futures);
-        for (FunctionDef def : nonUserFunctions) {
-            m.put(def.getSymbol(), def);
-        }
-        return m;
-    }
-
-    private class TypeCheckerContext {
-
-        private final Deque<Triple<Term, Type, Type>> constraints = new ArrayDeque<>();
-        private final Deque<Triple<Term, Type, Type>> formulaConstraints = new ArrayDeque<>();
-        private final Map<TypeVar, Type> typeVars = new HashMap<>();
-        private String error;
-
-        private Term rewriteTerm(Term t, Substitution m) throws TypeException {
-            return t.accept(termRewriter, m);
-        }
-
-        public Term[] typeCheckFact(RelationSymbol sym, Term[] args) throws TypeException {
-            Map<Var, Type> subst = new HashMap<>();
-            genConstraints(sym, args, subst);
-            if (!checkConstraints()) {
-                throw new TypeException("Type error in fact: " + UserPredicate.make(sym, args, false) + "\n" + error);
-            }
-            Substitution m = makeIndexSubstitution(subst);
-            try {
-                return Terms.mapExn(args, t -> rewriteTerm(t, m));
-            } catch (TypeException e) {
-                throw new TypeException(
-                        "Problem with rewriting fact: " + UserPredicate.make(sym, args, false) + "\n" + e.getMessage());
-            }
-
-        }
-
-        private ComplexLiteral rewriteLiteral(ComplexLiteral l, Substitution m, Map<Var, Type> env) throws TypeException {
-            try {
-                Term[] args = Terms.mapExn(l.getArgs(), t -> rewriteTerm(t, m));
-                return l.accept(new ComplexLiteralExnVisitor<Void, ComplexLiteral, TypeException>() {
-
-                    @Override
-                    public ComplexLiteral visit(UnificationPredicate pred, Void input) throws TypeException {
-                        return UnificationPredicate.make(args[0], args[1], pred.isNegated());
-                    }
-
-                    @Override
-                    public ComplexLiteral visit(UserPredicate pred, Void input) throws TypeException {
-                        return UserPredicate.make(pred.getSymbol(), args, pred.isNegated());
-                    }
-
-                }, null);
-            } catch (TypeException e) {
-                throw new TypeException("Problem with rewriting literal: " + l + "\n" + e.getMessage());
-            }
-        }
-
-        public UserPredicate typeCheckQuery(UserPredicate q) throws TypeException {
-            Map<Var, Type> subst = new HashMap<>();
-            genConstraints(q, subst);
-            if (!checkConstraints()) {
-                throw new TypeException("Type error in query: " + q + "\n" + error);
-            }
-            Substitution m = makeIndexSubstitution(subst);
-            try {
-                return (UserPredicate) rewriteLiteral(q, m, subst);
-            } catch (TypeException e) {
-                throw new TypeException("Problem with rewriting query: " + q + "\n" + e.getMessage());
-            }
-        }
-
-        public BasicRule typeCheckRule(Rule<UserPredicate, ComplexLiteral> r) throws TypeException {
-            Map<Var, Type> subst = new HashMap<>();
-            processAtoms(r, subst);
-            genConstraints(r.getHead(), subst);
-            if (!checkConstraints()) {
-                String msg = "Type error in rule:\n";
-                msg += r + "\n";
-                msg += error;
-                throw new TypeException(msg);
-            }
-            Substitution m = makeIndexSubstitution(subst);
-            UserPredicate newHead = (UserPredicate) rewriteLiteral(r.getHead(), m, subst);
-            try {
-                List<ComplexLiteral> newBody = new ArrayList<>();
-                for (ComplexLiteral a : r) {
-                    newBody.add(rewriteLiteral(a, m, subst));
-                }
-                return BasicRule.make(newHead, newBody);
-            } catch (TypeException e) {
-                throw new TypeException("Problem with rewriting rule:\n" + r + "\n" + e.getMessage());
-            }
-        }
-
-        private Substitution makeIndexSubstitution(Map<Var, Type> subst) {
-            Substitution m = new SimpleSubstitution();
-            for (Map.Entry<Var, Type> e : subst.entrySet()) {
-                Var x = e.getKey();
-                Type t = lookupType(e.getValue());
-                if (t instanceof TypeIndex) {
-                    int idx = ((TypeIndex) t).getIndex();
-                    ConstructorSymbol csym = prog.getSymbolManager().lookupIndexConstructorSymbol(idx);
-                    Term c = Constructors.make(csym, Terms.singletonArray(I32.make(idx)));
-                    m.put(x, c);
-                }
-            }
-            return m;
-        }
-
-        public UserFunctionDef typeCheckFunction(UserFunctionDef functionDef) throws TypeException {
-            Map<Var, Type> subst = new HashMap<>();
-            genConstraints(functionDef, subst);
-            if (!checkConstraints()) {
-                throw new TypeException("Type error in function: " + functionDef.getSymbol() + "\n"
-                        + functionDef.getBody() + "\n" + error);
-            }
-            Substitution m = makeIndexSubstitution(subst);
-            try {
-                return UserFunctionDef.get(functionDef.getSymbol(), functionDef.getParams(),
-                        rewriteTerm(functionDef.getBody(), m));
-            } catch (Throwable e) {
-                throw new TypeException("Problem with rewriting the function: " + functionDef.getSymbol() + "\n"
-                        + functionDef.getBody() + "\n" + e.getMessage());
-            }
-        }
-
-        private void processAtoms(Iterable<ComplexLiteral> atoms, Map<Var, Type> subst) {
-            for (ComplexLiteral a : atoms) {
-                genConstraints(a, subst);
-            }
-        }
-
-        private void genConstraints(RelationSymbol sym, Term[] args, Map<Var, Type> subst) {
-            FunctorType ftype = sym.getCompileTimeType().freshen();
-            assert ftype.getArgTypes().size() == args.length;
-            int i = 0;
-            for (Type type : ftype.getArgTypes()) {
-                genConstraints(args[i], type, subst, false);
-                ++i;
-            }
-        }
-
-        private void genConstraints(ComplexLiteral a, Map<Var, Type> subst) {
-            a.accept(new ComplexLiteralVisitor<Void, Void>() {
-
-                @Override
-                public Void visit(UserPredicate normalAtom, Void in) {
-                    genConstraints(normalAtom.getSymbol(), normalAtom.getArgs(), subst);
-                    return null;
-                }
-
-                @Override
-                public Void visit(UnificationPredicate unifyAtom, Void in) {
-                    TypeVar var = TypeVar.fresh();
-                    genConstraints(unifyAtom.getLhs(), var, subst, false);
-                    genConstraints(unifyAtom.getRhs(), var, subst, false);
-                    return null;
-                }
-
-            }, null);
-        }
-
-        private void genConstraints(UserFunctionDef def, Map<Var, Type> subst) {
-            FunctionSymbol sym = def.getSymbol();
-            genConstraints(sym, def.getParams(), def.getBody(), subst);
-        }
-
-        private void genConstraints(FunctionSymbol sym, List<Var> params, Term body, Map<Var, Type> subst) {
-            FunctorType scheme = sym.getCompileTimeType().freshen();
-            Map<TypeVar, OpaqueType> opaqueTypes = new HashMap<>();
-            List<Type> argTypes = scheme.getArgTypes();
-            for (Type t : argTypes) {
-                addConstraint(null, t, mkTypeVarsOpaque(t, opaqueTypes), false);
-            }
-            Type r = scheme.getRetType();
-            addConstraint(null, r, mkTypeVarsOpaque(r, opaqueTypes), false);
-            for (int i = 0; i < params.size(); ++i) {
-                subst.put(params.get(i), argTypes.get(i));
-            }
-            genConstraints(body, r, subst, false);
-        }
-
-        private Type mkTypeVarsOpaque(Type t, Map<TypeVar, OpaqueType> subst) {
-            return t.accept(new TypeVisitor<Void, Type>() {
-                @Override
-                public Type visit(TypeVar typeVar, Void in) {
-                    return Util.lookupOrCreate(subst, typeVar, OpaqueType::get);
-                }
-
-                @Override
-                public Type visit(AlgebraicDataType algebraicType, Void in) {
-                    List<Type> newArgs = algebraicType.getTypeArgs().stream().map(t -> t.accept(this, null)).collect(Collectors.toList());
-                    return AlgebraicDataType.make(algebraicType.getSymbol(), newArgs);
-                }
-
-                @Override
-                public Type visit(OpaqueType opaqueType, Void in) {
-                    return opaqueType;
-                }
-
-                @Override
-                public Type visit(TypeIndex typeIndex, Void in) {
-                    return typeIndex;
-                }
-            }, null);
-        }
-
-        private void genConstraintsForExpr(Expr e, Type exprType, Map<Var, Type> varTypes, boolean inFormula) {
-            e.accept(new ExprVisitor<Void, Void>() {
-
-                @Override
-                public Void visit(MatchExpr matchExpr, Void in) {
-                    assert !inFormula;
-                    TypeVar guardType = TypeVar.fresh();
-                    Term guard = matchExpr.getMatchee();
-                    genConstraints(guard, guardType, varTypes, inFormula);
-                    for (MatchClause cl : matchExpr) {
-                        genConstraints(cl.getLhs(), guardType, varTypes, inFormula);
-                        genConstraints(cl.getRhs(), exprType, varTypes, inFormula);
-                    }
-                    return null;
-                }
-
-                @Override
-                public Void visit(FunctionCall funcCall, Void in) {
-                    genConstraintsForFunctionCall(funcCall, exprType, varTypes, inFormula);
-                    return null;
-                }
-
-                @Override
-                public Void visit(LetFunExpr letFun, Void in) {
-                    assert !inFormula;
-                    for (NestedFunctionDef def : letFun.getDefs()) {
-                        def = def.freshen();
-                        genConstraints(def.getSymbol(), def.getParams(), def.getBody(), varTypes);
-                    }
-                    genConstraints(letFun.getLetBody(), exprType, varTypes, inFormula);
-                    return null;
-                }
-
-                @Override
-                public Void visit(Fold fold, Void in) {
-                    assert !inFormula;
-                    FunctionSymbol sym = fold.getFunction();
-                    Term[] args = fold.getArgs();
-                    assert sym.getArity() == args.length && args.length == 2;
-                    Type itemType = TypeVar.fresh();
-                    Type listType = BuiltInTypes.list(itemType);
-                    FunctorType funType = sym.getCompileTimeType().freshen();
-                    genConstraints(args[0], exprType, varTypes, inFormula);
-                    genConstraints(args[0], funType.getArgTypes().get(0), varTypes, inFormula);
-                    genConstraints(args[1], listType, varTypes, inFormula);
-                    addConstraint(args[1], itemType, funType.getArgTypes().get(1), inFormula);
-                    addConstraint(fold, exprType, funType.getRetType(), inFormula);
-                    return null;
-                }
-
-            }, null);
-        }
-
-        private void addConstraint(Term t, Type t1, Type t2, boolean inFormula) {
-            Triple<Term, Type, Type> constraint = new Triple<>(t, t1, t2);
-            if (inFormula) {
-                formulaConstraints.add(constraint);
-            } else {
-                constraints.add(constraint);
-            }
-        }
-
-        private void genConstraints(Term t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
-            t.accept(new TermVisitor<Void, Void>() {
-
-                @Override
-                public Void visit(Var t, Void in) {
-                    genConstraintsForVar(t, ttype, subst, inFormula);
-                    return null;
-                }
-
-                @Override
-                public Void visit(Constructor t, Void in) {
-                    genConstraintsForConstructor(t, ttype, subst, inFormula);
-                    return null;
-                }
-
-                @Override
-                public Void visit(Primitive<?> prim, Void in) {
-                    genConstraintsForPrimitive(prim, ttype, inFormula);
-                    return null;
-                }
-
-                @Override
-                public Void visit(Expr expr, Void in) {
-                    genConstraintsForExpr(expr, ttype, subst, inFormula);
-                    return null;
-                }
-
-            }, null);
-        }
-
-        private void genConstraintsForVar(Var t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
-            Type s = Util.lookupOrCreate(subst, t, () -> {
-                Type x = TypeVar.fresh();
-                if (inFormula) {
-                    x = BuiltInTypes.smt(x);
-                }
-                return x;
-            });
-            addConstraint(t, s, ttype, inFormula);
-        }
-
-        private void genConstraintsForPrimitive(Primitive<?> t, Type ttype, boolean inFormula) {
-            addConstraint(t, ttype, t.getType().freshen(), inFormula);
-        }
-
-        private void genConstraintsForConstructor(Constructor t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
-            boolean wasInFormula = inFormula;
-            ConstructorSymbol cnstrSym = t.getSymbol();
-            if (cnstrSym.equals(BuiltInConstructorSymbol.ENTER_FORMULA)) {
-                assert !wasInFormula;
-                inFormula = true;
-            }
-            if (cnstrSym.equals(BuiltInConstructorSymbol.EXIT_FORMULA)) {
-                inFormula = false;
-            }
-            FunctorType cnstrType = cnstrSym.getCompileTimeType();
-            if (!(cnstrSym instanceof ParameterizedConstructorSymbol)) {
-                cnstrType = cnstrType.freshen();
-            }
-            Term[] args = t.getArgs();
-            List<Type> argTypes = cnstrType.getArgTypes();
-            for (int i = 0; i < args.length; ++i) {
-                Type argType = argTypes.get(i);
-                genConstraints(args[i], argType, subst, inFormula);
-            }
-            addConstraint(t, cnstrType.getRetType(), ttype, wasInFormula);
-        }
-
-        private void genConstraintsForFunctionCall(FunctionCall function, Type ttype, Map<Var, Type> subst,
-                                                   boolean inFormula) {
-            FunctorType funType = (FunctorType) function.getSymbol().getCompileTimeType().freshen();
-            Term[] args = function.getArgs();
-            List<Type> argTypes = funType.getArgTypes();
-            for (int i = 0; i < args.length; ++i) {
-                genConstraints(args[i], argTypes.get(i), subst, inFormula);
-            }
-            addConstraint(function, funType.getRetType(), ttype, inFormula);
-        }
-
-        private boolean checkConstraints() {
-            Set<Type> typesInFormulae = new HashSet<>();
-            for (Triple<Term, Type, Type> p : formulaConstraints) {
-                typesInFormulae.add(p.second);
-            }
-            // First try to unify constraints generated outside of formula and then
-            // constraints generated inside formula. This might generate more constraints,
-            // but all of them will be treated as being in a non-formula context.
-            boolean ok = checkConstraints(false) && checkConstraints(true) && checkConstraints(false);
-            assert !ok || constraints.isEmpty() && formulaConstraints.isEmpty();
-            ok = ok && checkTypesInFormulae(typesInFormulae);
-            return ok;
-        }
-
-        private boolean checkTypesInFormulae(Set<Type> types) {
-            for (Type ty : types) {
-                if (!checkTypeInFormula(ty)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private boolean checkTypeInFormula(Type ty) {
-            ty = lookupType(ty);
-            if (!Types.isSmtRepresentable(ty)) {
-                error = "Terms of the following type are not allowed in formulas: " + ty
-                        + "\nThe following types can lead to this error: model, smt_pattern, smt_wrapped_var,"
-                        + " and type variables that are not proven to contain a safe type";
-                return false;
-            }
-            return true;
-        }
-
-        private boolean checkConstraints(boolean inFormulaContext) {
-            Deque<Triple<Term, Type, Type>> q = inFormulaContext ? formulaConstraints : constraints;
-            while (!q.isEmpty()) {
-                Triple<Term, Type, Type> constraint = q.pop();
-                Type type1 = lookupType(constraint.second);
-                Type type2 = lookupType(constraint.third);
-                if (inFormulaContext) {
-                    type1 = simplify(type1);
-                    type2 = simplify(type2);
-                }
-                if (type1.isVar() || type2.isVar()) {
-                    if (!handleVars(type1, type2)) {
-                        return false;
-                    }
-                } else if (!unify(constraint.first, type1, type2)) {
-                    error = "Cannot unify " + type1 + " and " + type2;
-                    error += "\nProblematic term: " + constraint.first;
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private boolean handleVars(Type type1, Type type2) {
-            if (type1.isVar() && type2.isVar()) {
-                addBinding((TypeVar) type1, type2, typeVars);
-                return true;
-            }
-
-            TypeVar var;
-            Type other;
-            if (type1.isVar()) {
-                var = (TypeVar) type1;
-                other = type2;
-            } else {
-                assert type2.isVar();
-                var = (TypeVar) type2;
-                other = type1;
-            }
-            // Occurs check
-            if (Types.getTypeVars(other).contains(var)) {
-                return false;
-            }
-            typeVars.put(var, other);
-            return true;
-        }
-
-        private boolean unify(Term t, Type type1, Type type2) {
-            return type1.accept(new TypeVisitor<Type, Boolean>() {
-
-                @Override
-                public Boolean visit(TypeVar typeVar, Type other) {
-                    throw new AssertionError("unreachable");
-                }
-
-                @Override
-                public Boolean visit(AlgebraicDataType typeRef, Type other) {
-                    if (!(other instanceof AlgebraicDataType)) {
-                        return false;
-                    }
-                    AlgebraicDataType otherTypeRef = (AlgebraicDataType) other;
-                    if (!typeRef.getSymbol().equals(otherTypeRef.getSymbol())) {
-                        return false;
-                    }
-                    List<Type> args1 = typeRef.getTypeArgs();
-                    List<Type> args2 = otherTypeRef.getTypeArgs();
-                    for (int i = 0; i < args1.size(); ++i) {
-                        addConstraint(t, args1.get(i), args2.get(i), false);
-                    }
-                    return true;
-                }
-
-                @Override
-                public Boolean visit(OpaqueType opaqueType, Type other) {
-                    return opaqueType.equals(other);
-                }
-
-                @Override
-                public Boolean visit(TypeIndex typeIndex, Type other) {
-                    return typeIndex.equals(other);
-                }
-
-            }, type2);
-        }
-
-        private Type lookupType(Type t) {
-            return TypeChecker.lookupType(t, typeVars);
-        }
-
-        private final TermVisitorExn<Substitution, Term, TypeException> termRewriter = new TermVisitorExn<Substitution, Term, TypeException>() {
-
-            @Override
-            public Term visit(Var x, Substitution subst) throws TypeException {
-                if (subst.containsKey(x)) {
-                    return subst.get(x);
-                }
-                return x;
-            }
-
-            @Override
-            public Term visit(Constructor c, Substitution subst) throws TypeException {
-                ConstructorSymbol sym = c.getSymbol();
-                if (sym.equals(BuiltInConstructorSymbol.ENTER_FORMULA) || sym.equals(BuiltInConstructorSymbol.EXIT_FORMULA)) {
-                    return c.getArgs()[0].accept(this, subst);
-                }
-                if (sym instanceof ParameterizedConstructorSymbol) {
-                    try {
-                        sym = (ConstructorSymbol) handleParameterizedSymbol((ParameterizedConstructorSymbol) sym);
-                    } catch (TypeException e) {
-                        throw new TypeException("Problem with rewriting term " + c + ":\n" + e.getMessage());
-                    }
-                }
-                Term[] args = c.getArgs();
-                Term[] newArgs = new Term[args.length];
-                for (int i = 0; i < args.length; ++i) {
-                    newArgs[i] = args[i].accept(this, subst);
-                }
-                return Constructors.make(sym, newArgs);
-            }
-
-            @Override
-            public Term visit(Primitive<?> p, Substitution subst) throws TypeException {
-                return p;
-            }
-
-            @Override
-            public Term visit(Expr e, Substitution subst) throws TypeException {
-                return e.accept(exprRewriter, subst);
-            }
-
-        };
-
-        private ParameterizedSymbol handleParameterizedSymbol(ParameterizedSymbol sym) throws TypeException {
-            List<Param> params = sym.getArgs();
-            params = Param.applySubst(params, typeVars);
-            for (Param param : params) {
-                if (Types.containsTypeVarOrOpaqueType(param.getType())) {
-                    throw new TypeException("Cannot instantiate parameterized symbol " + sym
-                            + " with a parameter that is not ground: " + param);
-                }
-            }
-            return sym.copyWithNewArgs(params).makeFinal();
-        }
-
-        private final Map<FunctionSymbol, FunctionSymbol> topLevelSymbolOfNestedFunction = new HashMap<>();
-        private final Map<FunctionSymbol, List<Var>> capturedVarsOfNestedFunction = new HashMap<>();
-
-        private final ExprVisitorExn<Substitution, Term, TypeException> exprRewriter = new ExprVisitorExn<Substitution, Term, TypeException>() {
-
-            @Override
-            public Term visit(MatchExpr matchExpr, Substitution subst) throws TypeException {
-                Term scrutinee = matchExpr.getMatchee().accept(termRewriter, subst);
-                List<MatchClause> clauses = new ArrayList<>();
-                for (MatchClause cl : matchExpr) {
-                    Term lhs = cl.getLhs().accept(termRewriter, subst);
-                    Term rhs = cl.getRhs().accept(termRewriter, subst);
-                    clauses.add(MatchClause.make(lhs, rhs));
-                }
-                return MatchExpr.make(scrutinee, clauses);
-            }
-
-            @Override
-            public Term visit(FunctionCall funcCall, Substitution subst) throws TypeException {
-                FunctionSymbol sym = funcCall.getSymbol();
-                List<Var> capturedVars = Collections.emptyList();
-                if (topLevelSymbolOfNestedFunction.containsKey(sym)) {
-                    sym = topLevelSymbolOfNestedFunction.get(sym);
-                    capturedVars = capturedVarsOfNestedFunction.get(sym);
-                }
-                Term[] args = funcCall.getArgs();
-                Term[] newArgs = new Term[args.length + capturedVars.size()];
-                int i = 0;
-                for (; i < args.length; ++i) {
-                    newArgs[i] = args[i].accept(termRewriter, subst);
-                }
-                for (Var x : capturedVars) {
-                    newArgs[i] = x;
-                    ++i;
-                }
-                return prog.getFunctionCallFactory().make(sym, newArgs);
-            }
-
-            @Override
-            public Term visit(LetFunExpr letFun, Substitution in) throws TypeException {
-                Set<NestedFunctionDef> defs = new HashSet<>();
-                Set<Var> capturedVarSet = new HashSet<>();
-                for (NestedFunctionDef def : letFun.getDefs()) {
-                    def = firstRewritingPass(def, in);
-                    defs.add(def);
-                    Set<Var> s = def.getBody().varSet();
-                    s.removeAll(def.getParams());
-                    capturedVarSet.addAll(s);
-                }
-                List<Var> capturedVars = new ArrayList<>(capturedVarSet);
-                for (NestedFunctionDef def : defs) {
-                    FunctionSymbol oldSym = def.getSymbol();
-                    int newArity = oldSym.getArity() + capturedVarSet.size();
-                    FunctionSymbol newSym = prog.getSymbolManager().createFunctionSymbol(oldSym + "$toplevel", newArity,
-                            null);
-                    topLevelSymbolOfNestedFunction.put(oldSym, newSym);
-                    capturedVarsOfNestedFunction.put(newSym, capturedVars);
-                }
-                for (NestedFunctionDef def : defs) {
-                    FunctionSymbol sym = topLevelSymbolOfNestedFunction.get(def.getSymbol());
-                    List<Var> params = new ArrayList<>(def.getParams());
-                    params.addAll(capturedVars);
-                    FunctionDef newDef = UserFunctionDef.get(sym, params, def.getBody().accept(termRewriter, in));
-                    prog.getFunctionCallFactory().getDefManager().register(newDef);
-                }
-                return letFun.getLetBody().accept(termRewriter, in);
-            }
-
-            NestedFunctionDef firstRewritingPass(NestedFunctionDef def, Substitution subst) throws TypeException {
-                Substitution s = new SimpleSubstitution();
-                List<Var> newParams = new ArrayList<>();
-                for (Var param : def.getParams()) {
-                    if (!s.containsKey(param)) {
-                        Var newParam = Var.fresh(param.toString());
-                        s.put(param, newParam);
-                        newParams.add(newParam);
-                    } else {
-                        newParams.add((Var) s.get(param));
-                    }
-
-                }
-                Term body = def.getBody().applySubstitution(s).accept(termRewriter, subst);
-                return NestedFunctionDef.make(def.getSymbol(), newParams, body);
-            }
-
-            @Override
-            public Term visit(Fold fold, Substitution in) throws TypeException {
-                FunctionCall f = (FunctionCall) fold.getShamCall().accept(this, in);
-                return Fold.mk(f.getSymbol(), f.getArgs(), f.getFactory());
-            }
-
-        };
-
-    }
-
-    // XXX This and lookupType should be factored into a class for type
-    // substitutions.
-    public static void addBinding(TypeVar x, Type t, Map<TypeVar, Type> subst) {
-        if (t instanceof TypeVar) {
-            // Avoid cycles in map
-            TypeVar y = (TypeVar) t;
-            if (x.compareTo(y) > 0) {
-                subst.put(x, y);
-            } else if (x.compareTo(y) < 0) {
-                subst.put(y, x);
-            }
-        } else {
-            subst.put(x, t);
-        }
-    }
-
-    public static Type lookupType(Type t, Map<TypeVar, ? extends Type> subst) {
-        return t.accept(new TypeVisitor<Void, Type>() {
-
-            @Override
-            public Type visit(TypeVar typeVar, Void in) {
-                if (subst.containsKey(typeVar)) {
-                    return subst.get(typeVar).accept(this, in);
-                }
-                return typeVar;
-            }
-
-            @Override
-            public Type visit(AlgebraicDataType algebraicType, Void in) {
-                List<Type> args = Util.map(algebraicType.getTypeArgs(), t -> t.accept(this, in));
-                return AlgebraicDataType.make(algebraicType.getSymbol(), args);
-            }
-
-            @Override
-            public Type visit(OpaqueType opaqueType, Void in) {
-                return opaqueType;
-            }
-
-            @Override
-            public Type visit(TypeIndex typeIndex, Void in) {
-                return typeIndex;
-            }
-
-        }, null);
-    }
-
-    // Simplify type: make it a non-smt, non-sym type.
-    public static Type simplify(Type t) {
-        return t.accept(new TypeVisitor<Void, Type>() {
-
-            @Override
-            public Type visit(TypeVar typeVar, Void in) {
-                return typeVar;
-            }
-
-            @Override
-            public Type visit(AlgebraicDataType algebraicType, Void in) {
-                TypeSymbol sym = algebraicType.getSymbol();
-                List<Type> args = algebraicType.getTypeArgs();
-                if (sym.equals(BuiltInTypeSymbol.SMT_TYPE) || sym.equals(BuiltInTypeSymbol.SYM_TYPE)) {
-                    return args.get(0).accept(this, in);
-                }
-                args = Util.map(args, t -> t.accept(this, in));
-                return AlgebraicDataType.make(sym, args);
-            }
-
-            @Override
-            public Type visit(OpaqueType opaqueType, Void in) {
-                return opaqueType;
-            }
-
-            @Override
-            public Type visit(TypeIndex typeIndex, Void in) {
-                return typeIndex;
-            }
-
-        }, null);
-    }
+	private final Program<UserPredicate, BasicRule> prog;
+	private WellTypedProgram outputProgram;
+
+	public TypeChecker(Program<UserPredicate, BasicRule> prog2) {
+		this.prog = prog2;
+	}
+
+	public synchronized WellTypedProgram typeCheck() throws TypeException {
+		if (outputProgram != null) {
+			return outputProgram;
+		}
+		ExecutorService exec = Executors.newFixedThreadPool(Main.parallelism);
+		Map<RelationSymbol, Set<Term[]>> newFacts = typeCheckFacts(exec);
+		Map<FunctionSymbol, FunctionDef> newFuncs = typeCheckFunctions(exec);
+		FunctionDefManager dm = prog.getFunctionCallFactory().getDefManager();
+		for (FunctionDef func : newFuncs.values()) {
+			dm.reregister(func);
+		}
+		Map<RelationSymbol, Set<BasicRule>> newRules = typeCheckRules(exec);
+		UserPredicate newQuery = typeCheckQuery();
+		exec.shutdown();
+		outputProgram = new WellTypedProgram() {
+
+			@Override
+			public Set<FunctionSymbol> getFunctionSymbols() {
+				return dm.getFunctionSymbols();
+			}
+
+			@Override
+			public Set<RelationSymbol> getFactSymbols() {
+				return Collections.unmodifiableSet(newFacts.keySet());
+			}
+
+			@Override
+			public Set<RelationSymbol> getRuleSymbols() {
+				return Collections.unmodifiableSet(newRules.keySet());
+			}
+
+			@Override
+			public FunctionDef getDef(FunctionSymbol sym) {
+				return dm.lookup(sym);
+			}
+
+			@Override
+			public Set<Term[]> getFacts(RelationSymbol sym) {
+				if (!sym.isEdbSymbol()) {
+					throw new IllegalArgumentException();
+				}
+				if (!newFacts.containsKey(sym)) {
+					throw new IllegalArgumentException();
+				}
+				return newFacts.get(sym);
+			}
+
+			@Override
+			public Set<BasicRule> getRules(RelationSymbol sym) {
+				if (!sym.isIdbSymbol()) {
+					throw new IllegalArgumentException();
+				}
+				if (!newRules.containsKey(sym)) {
+					throw new IllegalArgumentException();
+				}
+				return newRules.get(sym);
+			}
+
+			@Override
+			public SymbolManager getSymbolManager() {
+				return prog.getSymbolManager();
+			}
+
+			@Override
+			public boolean hasQuery() {
+				return newQuery != null;
+			}
+
+			@Override
+			public UserPredicate getQuery() {
+				return newQuery;
+			}
+
+			@Override
+			public FunctionCallFactory getFunctionCallFactory() {
+				return prog.getFunctionCallFactory();
+			}
+
+			@Override
+			public Set<ConstructorSymbol> getUninterpretedFunctionSymbols() {
+				return prog.getUninterpretedFunctionSymbols();
+			}
+
+			@Override
+			public Set<TypeSymbol> getTypeSymbols() {
+				return prog.getTypeSymbols();
+			}
+
+		};
+		return outputProgram;
+	}
+
+	private UserPredicate typeCheckQuery() throws TypeException {
+		if (prog.hasQuery()) {
+			TypeCheckerContext ctx = new TypeCheckerContext();
+			return ctx.typeCheckQuery(prog.getQuery());
+		}
+		return null;
+	}
+
+	private static <K, V> Map<K, V> mapFromFutures(Map<K, Future<V>> futures) throws TypeException {
+		try {
+			return Util.fillMapWithFutures(futures, new HashMap<>());
+		} catch (InterruptedException | ExecutionException e) {
+			throw new TypeException(e);
+		}
+	}
+
+	private Map<RelationSymbol, Set<Term[]>> typeCheckFacts(ExecutorService exec) throws TypeException {
+		Map<RelationSymbol, Future<Set<Term[]>>> futures = new HashMap<>();
+		for (RelationSymbol sym : prog.getFactSymbols()) {
+			Future<Set<Term[]>> fut = exec.submit(new Callable<Set<Term[]>>() {
+
+				@Override
+				public Set<Term[]> call() throws Exception {
+					Set<Term[]> s = new HashSet<>();
+					TypeCheckerContext ctx = new TypeCheckerContext();
+					for (Term[] args : prog.getFacts(sym)) {
+						s.add(ctx.typeCheckFact(sym, args));
+					}
+					return s;
+				}
+
+			});
+			futures.put(sym, fut);
+		}
+		return mapFromFutures(futures);
+	}
+
+	private Map<RelationSymbol, Set<BasicRule>> typeCheckRules(ExecutorService exec) throws TypeException {
+		Map<RelationSymbol, Future<Set<BasicRule>>> futures = new HashMap<>();
+		for (RelationSymbol sym : prog.getRuleSymbols()) {
+			Future<Set<BasicRule>> fut = exec.submit(new Callable<Set<BasicRule>>() {
+
+				@Override
+				public Set<BasicRule> call() throws Exception {
+					Set<BasicRule> s = new HashSet<>();
+					for (BasicRule r : prog.getRules(sym)) {
+						TypeCheckerContext ctx = new TypeCheckerContext();
+						s.add(ctx.typeCheckRule(r));
+					}
+					return s;
+				}
+
+			});
+			futures.put(sym, fut);
+		}
+		return mapFromFutures(futures);
+	}
+
+	private Map<FunctionSymbol, FunctionDef> typeCheckFunctions(ExecutorService exec) throws TypeException {
+		Map<FunctionSymbol, Future<FunctionDef>> futures = new HashMap<>();
+		List<FunctionDef> nonUserFunctions = new ArrayList<>();
+		for (FunctionSymbol sym : prog.getFunctionSymbols()) {
+			FunctionDef def = prog.getDef(sym);
+			if (def instanceof UserFunctionDef) {
+				Future<FunctionDef> fut = exec.submit(() -> {
+					TypeCheckerContext ctx = new TypeCheckerContext();
+					try {
+						return ctx.typeCheckFunction((UserFunctionDef) def);
+					} catch (Throwable e) {
+						throw new TypeException("Problem type checking function: " + sym + "\n" + e.getMessage());
+					}
+				});
+				futures.put(sym, fut);
+			} else {
+				nonUserFunctions.add(def);
+			}
+		}
+		Map<FunctionSymbol, FunctionDef> m = mapFromFutures(futures);
+		for (FunctionDef def : nonUserFunctions) {
+			m.put(def.getSymbol(), def);
+		}
+		return m;
+	}
+
+	private class TypeCheckerContext {
+
+		private final Deque<Triple<Term, Type, Type>> constraints = new ArrayDeque<>();
+		private final Deque<Triple<Term, Type, Type>> formulaConstraints = new ArrayDeque<>();
+		private final Map<TypeVar, Type> typeVars = new HashMap<>();
+		private String error;
+
+		private Term rewriteTerm(Term t, Substitution m) throws TypeException {
+			return t.accept(termRewriter, m);
+		}
+
+		public Term[] typeCheckFact(RelationSymbol sym, Term[] args) throws TypeException {
+			Map<Var, Type> subst = new HashMap<>();
+			genConstraints(sym, args, subst);
+			if (!checkConstraints()) {
+				throw new TypeException("Type error in fact: " + UserPredicate.make(sym, args, false) + "\n" + error);
+			}
+			Substitution m = makeIndexSubstitution(subst);
+			try {
+				return Terms.mapExn(args, t -> rewriteTerm(t, m));
+			} catch (TypeException e) {
+				throw new TypeException(
+						"Problem with rewriting fact: " + UserPredicate.make(sym, args, false) + "\n" + e.getMessage());
+			}
+
+		}
+
+		private ComplexLiteral rewriteLiteral(ComplexLiteral l, Substitution m, Map<Var, Type> env)
+				throws TypeException {
+			try {
+				Term[] args = Terms.mapExn(l.getArgs(), t -> rewriteTerm(t, m));
+				return l.accept(new ComplexLiteralExnVisitor<Void, ComplexLiteral, TypeException>() {
+
+					@Override
+					public ComplexLiteral visit(UnificationPredicate pred, Void input) throws TypeException {
+						return UnificationPredicate.make(args[0], args[1], pred.isNegated());
+					}
+
+					@Override
+					public ComplexLiteral visit(UserPredicate pred, Void input) throws TypeException {
+						return UserPredicate.make(pred.getSymbol(), args, pred.isNegated());
+					}
+
+				}, null);
+			} catch (TypeException e) {
+				throw new TypeException("Problem with rewriting literal: " + l + "\n" + e.getMessage());
+			}
+		}
+
+		public UserPredicate typeCheckQuery(UserPredicate q) throws TypeException {
+			Map<Var, Type> subst = new HashMap<>();
+			genConstraints(q, subst);
+			if (!checkConstraints()) {
+				throw new TypeException("Type error in query: " + q + "\n" + error);
+			}
+			Substitution m = makeIndexSubstitution(subst);
+			try {
+				return (UserPredicate) rewriteLiteral(q, m, subst);
+			} catch (TypeException e) {
+				throw new TypeException("Problem with rewriting query: " + q + "\n" + e.getMessage());
+			}
+		}
+
+		public BasicRule typeCheckRule(Rule<UserPredicate, ComplexLiteral> r) throws TypeException {
+			Map<Var, Type> subst = new HashMap<>();
+			processAtoms(r, subst);
+			genConstraints(r.getHead(), subst);
+			if (!checkConstraints()) {
+				String msg = "Type error in rule:\n";
+				msg += r + "\n";
+				msg += error;
+				throw new TypeException(msg);
+			}
+			Substitution m = makeIndexSubstitution(subst);
+			UserPredicate newHead = (UserPredicate) rewriteLiteral(r.getHead(), m, subst);
+			try {
+				List<ComplexLiteral> newBody = new ArrayList<>();
+				for (ComplexLiteral a : r) {
+					newBody.add(rewriteLiteral(a, m, subst));
+				}
+				return BasicRule.make(newHead, newBody);
+			} catch (TypeException e) {
+				throw new TypeException("Problem with rewriting rule:\n" + r + "\n" + e.getMessage());
+			}
+		}
+
+		private Substitution makeIndexSubstitution(Map<Var, Type> subst) {
+			Substitution m = new SimpleSubstitution();
+			for (Map.Entry<Var, Type> e : subst.entrySet()) {
+				Var x = e.getKey();
+				Type t = lookupType(e.getValue());
+				if (t instanceof TypeIndex) {
+					int idx = ((TypeIndex) t).getIndex();
+					ConstructorSymbol csym = prog.getSymbolManager().lookupIndexConstructorSymbol(idx);
+					Term c = Constructors.make(csym, Terms.singletonArray(I32.make(idx)));
+					m.put(x, c);
+				}
+			}
+			return m;
+		}
+
+		public UserFunctionDef typeCheckFunction(UserFunctionDef functionDef) throws TypeException {
+			Map<Var, Type> subst = new HashMap<>();
+			genConstraints(functionDef, subst);
+			if (!checkConstraints()) {
+				throw new TypeException("Type error in function: " + functionDef.getSymbol() + "\n"
+						+ functionDef.getBody() + "\n" + error);
+			}
+			Substitution m = makeIndexSubstitution(subst);
+			try {
+				return UserFunctionDef.get(functionDef.getSymbol(), functionDef.getParams(),
+						rewriteTerm(functionDef.getBody(), m));
+			} catch (Throwable e) {
+				throw new TypeException("Problem with rewriting the function: " + functionDef.getSymbol() + "\n"
+						+ functionDef.getBody() + "\n" + e.getMessage());
+			}
+		}
+
+		private void processAtoms(Iterable<ComplexLiteral> atoms, Map<Var, Type> subst) {
+			for (ComplexLiteral a : atoms) {
+				genConstraints(a, subst);
+			}
+		}
+
+		private void genConstraints(RelationSymbol sym, Term[] args, Map<Var, Type> subst) {
+			FunctorType ftype = sym.getCompileTimeType().freshen();
+			assert ftype.getArgTypes().size() == args.length;
+			int i = 0;
+			for (Type type : ftype.getArgTypes()) {
+				genConstraints(args[i], type, subst, false);
+				++i;
+			}
+		}
+
+		private void genConstraints(ComplexLiteral a, Map<Var, Type> subst) {
+			a.accept(new ComplexLiteralVisitor<Void, Void>() {
+
+				@Override
+				public Void visit(UserPredicate normalAtom, Void in) {
+					genConstraints(normalAtom.getSymbol(), normalAtom.getArgs(), subst);
+					return null;
+				}
+
+				@Override
+				public Void visit(UnificationPredicate unifyAtom, Void in) {
+					TypeVar var = TypeVar.fresh();
+					genConstraints(unifyAtom.getLhs(), var, subst, false);
+					genConstraints(unifyAtom.getRhs(), var, subst, false);
+					return null;
+				}
+
+			}, null);
+		}
+
+		private void genConstraints(UserFunctionDef def, Map<Var, Type> subst) {
+			FunctionSymbol sym = def.getSymbol();
+			genConstraints(sym, def.getParams(), def.getBody(), subst);
+		}
+
+		private void genConstraints(FunctionSymbol sym, List<Var> params, Term body, Map<Var, Type> subst) {
+			FunctorType scheme = sym.getCompileTimeType().freshen();
+			Map<TypeVar, OpaqueType> opaqueTypes = new HashMap<>();
+			List<Type> argTypes = scheme.getArgTypes();
+			for (Type t : argTypes) {
+				addConstraint(null, t, mkTypeVarsOpaque(t, opaqueTypes), false);
+			}
+			Type r = scheme.getRetType();
+			addConstraint(null, r, mkTypeVarsOpaque(r, opaqueTypes), false);
+			for (int i = 0; i < params.size(); ++i) {
+				subst.put(params.get(i), argTypes.get(i));
+			}
+			genConstraints(body, r, subst, false);
+		}
+
+		private Type mkTypeVarsOpaque(Type t, Map<TypeVar, OpaqueType> subst) {
+			return t.accept(new TypeVisitor<Void, Type>() {
+				@Override
+				public Type visit(TypeVar typeVar, Void in) {
+					return Util.lookupOrCreate(subst, typeVar, OpaqueType::get);
+				}
+
+				@Override
+				public Type visit(AlgebraicDataType algebraicType, Void in) {
+					List<Type> newArgs = algebraicType.getTypeArgs().stream().map(t -> t.accept(this, null))
+							.collect(Collectors.toList());
+					return AlgebraicDataType.make(algebraicType.getSymbol(), newArgs);
+				}
+
+				@Override
+				public Type visit(OpaqueType opaqueType, Void in) {
+					return opaqueType;
+				}
+
+				@Override
+				public Type visit(TypeIndex typeIndex, Void in) {
+					return typeIndex;
+				}
+			}, null);
+		}
+
+		private void genConstraintsForExpr(Expr e, Type exprType, Map<Var, Type> varTypes, boolean inFormula) {
+			e.accept(new ExprVisitor<Void, Void>() {
+
+				@Override
+				public Void visit(MatchExpr matchExpr, Void in) {
+					assert !inFormula;
+					TypeVar guardType = TypeVar.fresh();
+					Term guard = matchExpr.getMatchee();
+					genConstraints(guard, guardType, varTypes, inFormula);
+					for (MatchClause cl : matchExpr) {
+						genConstraints(cl.getLhs(), guardType, varTypes, inFormula);
+						genConstraints(cl.getRhs(), exprType, varTypes, inFormula);
+					}
+					return null;
+				}
+
+				@Override
+				public Void visit(FunctionCall funcCall, Void in) {
+					genConstraintsForFunctionCall(funcCall, exprType, varTypes, inFormula);
+					return null;
+				}
+
+				@Override
+				public Void visit(LetFunExpr letFun, Void in) {
+					assert !inFormula;
+					for (NestedFunctionDef def : letFun.getDefs()) {
+						def = def.freshen();
+						genConstraints(def.getSymbol(), def.getParams(), def.getBody(), varTypes);
+					}
+					genConstraints(letFun.getLetBody(), exprType, varTypes, inFormula);
+					return null;
+				}
+
+				@Override
+				public Void visit(Fold fold, Void in) {
+					assert !inFormula;
+					FunctionSymbol sym = fold.getFunction();
+					Term[] args = fold.getArgs();
+					assert sym.getArity() == args.length && args.length == 2;
+					Type itemType = TypeVar.fresh();
+					Type listType = BuiltInTypes.list(itemType);
+					FunctorType funType = sym.getCompileTimeType().freshen();
+					genConstraints(args[0], exprType, varTypes, inFormula);
+					genConstraints(args[0], funType.getArgTypes().get(0), varTypes, inFormula);
+					genConstraints(args[1], listType, varTypes, inFormula);
+					addConstraint(args[1], itemType, funType.getArgTypes().get(1), inFormula);
+					addConstraint(fold, exprType, funType.getRetType(), inFormula);
+					return null;
+				}
+
+			}, null);
+		}
+
+		private void addConstraint(Term t, Type t1, Type t2, boolean inFormula) {
+			Triple<Term, Type, Type> constraint = new Triple<>(t, t1, t2);
+			if (inFormula) {
+				formulaConstraints.add(constraint);
+			} else {
+				constraints.add(constraint);
+			}
+		}
+
+		private void genConstraints(Term t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
+			t.accept(new TermVisitor<Void, Void>() {
+
+				@Override
+				public Void visit(Var t, Void in) {
+					genConstraintsForVar(t, ttype, subst, inFormula);
+					return null;
+				}
+
+				@Override
+				public Void visit(Constructor t, Void in) {
+					genConstraintsForConstructor(t, ttype, subst, inFormula);
+					return null;
+				}
+
+				@Override
+				public Void visit(Primitive<?> prim, Void in) {
+					genConstraintsForPrimitive(prim, ttype, inFormula);
+					return null;
+				}
+
+				@Override
+				public Void visit(Expr expr, Void in) {
+					genConstraintsForExpr(expr, ttype, subst, inFormula);
+					return null;
+				}
+
+			}, null);
+		}
+
+		private void genConstraintsForVar(Var t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
+			Type s = Util.lookupOrCreate(subst, t, () -> {
+				Type x = TypeVar.fresh();
+				if (inFormula) {
+					x = BuiltInTypes.smt(x);
+				}
+				return x;
+			});
+			addConstraint(t, s, ttype, inFormula);
+		}
+
+		private void genConstraintsForPrimitive(Primitive<?> t, Type ttype, boolean inFormula) {
+			addConstraint(t, ttype, t.getType().freshen(), inFormula);
+		}
+
+		private void genConstraintsForConstructor(Constructor t, Type ttype, Map<Var, Type> subst, boolean inFormula) {
+			boolean wasInFormula = inFormula;
+			ConstructorSymbol cnstrSym = t.getSymbol();
+			if (cnstrSym.equals(BuiltInConstructorSymbol.ENTER_FORMULA)) {
+				assert !wasInFormula;
+				inFormula = true;
+			}
+			if (cnstrSym.equals(BuiltInConstructorSymbol.EXIT_FORMULA)) {
+				inFormula = false;
+			}
+			FunctorType cnstrType = cnstrSym.getCompileTimeType();
+			if (!(cnstrSym instanceof ParameterizedConstructorSymbol)) {
+				cnstrType = cnstrType.freshen();
+			}
+			Term[] args = t.getArgs();
+			List<Type> argTypes = cnstrType.getArgTypes();
+			for (int i = 0; i < args.length; ++i) {
+				Type argType = argTypes.get(i);
+				genConstraints(args[i], argType, subst, inFormula);
+			}
+			addConstraint(t, cnstrType.getRetType(), ttype, wasInFormula);
+		}
+
+		private void genConstraintsForFunctionCall(FunctionCall function, Type ttype, Map<Var, Type> subst,
+				boolean inFormula) {
+			FunctorType funType = (FunctorType) function.getSymbol().getCompileTimeType().freshen();
+			Term[] args = function.getArgs();
+			List<Type> argTypes = funType.getArgTypes();
+			for (int i = 0; i < args.length; ++i) {
+				genConstraints(args[i], argTypes.get(i), subst, inFormula);
+			}
+			addConstraint(function, funType.getRetType(), ttype, inFormula);
+		}
+
+		private boolean checkConstraints() {
+			Set<Type> typesInFormulae = new HashSet<>();
+			for (Triple<Term, Type, Type> p : formulaConstraints) {
+				typesInFormulae.add(p.second);
+			}
+			// First try to unify constraints generated outside of formula and then
+			// constraints generated inside formula. This might generate more constraints,
+			// but all of them will be treated as being in a non-formula context.
+			boolean ok = checkConstraints(false) && checkConstraints(true) && checkConstraints(false);
+			assert !ok || constraints.isEmpty() && formulaConstraints.isEmpty();
+			ok = ok && checkTypesInFormulae(typesInFormulae);
+			return ok;
+		}
+
+		private boolean checkTypesInFormulae(Set<Type> types) {
+			for (Type ty : types) {
+				if (!checkTypeInFormula(ty)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		private boolean checkTypeInFormula(Type ty) {
+			ty = lookupType(ty);
+			if (!Types.isSmtRepresentable(ty)) {
+				error = "Terms of the following type are not allowed in formulas: " + ty
+						+ "\nThe following types can lead to this error: model, smt_pattern, smt_wrapped_var,"
+						+ " and type variables that are not proven to contain a safe type";
+				return false;
+			}
+			return true;
+		}
+
+		private boolean checkConstraints(boolean inFormulaContext) {
+			Deque<Triple<Term, Type, Type>> q = inFormulaContext ? formulaConstraints : constraints;
+			while (!q.isEmpty()) {
+				Triple<Term, Type, Type> constraint = q.pop();
+				Type type1 = lookupType(constraint.second);
+				Type type2 = lookupType(constraint.third);
+				if (inFormulaContext) {
+					type1 = simplify(type1);
+					type2 = simplify(type2);
+				}
+				if (type1.isVar() || type2.isVar()) {
+					if (!handleVars(type1, type2)) {
+						return false;
+					}
+				} else if (!unify(constraint.first, type1, type2)) {
+					error = "Cannot unify " + type1 + " and " + type2;
+					error += "\nProblematic term: " + constraint.first;
+					return false;
+				}
+			}
+			return true;
+		}
+
+		private boolean handleVars(Type type1, Type type2) {
+			if (type1.isVar() && type2.isVar()) {
+				addBinding((TypeVar) type1, type2, typeVars);
+				return true;
+			}
+
+			TypeVar var;
+			Type other;
+			if (type1.isVar()) {
+				var = (TypeVar) type1;
+				other = type2;
+			} else {
+				assert type2.isVar();
+				var = (TypeVar) type2;
+				other = type1;
+			}
+			// Occurs check
+			if (Types.getTypeVars(other).contains(var)) {
+				return false;
+			}
+			typeVars.put(var, other);
+			return true;
+		}
+
+		private boolean unify(Term t, Type type1, Type type2) {
+			return type1.accept(new TypeVisitor<Type, Boolean>() {
+
+				@Override
+				public Boolean visit(TypeVar typeVar, Type other) {
+					throw new AssertionError("unreachable");
+				}
+
+				@Override
+				public Boolean visit(AlgebraicDataType typeRef, Type other) {
+					if (!(other instanceof AlgebraicDataType)) {
+						return false;
+					}
+					AlgebraicDataType otherTypeRef = (AlgebraicDataType) other;
+					if (!typeRef.getSymbol().equals(otherTypeRef.getSymbol())) {
+						return false;
+					}
+					List<Type> args1 = typeRef.getTypeArgs();
+					List<Type> args2 = otherTypeRef.getTypeArgs();
+					for (int i = 0; i < args1.size(); ++i) {
+						addConstraint(t, args1.get(i), args2.get(i), false);
+					}
+					return true;
+				}
+
+				@Override
+				public Boolean visit(OpaqueType opaqueType, Type other) {
+					return opaqueType.equals(other);
+				}
+
+				@Override
+				public Boolean visit(TypeIndex typeIndex, Type other) {
+					return typeIndex.equals(other);
+				}
+
+			}, type2);
+		}
+
+		private Type lookupType(Type t) {
+			return TypeChecker.lookupType(t, typeVars);
+		}
+
+		private final TermVisitorExn<Substitution, Term, TypeException> termRewriter = new TermVisitorExn<Substitution, Term, TypeException>() {
+
+			@Override
+			public Term visit(Var x, Substitution subst) throws TypeException {
+				if (subst.containsKey(x)) {
+					return subst.get(x);
+				}
+				return x;
+			}
+
+			@Override
+			public Term visit(Constructor c, Substitution subst) throws TypeException {
+				ConstructorSymbol sym = c.getSymbol();
+				if (sym.equals(BuiltInConstructorSymbol.ENTER_FORMULA)
+						|| sym.equals(BuiltInConstructorSymbol.EXIT_FORMULA)) {
+					return c.getArgs()[0].accept(this, subst);
+				}
+				if (sym instanceof ParameterizedConstructorSymbol) {
+					try {
+						sym = (ConstructorSymbol) handleParameterizedSymbol((ParameterizedConstructorSymbol) sym);
+					} catch (TypeException e) {
+						throw new TypeException("Problem with rewriting term " + c + ":\n" + e.getMessage());
+					}
+				}
+				Term[] args = c.getArgs();
+				Term[] newArgs = new Term[args.length];
+				for (int i = 0; i < args.length; ++i) {
+					newArgs[i] = args[i].accept(this, subst);
+				}
+				return Constructors.make(sym, newArgs);
+			}
+
+			@Override
+			public Term visit(Primitive<?> p, Substitution subst) throws TypeException {
+				return p;
+			}
+
+			@Override
+			public Term visit(Expr e, Substitution subst) throws TypeException {
+				return e.accept(exprRewriter, subst);
+			}
+
+		};
+
+		private ParameterizedSymbol handleParameterizedSymbol(ParameterizedSymbol sym) throws TypeException {
+			List<Param> params = sym.getArgs();
+			params = Param.applySubst(params, typeVars);
+			for (Param param : params) {
+				if (Types.containsTypeVarOrOpaqueType(param.getType())) {
+					throw new TypeException("Cannot instantiate parameterized symbol " + sym
+							+ " with a parameter that is not ground: " + param);
+				}
+			}
+			return sym.copyWithNewArgs(params).makeFinal();
+		}
+
+		private final Map<FunctionSymbol, FunctionSymbol> topLevelSymbolOfNestedFunction = new HashMap<>();
+		private final Map<FunctionSymbol, List<Var>> capturedVarsOfNestedFunction = new HashMap<>();
+
+		private final ExprVisitorExn<Substitution, Term, TypeException> exprRewriter = new ExprVisitorExn<Substitution, Term, TypeException>() {
+
+			@Override
+			public Term visit(MatchExpr matchExpr, Substitution subst) throws TypeException {
+				Term scrutinee = matchExpr.getMatchee().accept(termRewriter, subst);
+				List<MatchClause> clauses = new ArrayList<>();
+				for (MatchClause cl : matchExpr) {
+					Term lhs = cl.getLhs().accept(termRewriter, subst);
+					Term rhs = cl.getRhs().accept(termRewriter, subst);
+					clauses.add(MatchClause.make(lhs, rhs));
+				}
+				return MatchExpr.make(scrutinee, clauses);
+			}
+
+			@Override
+			public Term visit(FunctionCall funcCall, Substitution subst) throws TypeException {
+				FunctionSymbol sym = funcCall.getSymbol();
+				List<Var> capturedVars = Collections.emptyList();
+				if (topLevelSymbolOfNestedFunction.containsKey(sym)) {
+					sym = topLevelSymbolOfNestedFunction.get(sym);
+					capturedVars = capturedVarsOfNestedFunction.get(sym);
+				}
+				Term[] args = funcCall.getArgs();
+				Term[] newArgs = new Term[args.length + capturedVars.size()];
+				int i = 0;
+				for (; i < args.length; ++i) {
+					newArgs[i] = args[i].accept(termRewriter, subst);
+				}
+				for (Var x : capturedVars) {
+					newArgs[i] = x;
+					++i;
+				}
+				return prog.getFunctionCallFactory().make(sym, newArgs);
+			}
+
+			@Override
+			public Term visit(LetFunExpr letFun, Substitution in) throws TypeException {
+				Set<NestedFunctionDef> defs = new HashSet<>();
+				Set<Var> capturedVarSet = new HashSet<>();
+				for (NestedFunctionDef def : letFun.getDefs()) {
+					def = firstRewritingPass(def, in);
+					defs.add(def);
+					Set<Var> s = def.getBody().varSet();
+					s.removeAll(def.getParams());
+					capturedVarSet.addAll(s);
+				}
+				List<Var> capturedVars = new ArrayList<>(capturedVarSet);
+				for (NestedFunctionDef def : defs) {
+					FunctionSymbol oldSym = def.getSymbol();
+					int newArity = oldSym.getArity() + capturedVarSet.size();
+					FunctionSymbol newSym = prog.getSymbolManager().createFunctionSymbol(oldSym + "$toplevel", newArity,
+							null);
+					topLevelSymbolOfNestedFunction.put(oldSym, newSym);
+					capturedVarsOfNestedFunction.put(newSym, capturedVars);
+				}
+				for (NestedFunctionDef def : defs) {
+					FunctionSymbol sym = topLevelSymbolOfNestedFunction.get(def.getSymbol());
+					List<Var> params = new ArrayList<>(def.getParams());
+					params.addAll(capturedVars);
+					FunctionDef newDef = UserFunctionDef.get(sym, params, def.getBody().accept(termRewriter, in));
+					prog.getFunctionCallFactory().getDefManager().register(newDef);
+				}
+				return letFun.getLetBody().accept(termRewriter, in);
+			}
+
+			NestedFunctionDef firstRewritingPass(NestedFunctionDef def, Substitution subst) throws TypeException {
+				Substitution s = new SimpleSubstitution();
+				List<Var> newParams = new ArrayList<>();
+				for (Var param : def.getParams()) {
+					if (!s.containsKey(param)) {
+						Var newParam = Var.fresh(param.toString());
+						s.put(param, newParam);
+						newParams.add(newParam);
+					} else {
+						newParams.add((Var) s.get(param));
+					}
+
+				}
+				Term body = def.getBody().applySubstitution(s).accept(termRewriter, subst);
+				return NestedFunctionDef.make(def.getSymbol(), newParams, body);
+			}
+
+			@Override
+			public Term visit(Fold fold, Substitution in) throws TypeException {
+				FunctionCall f = (FunctionCall) fold.getShamCall().accept(this, in);
+				return Fold.mk(f.getSymbol(), f.getArgs(), f.getFactory());
+			}
+
+		};
+
+	}
+
+	// XXX This and lookupType should be factored into a class for type
+	// substitutions.
+	public static void addBinding(TypeVar x, Type t, Map<TypeVar, Type> subst) {
+		if (t instanceof TypeVar) {
+			// Avoid cycles in map
+			TypeVar y = (TypeVar) t;
+			if (x.compareTo(y) > 0) {
+				subst.put(x, y);
+			} else if (x.compareTo(y) < 0) {
+				subst.put(y, x);
+			}
+		} else {
+			subst.put(x, t);
+		}
+	}
+
+	public static Type lookupType(Type t, Map<TypeVar, ? extends Type> subst) {
+		return t.accept(new TypeVisitor<Void, Type>() {
+
+			@Override
+			public Type visit(TypeVar typeVar, Void in) {
+				if (subst.containsKey(typeVar)) {
+					return subst.get(typeVar).accept(this, in);
+				}
+				return typeVar;
+			}
+
+			@Override
+			public Type visit(AlgebraicDataType algebraicType, Void in) {
+				List<Type> args = Util.map(algebraicType.getTypeArgs(), t -> t.accept(this, in));
+				return AlgebraicDataType.make(algebraicType.getSymbol(), args);
+			}
+
+			@Override
+			public Type visit(OpaqueType opaqueType, Void in) {
+				return opaqueType;
+			}
+
+			@Override
+			public Type visit(TypeIndex typeIndex, Void in) {
+				return typeIndex;
+			}
+
+		}, null);
+	}
+
+	// Simplify type: make it a non-smt, non-sym type.
+	public static Type simplify(Type t) {
+		return t.accept(new TypeVisitor<Void, Type>() {
+
+			@Override
+			public Type visit(TypeVar typeVar, Void in) {
+				return typeVar;
+			}
+
+			@Override
+			public Type visit(AlgebraicDataType algebraicType, Void in) {
+				TypeSymbol sym = algebraicType.getSymbol();
+				List<Type> args = algebraicType.getTypeArgs();
+				if (sym.equals(BuiltInTypeSymbol.SMT_TYPE) || sym.equals(BuiltInTypeSymbol.SYM_TYPE)) {
+					return args.get(0).accept(this, in);
+				}
+				args = Util.map(args, t -> t.accept(this, in));
+				return AlgebraicDataType.make(sym, args);
+			}
+
+			@Override
+			public Type visit(OpaqueType opaqueType, Void in) {
+				return opaqueType;
+			}
+
+			@Override
+			public Type visit(TypeIndex typeIndex, Void in) {
+				return typeIndex;
+			}
+
+		}, null);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/TypeException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/TypeException.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 /**
  * An exception signifying a type error.
  *
@@ -38,8 +37,7 @@ public class TypeException extends Exception {
 	/**
 	 * Constructs an exception signifying a type error.
 	 * 
-	 * @param message
-	 *            the error message
+	 * @param message the error message
 	 */
 	public TypeException(String message) {
 		super(message);
@@ -48,8 +46,7 @@ public class TypeException extends Exception {
 	/**
 	 * Constructs an exception signifying a type error.
 	 * 
-	 * @param cause
-	 *            the exception that caused this exception
+	 * @param cause the exception that caused this exception
 	 */
 	public TypeException(Throwable cause) {
 		super(cause);
@@ -58,10 +55,8 @@ public class TypeException extends Exception {
 	/**
 	 * Constructs an exception signifying a type error.
 	 * 
-	 * @param message
-	 *            the error message
-	 * @param cause
-	 *            the exception that caused this exception
+	 * @param message the error message
+	 * @param cause   the exception that caused this exception
 	 */
 	public TypeException(String message, Throwable cause) {
 		super(message, cause);
@@ -70,14 +65,10 @@ public class TypeException extends Exception {
 	/**
 	 * Constructs an exception signifying a type error.
 	 * 
-	 * @param message
-	 *            the error message
-	 * @param cause
-	 *            the exception that caused this exception
-	 * @param enableSuppression
-	 *            whether or not suppression is enabled or disabled
-	 * @param writableStackTrace
-	 *            whether or not the stack trace should be writable
+	 * @param message            the error message
+	 * @param cause              the exception that caused this exception
+	 * @param enableSuppression  whether or not suppression is enabled or disabled
+	 * @param writableStackTrace whether or not the stack trace should be writable
 	 */
 	public TypeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/TypeManager.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/TypeManager.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/Types.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/Types.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,714 +45,718 @@ import edu.harvard.seas.pl.formulog.util.Util;
 
 public final class Types {
 
-    private Types() {
-        throw new AssertionError();
-    }
+	private Types() {
+		throw new AssertionError();
+	}
 
-    public interface Type {
+	public interface Type {
 
-        <I, O> O accept(TypeVisitor<I, O> visitor, I in);
+		<I, O> O accept(TypeVisitor<I, O> visitor, I in);
 
-        Type applySubst(Map<TypeVar, ? extends Type> subst);
+		Type applySubst(Map<TypeVar, ? extends Type> subst);
 
-        Type freshen();
+		Type freshen();
 
-        default boolean isVar() {
-            return false;
-        }
+		default boolean isVar() {
+			return false;
+		}
 
-        default boolean isIndex() {
-            return false;
-        }
+		default boolean isIndex() {
+			return false;
+		}
 
-    }
+	}
 
-    public interface TypeVisitor<I, O> {
+	public interface TypeVisitor<I, O> {
 
-        O visit(TypeVar typeVar, I in);
+		O visit(TypeVar typeVar, I in);
 
-        O visit(AlgebraicDataType algebraicType, I in);
+		O visit(AlgebraicDataType algebraicType, I in);
 
-        O visit(OpaqueType opaqueType, I in);
+		O visit(OpaqueType opaqueType, I in);
 
-        O visit(TypeIndex typeIndex, I in);
+		O visit(TypeIndex typeIndex, I in);
 
-    }
+	}
 
-    public static class TypeVar implements Type, Comparable<TypeVar> {
+	public static class TypeVar implements Type, Comparable<TypeVar> {
 
-        private static final Map<String, Integer> memo = new ConcurrentHashMap<>();
-        private static final AtomicInteger cnt = new AtomicInteger();
-
-        private final int id;
-
-        private TypeVar(int id) {
-            this.id = id;
-        }
-
-        public static TypeVar get(String id) {
-            int i = Util.lookupOrCreate(memo, id, cnt::getAndIncrement);
-            return new TypeVar(i);
-        }
-
-        @Override
-        public String toString() {
-            return "'_" + id;
-        }
-
-        @Override
-        public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
-            return visitor.visit(this, in);
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + id;
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            TypeVar other = (TypeVar) obj;
-            return id == other.id;
-        }
-
-        @Override
-        public Type applySubst(Map<TypeVar, ? extends Type> subst) {
-            return TypeChecker.lookupType(this, subst);
-        }
-
-        public static TypeVar fresh() {
-            return new TypeVar(cnt.getAndIncrement());
-        }
-
-        @Override
-        public boolean isVar() {
-            return true;
-        }
-
-        @Override
-        public int compareTo(TypeVar o) {
-            return Integer.compare(this.id, o.id);
-        }
-
-        @Override
-        public Type freshen() {
-            return fresh();
-        }
-
-    }
-
-    private static List<Type> freshen(List<Type> types) {
-        return types.stream().map(Type::freshen).collect(Collectors.toList());
-    }
-
-    public static class AlgebraicDataType implements Type, Iterable<Type> {
-
-        private final TypeSymbol sym;
-        private final List<Type> typeArgs;
-        private final AtomicReference<Set<ConstructorScheme>> constructors = new AtomicReference<>();
-
-        private static final Map<Symbol, Pair<List<TypeVar>, Set<ConstructorScheme>>> memo = new ConcurrentHashMap<>();
-
-        private AlgebraicDataType(TypeSymbol sym, List<Type> typeArgs) {
-            this.sym = sym;
-            this.typeArgs = new ArrayList<>(typeArgs);
-            check();
-        }
-
-        private void check() {
-            if (sym.getArity() != typeArgs.size()) {
-                throw new IllegalArgumentException("Arity of symbol " + sym + " (" + sym.getArity()
-                        + ") does not match number of provided type parameters: " + typeArgs);
-            }
-            if (sym.isAlias()) {
-                throw new IllegalArgumentException("Cannot create a type with alias symbol " + sym);
-            }
-            if (sym instanceof BuiltInTypeSymbol) {
-                switch ((BuiltInTypeSymbol) sym) {
-                    case ARRAY_TYPE:
-                    case BOOL_TYPE:
-                    case CMP_TYPE:
-                    case INT_TYPE:
-                    case LIST_TYPE:
-                    case MODEL_TYPE:
-                    case OPTION_TYPE:
-                    case SMT_PATTERN_TYPE:
-                    case SMT_WRAPPED_VAR_TYPE:
-                    case STRING_TYPE:
-                    case OPAQUE_SET:
-                        break;
-                    case BV:
-                    case FP:
-                        for (Type arg : typeArgs) {
-                            if (!arg.isVar() && !(arg instanceof TypeIndex)) {
-                                throw new IllegalArgumentException("Cannot instantiate built-in type " + sym + " with type argument " + arg);
-                            }
-                        }
-                        break;
-                    case SMT_TYPE:
-                    case SYM_TYPE:
-                        for (Type arg : typeArgs) {
-                            if (!mayBePreSmtType(arg)) {
-                                throw new IllegalArgumentException("Cannot instantiate built-in type " + sym + " with type argument " + arg);
-                            }
-                        }
-                        break;
-                    default:
-                        throw new AssertionError("impossible");
-                }
-            }
-        }
-
-        public static AlgebraicDataType makeWithFreshArgs(TypeSymbol sym) {
-            List<Type> typeArgs = new ArrayList<>();
-            for (int i = 0; i < sym.getArity(); ++i) {
-                typeArgs.add(TypeVar.fresh());
-            }
-            return make(sym, typeArgs);
-        }
-
-        public static AlgebraicDataType make(TypeSymbol sym, Type... typeArgs) {
-            return make(sym, Arrays.asList(typeArgs));
-        }
-
-        public static AlgebraicDataType make(TypeSymbol sym, List<Type> typeArgs) {
-            return new AlgebraicDataType(sym, typeArgs);
-        }
-
-        public static void setConstructors(TypeSymbol sym, List<TypeVar> typeParams,
-                                           Collection<ConstructorScheme> constructors) {
-            if (sym.isAlias()) {
-                throw new IllegalArgumentException("Cannot set constructors for type alias symbol " + sym + ".");
-            }
-            if (typeParams.size() != (new HashSet<>(typeParams).size())) {
-                throw new IllegalArgumentException("Each type variable must be unique.");
-            }
-            if (memo.put(sym, new Pair<>(typeParams, new HashSet<>(constructors))) != null) {
-                throw new IllegalStateException("Cannot set the constructors for a type multiple times.");
-            }
-        }
-
-        public boolean hasConstructors() {
-            return memo.containsKey(sym);
-        }
-
-        public Set<ConstructorScheme> getConstructors() {
-            Set<ConstructorScheme> s = constructors.get();
-            if (s == null) {
-                Pair<List<TypeVar>, Set<ConstructorScheme>> p = memo.get(sym);
-                if (p == null) {
-                    throw new IllegalStateException("No constructors have been set for symbol " + sym + ".");
-                }
-                List<TypeVar> params = p.fst();
-                Map<TypeVar, Type> subst = new HashMap<>();
-                for (int i = 0; i < params.size(); ++i) {
-                    TypeVar x = params.get(i);
-                    Type t = typeArgs.get(i);
-                    // XXX This is to avoid cycles in subst, but is obviously fragile
-                    if (!x.equals(t)) {
-                        subst.put(x, t);
-                    }
-                }
-                s = new HashSet<>();
-                for (ConstructorScheme c : p.snd()) {
-                    List<Type> newArgs = new ArrayList<>();
-                    for (Type t : c.getTypeArgs()) {
-                        newArgs.add(t.applySubst(subst));
-                    }
-                    s.add(new ConstructorScheme(c.getSymbol(), newArgs, c.getGetterSymbols()));
-                }
-                if (!constructors.compareAndSet(null, s)) {
-                    s = constructors.get();
-                }
-            }
-            return s;
-        }
-
-        public TypeSymbol getSymbol() {
-            return sym;
-        }
-
-        @Override
-        public Iterator<Type> iterator() {
-            return typeArgs.iterator();
-        }
-
-        @Override
-        public String toString() {
-            if (sym.equals(BuiltInTypeSymbol.BV) || sym.equals(BuiltInTypeSymbol.FP)) {
-                return toStringBvOrFp();
-            }
-            if (typeArgs.isEmpty()) {
-                return sym.toString();
-            }
-            if (typeArgs.size() == 1) {
-                return typeArgs.get(0) + " " + sym;
-            }
-            StringBuilder sb = new StringBuilder("(");
-            Iterator<Type> it = typeArgs.iterator();
-            sb.append(it.next());
-            while (it.hasNext()) {
-                sb.append(", ").append(it.next());
-            }
-            sb.append(") ").append(sym);
-            return sb.toString();
-        }
-
-        private String toStringBvOrFp() {
-            StringBuilder sb = new StringBuilder(sym.toString());
-            sb.append("[");
-            for (Iterator<Type> it = typeArgs.iterator(); it.hasNext(); ) {
-                Type arg = it.next();
-                if (arg instanceof TypeIndex) {
-                    sb.append(((TypeIndex) arg).getIndex());
-                } else {
-                    assert arg.isVar();
-                    sb.append(arg);
-                }
-                if (it.hasNext()) {
-                    sb.append(", ");
-                }
-            }
-            return sb + "]";
-        }
-
-        @Override
-        public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
-            return visitor.visit(this, in);
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((sym == null) ? 0 : sym.hashCode());
-            result = prime * result + ((typeArgs == null) ? 0 : typeArgs.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            AlgebraicDataType other = (AlgebraicDataType) obj;
-            if (sym == null) {
-                if (other.sym != null)
-                    return false;
-            } else if (!sym.equals(other.sym))
-                return false;
-            if (typeArgs == null) {
-                return other.typeArgs == null;
-            } else return typeArgs.equals(other.typeArgs);
-        }
-
-        public List<Type> getTypeArgs() {
-            return typeArgs;
-        }
-
-        @Override
-        public Type applySubst(Map<TypeVar, ? extends Type> subst) {
-            List<Type> newTypes = new ArrayList<>();
-            for (Type t : typeArgs) {
-                newTypes.add(t.applySubst(subst));
-            }
-            return make(sym, newTypes);
-        }
-
-        @Override
-        public Type freshen() {
-            return make(sym, Types.freshen(typeArgs));
-        }
-
-        public static class ConstructorScheme {
-
-            private final ConstructorSymbol sym;
-            private final List<Type> typeArgs;
-            private final List<ConstructorSymbol> getterSyms;
-
-            public ConstructorScheme(ConstructorSymbol sym, List<Type> typeArgs, List<ConstructorSymbol> getterSyms) {
-                this.sym = sym;
-                this.typeArgs = typeArgs;
-                this.getterSyms = getterSyms;
-                assert sym != null;
-            }
-
-            public ConstructorSymbol getSymbol() {
-                return sym;
-            }
-
-            public List<Type> getTypeArgs() {
-                return typeArgs;
-            }
-
-            public List<ConstructorSymbol> getGetterSymbols() {
-                return getterSyms;
-            }
-
-            @Override
-            public int hashCode() {
-                final int prime = 31;
-                int result = 1;
-                result = prime * result + ((getterSyms == null) ? 0 : getterSyms.hashCode());
-                result = prime * result + sym.hashCode();
-                result = prime * result + ((typeArgs == null) ? 0 : typeArgs.hashCode());
-                return result;
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                if (this == obj)
-                    return true;
-                if (obj == null)
-                    return false;
-                if (getClass() != obj.getClass())
-                    return false;
-                ConstructorScheme other = (ConstructorScheme) obj;
-                if (getterSyms == null) {
-                    if (other.getterSyms != null)
-                        return false;
-                } else if (!getterSyms.equals(other.getterSyms))
-                    return false;
-                if (!sym.equals(other.sym))
-                    return false;
-                if (typeArgs == null) {
-                    return other.typeArgs == null;
-                } else return typeArgs.equals(other.typeArgs);
-            }
-
-        }
-
-    }
-
-    public static class OpaqueType implements Type {
-        /*
-         * This class is used (exclusively) during type checking.
-         */
-
-        private static final AtomicInteger cnt = new AtomicInteger();
-        private final int id;
-
-        private OpaqueType() {
-            id = cnt.getAndIncrement();
-        }
-
-        public static OpaqueType get() {
-            return new OpaqueType();
-        }
-
-        @Override
-        public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
-            return visitor.visit(this, in);
-        }
-
-        @Override
-        public Type applySubst(Map<TypeVar, ? extends Type> subst) {
-            return this;
-        }
-
-        @Override
-        public String toString() {
-            return "Opaque" + id;
-        }
-
-        @Override
-        public Type freshen() {
-            return get();
-        }
-
-    }
-
-    public static class TypeIndex implements Type {
-
-        private final int index;
-
-        private TypeIndex(int index) {
-            this.index = index;
-        }
-
-        public static TypeIndex make(int index) {
-            return new TypeIndex(index);
-        }
-
-        @Override
-        public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
-            return visitor.visit(this, in);
-        }
-
-        @Override
-        public Type applySubst(Map<TypeVar, ? extends Type> subst) {
-            return this;
-        }
-
-        @Override
-        public Type freshen() {
-            return this;
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + index;
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            TypeIndex other = (TypeIndex) obj;
-            return index == other.index;
-        }
-
-        @Override
-        public String toString() {
-            return "[" + index + "]";
-        }
-
-        @Override
-        public boolean isIndex() {
-            return true;
-        }
-
-        public int getIndex() {
-            return index;
-        }
-
-        public List<TypeIndex> expandAsFpIndex() {
-            switch (index) {
-                case 16:
-                    return Arrays.asList(make(5), make(11));
-                case 32:
-                    return Arrays.asList(make(8), make(24));
-                case 64:
-                    return Arrays.asList(make(11), make(53));
-                case 128:
-                    return Arrays.asList(make(15), make(113));
-                default:
-                    throw new IllegalArgumentException("Illegal floating point width alias: " + index);
-            }
-        }
-
-    }
-
-    // Helpers /////////////////////////////////////////////////////////////////
-
-    public static Set<TypeVar> getTypeVars(Type t) {
-        return getTypeVars(Collections.singletonList(t));
-    }
-
-    public static Set<TypeVar> getTypeVars(Collection<Type> t) {
-        Set<TypeVar> set = new HashSet<>();
-        getTypeVars(t, set);
-        return set;
-    }
-
-    private static void getTypeVars(Type t, Set<TypeVar> acc) {
-        t.accept(new TypeVisitor<Void, Void>() {
-
-            @Override
-            public Void visit(TypeVar typeVar, Void in) {
-                acc.add(typeVar);
-                return null;
-            }
-
-            @Override
-            public Void visit(OpaqueType opaqueType, Void in) {
-                return null;
-            }
-
-            @Override
-            public Void visit(AlgebraicDataType namedType, Void in) {
-                getTypeVars(namedType.getTypeArgs(), acc);
-                return null;
-            }
-
-            @Override
-            public Void visit(TypeIndex typeIndex, Void in) {
-                return null;
-            }
-
-        }, null);
-    }
-
-    private static void getTypeVars(Collection<Type> types, Set<TypeVar> acc) {
-        for (Type t : types) {
-            getTypeVars(t, acc);
-        }
-    }
-
-    public static boolean containsTypeVarOrOpaqueType(Type t) {
-        return t.accept(new TypeVisitor<Void, Boolean>() {
-
-            @Override
-            public Boolean visit(TypeVar typeVar, Void in) {
-                return true;
-            }
-
-            @Override
-            public Boolean visit(AlgebraicDataType algebraicType, Void in) {
-                for (Type ty : algebraicType.getTypeArgs()) {
-                    if (ty.accept(this, in)) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            @Override
-            public Boolean visit(OpaqueType opaqueType, Void in) {
-                return true;
-            }
-
-            @Override
-            public Boolean visit(TypeIndex typeIndex, Void in) {
-                return false;
-            }
-
-        }, null);
-    }
-
-    public static boolean isSmtRepresentable(Type t) {
-        return !t.isIndex() && t.accept(new TypeVisitor<Void, Boolean>() {
-
-            @Override
-            public Boolean visit(TypeVar typeVar, Void in) {
-                return true;
-            }
-
-            @Override
-            public Boolean visit(AlgebraicDataType algebraicType, Void in) {
-                TypeSymbol sym = algebraicType.getSymbol();
-                if (sym instanceof BuiltInTypeSymbol) {
-                    switch ((BuiltInTypeSymbol) sym) {
-                        case ARRAY_TYPE:
-                        case BOOL_TYPE:
-                        case BV:
-                        case CMP_TYPE:
-                        case FP:
-                        case INT_TYPE:
-                        case LIST_TYPE:
-                        case OPTION_TYPE:
-                        case SMT_TYPE:
-                        case STRING_TYPE:
-                        case SYM_TYPE:
-                            break;
-                        case OPAQUE_SET:
-                        case MODEL_TYPE:
-                        case SMT_PATTERN_TYPE:
-                        case SMT_WRAPPED_VAR_TYPE:
-                            return false;
-                        default:
-                            throw new AssertionError("impossible");
-                    }
-                }
-                for (Type typeArg : algebraicType.getTypeArgs()) {
-                    if (!typeArg.accept(this, in)) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            @Override
-            public Boolean visit(OpaqueType opaqueType, Void in) {
-                return false;
-            }
-
-            @Override
-            public Boolean visit(TypeIndex typeIndex, Void in) {
-                return true;
-            }
-
-        }, null);
-    }
-
-    public static boolean mayBePreSmtType(Type t) {
-        return !t.isIndex() && t.accept(new TypeVisitor<Void, Boolean>() {
-
-            @Override
-            public Boolean visit(TypeVar typeVar, Void in) {
-                return true;
-            }
-
-            @Override
-            public Boolean visit(AlgebraicDataType algebraicType, Void in) {
-                TypeSymbol sym = algebraicType.getSymbol();
-                if (sym instanceof BuiltInTypeSymbol) {
-                    switch ((BuiltInTypeSymbol) sym) {
-                        case ARRAY_TYPE:
-                        case BOOL_TYPE:
-                        case BV:
-                        case CMP_TYPE:
-                        case FP:
-                        case INT_TYPE:
-                        case LIST_TYPE:
-                        case OPTION_TYPE:
-                        case STRING_TYPE:
-                            break;
-                        case OPAQUE_SET:
-                        case MODEL_TYPE:
-                        case SMT_PATTERN_TYPE:
-                        case SMT_TYPE:
-                        case SMT_WRAPPED_VAR_TYPE:
-                        case SYM_TYPE:
-                            return false;
-                        default:
-                            throw new AssertionError("impossible");
-                    }
-                }
-                for (Type typeArg : algebraicType.getTypeArgs()) {
-                    if (!typeArg.accept(this, in)) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            @Override
-            public Boolean visit(OpaqueType opaqueType, Void in) {
-                return false;
-            }
-
-            @Override
-            public Boolean visit(TypeIndex typeIndex, Void in) {
-                return true;
-            }
-
-        }, null);
-    }
-
-    public static boolean isTupleType(Type t) {
-        if (!(t instanceof AlgebraicDataType)) {
-            return false;
-        }
-        TypeSymbol sym = ((AlgebraicDataType) t).getSymbol();
-        return sym.equals(GlobalSymbolManager.lookupTupleTypeSymbol(sym.getArity()));
-    }
-
-    public static boolean isSmtVarType(Type t) {
-        if (!(t instanceof AlgebraicDataType)) {
-            return false;
-        }
-        return ((AlgebraicDataType) t).getSymbol().equals(BuiltInTypeSymbol.SYM_TYPE);
-    }
+		private static final Map<String, Integer> memo = new ConcurrentHashMap<>();
+		private static final AtomicInteger cnt = new AtomicInteger();
+
+		private final int id;
+
+		private TypeVar(int id) {
+			this.id = id;
+		}
+
+		public static TypeVar get(String id) {
+			int i = Util.lookupOrCreate(memo, id, cnt::getAndIncrement);
+			return new TypeVar(i);
+		}
+
+		@Override
+		public String toString() {
+			return "'_" + id;
+		}
+
+		@Override
+		public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
+			return visitor.visit(this, in);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + id;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			TypeVar other = (TypeVar) obj;
+			return id == other.id;
+		}
+
+		@Override
+		public Type applySubst(Map<TypeVar, ? extends Type> subst) {
+			return TypeChecker.lookupType(this, subst);
+		}
+
+		public static TypeVar fresh() {
+			return new TypeVar(cnt.getAndIncrement());
+		}
+
+		@Override
+		public boolean isVar() {
+			return true;
+		}
+
+		@Override
+		public int compareTo(TypeVar o) {
+			return Integer.compare(this.id, o.id);
+		}
+
+		@Override
+		public Type freshen() {
+			return fresh();
+		}
+
+	}
+
+	private static List<Type> freshen(List<Type> types) {
+		return types.stream().map(Type::freshen).collect(Collectors.toList());
+	}
+
+	public static class AlgebraicDataType implements Type, Iterable<Type> {
+
+		private final TypeSymbol sym;
+		private final List<Type> typeArgs;
+		private final AtomicReference<Set<ConstructorScheme>> constructors = new AtomicReference<>();
+
+		private static final Map<Symbol, Pair<List<TypeVar>, Set<ConstructorScheme>>> memo = new ConcurrentHashMap<>();
+
+		private AlgebraicDataType(TypeSymbol sym, List<Type> typeArgs) {
+			this.sym = sym;
+			this.typeArgs = new ArrayList<>(typeArgs);
+			check();
+		}
+
+		private void check() {
+			if (sym.getArity() != typeArgs.size()) {
+				throw new IllegalArgumentException("Arity of symbol " + sym + " (" + sym.getArity()
+						+ ") does not match number of provided type parameters: " + typeArgs);
+			}
+			if (sym.isAlias()) {
+				throw new IllegalArgumentException("Cannot create a type with alias symbol " + sym);
+			}
+			if (sym instanceof BuiltInTypeSymbol) {
+				switch ((BuiltInTypeSymbol) sym) {
+				case ARRAY_TYPE:
+				case BOOL_TYPE:
+				case CMP_TYPE:
+				case INT_TYPE:
+				case LIST_TYPE:
+				case MODEL_TYPE:
+				case OPTION_TYPE:
+				case SMT_PATTERN_TYPE:
+				case SMT_WRAPPED_VAR_TYPE:
+				case STRING_TYPE:
+				case OPAQUE_SET:
+					break;
+				case BV:
+				case FP:
+					for (Type arg : typeArgs) {
+						if (!arg.isVar() && !(arg instanceof TypeIndex)) {
+							throw new IllegalArgumentException(
+									"Cannot instantiate built-in type " + sym + " with type argument " + arg);
+						}
+					}
+					break;
+				case SMT_TYPE:
+				case SYM_TYPE:
+					for (Type arg : typeArgs) {
+						if (!mayBePreSmtType(arg)) {
+							throw new IllegalArgumentException(
+									"Cannot instantiate built-in type " + sym + " with type argument " + arg);
+						}
+					}
+					break;
+				default:
+					throw new AssertionError("impossible");
+				}
+			}
+		}
+
+		public static AlgebraicDataType makeWithFreshArgs(TypeSymbol sym) {
+			List<Type> typeArgs = new ArrayList<>();
+			for (int i = 0; i < sym.getArity(); ++i) {
+				typeArgs.add(TypeVar.fresh());
+			}
+			return make(sym, typeArgs);
+		}
+
+		public static AlgebraicDataType make(TypeSymbol sym, Type... typeArgs) {
+			return make(sym, Arrays.asList(typeArgs));
+		}
+
+		public static AlgebraicDataType make(TypeSymbol sym, List<Type> typeArgs) {
+			return new AlgebraicDataType(sym, typeArgs);
+		}
+
+		public static void setConstructors(TypeSymbol sym, List<TypeVar> typeParams,
+				Collection<ConstructorScheme> constructors) {
+			if (sym.isAlias()) {
+				throw new IllegalArgumentException("Cannot set constructors for type alias symbol " + sym + ".");
+			}
+			if (typeParams.size() != (new HashSet<>(typeParams).size())) {
+				throw new IllegalArgumentException("Each type variable must be unique.");
+			}
+			if (memo.put(sym, new Pair<>(typeParams, new HashSet<>(constructors))) != null) {
+				throw new IllegalStateException("Cannot set the constructors for a type multiple times.");
+			}
+		}
+
+		public boolean hasConstructors() {
+			return memo.containsKey(sym);
+		}
+
+		public Set<ConstructorScheme> getConstructors() {
+			Set<ConstructorScheme> s = constructors.get();
+			if (s == null) {
+				Pair<List<TypeVar>, Set<ConstructorScheme>> p = memo.get(sym);
+				if (p == null) {
+					throw new IllegalStateException("No constructors have been set for symbol " + sym + ".");
+				}
+				List<TypeVar> params = p.fst();
+				Map<TypeVar, Type> subst = new HashMap<>();
+				for (int i = 0; i < params.size(); ++i) {
+					TypeVar x = params.get(i);
+					Type t = typeArgs.get(i);
+					// XXX This is to avoid cycles in subst, but is obviously fragile
+					if (!x.equals(t)) {
+						subst.put(x, t);
+					}
+				}
+				s = new HashSet<>();
+				for (ConstructorScheme c : p.snd()) {
+					List<Type> newArgs = new ArrayList<>();
+					for (Type t : c.getTypeArgs()) {
+						newArgs.add(t.applySubst(subst));
+					}
+					s.add(new ConstructorScheme(c.getSymbol(), newArgs, c.getGetterSymbols()));
+				}
+				if (!constructors.compareAndSet(null, s)) {
+					s = constructors.get();
+				}
+			}
+			return s;
+		}
+
+		public TypeSymbol getSymbol() {
+			return sym;
+		}
+
+		@Override
+		public Iterator<Type> iterator() {
+			return typeArgs.iterator();
+		}
+
+		@Override
+		public String toString() {
+			if (sym.equals(BuiltInTypeSymbol.BV) || sym.equals(BuiltInTypeSymbol.FP)) {
+				return toStringBvOrFp();
+			}
+			if (typeArgs.isEmpty()) {
+				return sym.toString();
+			}
+			if (typeArgs.size() == 1) {
+				return typeArgs.get(0) + " " + sym;
+			}
+			StringBuilder sb = new StringBuilder("(");
+			Iterator<Type> it = typeArgs.iterator();
+			sb.append(it.next());
+			while (it.hasNext()) {
+				sb.append(", ").append(it.next());
+			}
+			sb.append(") ").append(sym);
+			return sb.toString();
+		}
+
+		private String toStringBvOrFp() {
+			StringBuilder sb = new StringBuilder(sym.toString());
+			sb.append("[");
+			for (Iterator<Type> it = typeArgs.iterator(); it.hasNext();) {
+				Type arg = it.next();
+				if (arg instanceof TypeIndex) {
+					sb.append(((TypeIndex) arg).getIndex());
+				} else {
+					assert arg.isVar();
+					sb.append(arg);
+				}
+				if (it.hasNext()) {
+					sb.append(", ");
+				}
+			}
+			return sb + "]";
+		}
+
+		@Override
+		public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
+			return visitor.visit(this, in);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((sym == null) ? 0 : sym.hashCode());
+			result = prime * result + ((typeArgs == null) ? 0 : typeArgs.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			AlgebraicDataType other = (AlgebraicDataType) obj;
+			if (sym == null) {
+				if (other.sym != null)
+					return false;
+			} else if (!sym.equals(other.sym))
+				return false;
+			if (typeArgs == null) {
+				return other.typeArgs == null;
+			} else
+				return typeArgs.equals(other.typeArgs);
+		}
+
+		public List<Type> getTypeArgs() {
+			return typeArgs;
+		}
+
+		@Override
+		public Type applySubst(Map<TypeVar, ? extends Type> subst) {
+			List<Type> newTypes = new ArrayList<>();
+			for (Type t : typeArgs) {
+				newTypes.add(t.applySubst(subst));
+			}
+			return make(sym, newTypes);
+		}
+
+		@Override
+		public Type freshen() {
+			return make(sym, Types.freshen(typeArgs));
+		}
+
+		public static class ConstructorScheme {
+
+			private final ConstructorSymbol sym;
+			private final List<Type> typeArgs;
+			private final List<ConstructorSymbol> getterSyms;
+
+			public ConstructorScheme(ConstructorSymbol sym, List<Type> typeArgs, List<ConstructorSymbol> getterSyms) {
+				this.sym = sym;
+				this.typeArgs = typeArgs;
+				this.getterSyms = getterSyms;
+				assert sym != null;
+			}
+
+			public ConstructorSymbol getSymbol() {
+				return sym;
+			}
+
+			public List<Type> getTypeArgs() {
+				return typeArgs;
+			}
+
+			public List<ConstructorSymbol> getGetterSymbols() {
+				return getterSyms;
+			}
+
+			@Override
+			public int hashCode() {
+				final int prime = 31;
+				int result = 1;
+				result = prime * result + ((getterSyms == null) ? 0 : getterSyms.hashCode());
+				result = prime * result + sym.hashCode();
+				result = prime * result + ((typeArgs == null) ? 0 : typeArgs.hashCode());
+				return result;
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj)
+					return true;
+				if (obj == null)
+					return false;
+				if (getClass() != obj.getClass())
+					return false;
+				ConstructorScheme other = (ConstructorScheme) obj;
+				if (getterSyms == null) {
+					if (other.getterSyms != null)
+						return false;
+				} else if (!getterSyms.equals(other.getterSyms))
+					return false;
+				if (!sym.equals(other.sym))
+					return false;
+				if (typeArgs == null) {
+					return other.typeArgs == null;
+				} else
+					return typeArgs.equals(other.typeArgs);
+			}
+
+		}
+
+	}
+
+	public static class OpaqueType implements Type {
+		/*
+		 * This class is used (exclusively) during type checking.
+		 */
+
+		private static final AtomicInteger cnt = new AtomicInteger();
+		private final int id;
+
+		private OpaqueType() {
+			id = cnt.getAndIncrement();
+		}
+
+		public static OpaqueType get() {
+			return new OpaqueType();
+		}
+
+		@Override
+		public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
+			return visitor.visit(this, in);
+		}
+
+		@Override
+		public Type applySubst(Map<TypeVar, ? extends Type> subst) {
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			return "Opaque" + id;
+		}
+
+		@Override
+		public Type freshen() {
+			return get();
+		}
+
+	}
+
+	public static class TypeIndex implements Type {
+
+		private final int index;
+
+		private TypeIndex(int index) {
+			this.index = index;
+		}
+
+		public static TypeIndex make(int index) {
+			return new TypeIndex(index);
+		}
+
+		@Override
+		public <I, O> O accept(TypeVisitor<I, O> visitor, I in) {
+			return visitor.visit(this, in);
+		}
+
+		@Override
+		public Type applySubst(Map<TypeVar, ? extends Type> subst) {
+			return this;
+		}
+
+		@Override
+		public Type freshen() {
+			return this;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + index;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			TypeIndex other = (TypeIndex) obj;
+			return index == other.index;
+		}
+
+		@Override
+		public String toString() {
+			return "[" + index + "]";
+		}
+
+		@Override
+		public boolean isIndex() {
+			return true;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public List<TypeIndex> expandAsFpIndex() {
+			switch (index) {
+			case 16:
+				return Arrays.asList(make(5), make(11));
+			case 32:
+				return Arrays.asList(make(8), make(24));
+			case 64:
+				return Arrays.asList(make(11), make(53));
+			case 128:
+				return Arrays.asList(make(15), make(113));
+			default:
+				throw new IllegalArgumentException("Illegal floating point width alias: " + index);
+			}
+		}
+
+	}
+
+	// Helpers /////////////////////////////////////////////////////////////////
+
+	public static Set<TypeVar> getTypeVars(Type t) {
+		return getTypeVars(Collections.singletonList(t));
+	}
+
+	public static Set<TypeVar> getTypeVars(Collection<Type> t) {
+		Set<TypeVar> set = new HashSet<>();
+		getTypeVars(t, set);
+		return set;
+	}
+
+	private static void getTypeVars(Type t, Set<TypeVar> acc) {
+		t.accept(new TypeVisitor<Void, Void>() {
+
+			@Override
+			public Void visit(TypeVar typeVar, Void in) {
+				acc.add(typeVar);
+				return null;
+			}
+
+			@Override
+			public Void visit(OpaqueType opaqueType, Void in) {
+				return null;
+			}
+
+			@Override
+			public Void visit(AlgebraicDataType namedType, Void in) {
+				getTypeVars(namedType.getTypeArgs(), acc);
+				return null;
+			}
+
+			@Override
+			public Void visit(TypeIndex typeIndex, Void in) {
+				return null;
+			}
+
+		}, null);
+	}
+
+	private static void getTypeVars(Collection<Type> types, Set<TypeVar> acc) {
+		for (Type t : types) {
+			getTypeVars(t, acc);
+		}
+	}
+
+	public static boolean containsTypeVarOrOpaqueType(Type t) {
+		return t.accept(new TypeVisitor<Void, Boolean>() {
+
+			@Override
+			public Boolean visit(TypeVar typeVar, Void in) {
+				return true;
+			}
+
+			@Override
+			public Boolean visit(AlgebraicDataType algebraicType, Void in) {
+				for (Type ty : algebraicType.getTypeArgs()) {
+					if (ty.accept(this, in)) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			@Override
+			public Boolean visit(OpaqueType opaqueType, Void in) {
+				return true;
+			}
+
+			@Override
+			public Boolean visit(TypeIndex typeIndex, Void in) {
+				return false;
+			}
+
+		}, null);
+	}
+
+	public static boolean isSmtRepresentable(Type t) {
+		return !t.isIndex() && t.accept(new TypeVisitor<Void, Boolean>() {
+
+			@Override
+			public Boolean visit(TypeVar typeVar, Void in) {
+				return true;
+			}
+
+			@Override
+			public Boolean visit(AlgebraicDataType algebraicType, Void in) {
+				TypeSymbol sym = algebraicType.getSymbol();
+				if (sym instanceof BuiltInTypeSymbol) {
+					switch ((BuiltInTypeSymbol) sym) {
+					case ARRAY_TYPE:
+					case BOOL_TYPE:
+					case BV:
+					case CMP_TYPE:
+					case FP:
+					case INT_TYPE:
+					case LIST_TYPE:
+					case OPTION_TYPE:
+					case SMT_TYPE:
+					case STRING_TYPE:
+					case SYM_TYPE:
+						break;
+					case OPAQUE_SET:
+					case MODEL_TYPE:
+					case SMT_PATTERN_TYPE:
+					case SMT_WRAPPED_VAR_TYPE:
+						return false;
+					default:
+						throw new AssertionError("impossible");
+					}
+				}
+				for (Type typeArg : algebraicType.getTypeArgs()) {
+					if (!typeArg.accept(this, in)) {
+						return false;
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public Boolean visit(OpaqueType opaqueType, Void in) {
+				return false;
+			}
+
+			@Override
+			public Boolean visit(TypeIndex typeIndex, Void in) {
+				return true;
+			}
+
+		}, null);
+	}
+
+	public static boolean mayBePreSmtType(Type t) {
+		return !t.isIndex() && t.accept(new TypeVisitor<Void, Boolean>() {
+
+			@Override
+			public Boolean visit(TypeVar typeVar, Void in) {
+				return true;
+			}
+
+			@Override
+			public Boolean visit(AlgebraicDataType algebraicType, Void in) {
+				TypeSymbol sym = algebraicType.getSymbol();
+				if (sym instanceof BuiltInTypeSymbol) {
+					switch ((BuiltInTypeSymbol) sym) {
+					case ARRAY_TYPE:
+					case BOOL_TYPE:
+					case BV:
+					case CMP_TYPE:
+					case FP:
+					case INT_TYPE:
+					case LIST_TYPE:
+					case OPTION_TYPE:
+					case STRING_TYPE:
+						break;
+					case OPAQUE_SET:
+					case MODEL_TYPE:
+					case SMT_PATTERN_TYPE:
+					case SMT_TYPE:
+					case SMT_WRAPPED_VAR_TYPE:
+					case SYM_TYPE:
+						return false;
+					default:
+						throw new AssertionError("impossible");
+					}
+				}
+				for (Type typeArg : algebraicType.getTypeArgs()) {
+					if (!typeArg.accept(this, in)) {
+						return false;
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public Boolean visit(OpaqueType opaqueType, Void in) {
+				return false;
+			}
+
+			@Override
+			public Boolean visit(TypeIndex typeIndex, Void in) {
+				return true;
+			}
+
+		}, null);
+	}
+
+	public static boolean isTupleType(Type t) {
+		if (!(t instanceof AlgebraicDataType)) {
+			return false;
+		}
+		TypeSymbol sym = ((AlgebraicDataType) t).getSymbol();
+		return sym.equals(GlobalSymbolManager.lookupTupleTypeSymbol(sym.getArity()));
+	}
+
+	public static boolean isSmtVarType(Type t) {
+		if (!(t instanceof AlgebraicDataType)) {
+			return false;
+		}
+		return ((AlgebraicDataType) t).getSymbol().equals(BuiltInTypeSymbol.SYM_TYPE);
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/types/WellTypedProgram.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/types/WellTypedProgram.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.types;
 
 import edu.harvard.seas.pl.formulog.ast.BasicRule;
 
-
 import edu.harvard.seas.pl.formulog.ast.Program;
 import edu.harvard.seas.pl.formulog.ast.UserPredicate;
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/unification/EmptySubstitution.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/unification/EmptySubstitution.java
@@ -20,14 +20,13 @@ package edu.harvard.seas.pl.formulog.unification;
  * #L%
  */
 
-
 import java.util.Collections;
 
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.ast.Var;
 
 public enum EmptySubstitution implements Substitution {
-	
+
 	INSTANCE;
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/unification/OverwriteSubstitution.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/unification/OverwriteSubstitution.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.unification;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,11 +33,11 @@ public class OverwriteSubstitution implements Substitution {
 	public OverwriteSubstitution() {
 		this(new HashMap<>());
 	}
-	
+
 	private OverwriteSubstitution(Map<Var, Term> m) {
 		this.m = m;
 	}
-	
+
 	@Override
 	public void put(Var v, Term t) {
 		m.put(v, t);
@@ -63,7 +62,7 @@ public class OverwriteSubstitution implements Substitution {
 	public OverwriteSubstitution copy() {
 		return new OverwriteSubstitution(new HashMap<>(m));
 	}
-	
+
 	@Override
 	public String toString() {
 		return m.toString();

--- a/src/main/java/edu/harvard/seas/pl/formulog/unification/SimpleSubstitution.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/unification/SimpleSubstitution.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.unification;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,7 +51,7 @@ public class SimpleSubstitution implements Substitution {
 	public Iterable<Var> iterateKeys() {
 		return map.keySet();
 	}
-	
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("[");

--- a/src/main/java/edu/harvard/seas/pl/formulog/unification/Substitution.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/unification/Substitution.java
@@ -20,14 +20,13 @@ package edu.harvard.seas.pl.formulog.unification;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.ast.Var;
 
 public interface Substitution {
-	
+
 	void put(Var v, Term t);
-	
+
 	Term get(Var v);
 
 	static Term getIfPresent(Term t, Substitution s) {
@@ -36,13 +35,13 @@ public interface Substitution {
 		}
 		return t;
 	}
-	
+
 	boolean containsKey(Var v);
-	
+
 	Iterable<Var> iterateKeys();
 
 //	Substitution copy();
-	
+
 //	int newCheckpoint();
 
 //	int getCheckpoint();
@@ -52,5 +51,5 @@ public interface Substitution {
 //	int popCheckpoint();
 
 //	void mergeCheckpoint();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/unification/Unification.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/unification/Unification.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.unification;
  * #L%
  */
 
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/AbstractFJPTask.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/AbstractFJPTask.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.concurrent.RecursiveAction;
 
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -43,7 +42,7 @@ public abstract class AbstractFJPTask extends RecursiveAction {
 			exec.fail(e);
 		}
 	}
-	
+
 	public abstract void doTask() throws EvaluationException;
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/CompositeIterable.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/CompositeIterable.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -29,27 +28,27 @@ import java.util.Queue;
 public class CompositeIterable<T> implements Iterable<T> {
 
 	private final Iterable<Iterable<T>> its;
-	
+
 	public CompositeIterable(Iterable<Iterable<T>> its) {
 		this.its = its;
 	}
-	
+
 	@Override
 	public Iterator<T> iterator() {
 		return new CompositeIterator();
 	}
-	
+
 	private final class CompositeIterator implements Iterator<T> {
-		
+
 		private final Queue<Iterator<T>> iterators;
-		
+
 		public CompositeIterator() {
 			Queue<Iterator<T>> l = new ArrayDeque<>();
 			for (Iterable<T> it : its) {
 				l.add(it.iterator());
 			}
 			this.iterators = l;
-			
+
 		}
 
 		private boolean load() {
@@ -62,7 +61,7 @@ public class CompositeIterable<T> implements Iterable<T> {
 			iterators.remove();
 			return load();
 		}
-		
+
 		@Override
 		public synchronized boolean hasNext() {
 			return load();
@@ -75,7 +74,7 @@ public class CompositeIterable<T> implements Iterable<T> {
 			}
 			return iterators.peek().next();
 		}
-		
+
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/CountingFJP.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/CountingFJP.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.util;
 
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 
-
 public interface CountingFJP {
 
 	void externallyAddTask(AbstractFJPTask w);

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/CountingFJPImpl.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/CountingFJPImpl.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.ForkJoinWorkerThread;

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/DedupWorkList.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/DedupWorkList.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/ExceptionalFunction.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/ExceptionalFunction.java
@@ -20,10 +20,9 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 @FunctionalInterface
 public interface ExceptionalFunction<T1, T2, E extends Exception> {
-	
+
 	T2 apply(T1 arg) throws E;
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/FunctorUtil.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/FunctorUtil.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,7 +76,7 @@ public final class FunctorUtil {
 	public static class Memoizer<T extends Term> {
 
 		private final Map<Key, T> memo = new ConcurrentHashMap<>();
-		
+
 		public T lookupOrCreate(Symbol sym, Term[] args, Supplier<T> constructor) {
 			if (sym.getArity() != args.length) {
 				throw new IllegalArgumentException("Symbol " + sym + " has arity " + sym.getArity() + " but args "

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/IntArrayWrapper.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/IntArrayWrapper.java
@@ -20,26 +20,25 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.Arrays;
 
 public class IntArrayWrapper {
 
 	private final int[] a;
-	
+
 	public IntArrayWrapper(int[] a) {
 		this.a = a;
 	}
-	
+
 	public int[] getVal() {
 		return a;
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Arrays.hashCode(a);
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof int[]) {
@@ -47,5 +46,5 @@ public class IntArrayWrapper {
 		}
 		return false;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/MockCountingFJP.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/MockCountingFJP.java
@@ -25,11 +25,10 @@ import java.util.Deque;
 
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 
-
 public class MockCountingFJP implements CountingFJP {
 
 	private volatile EvaluationException failureCause;
-	
+
 	private final Deque<AbstractFJPTask> workItems = new ArrayDeque<>();
 
 	public synchronized void externallyAddTask(AbstractFJPTask w) {
@@ -48,24 +47,24 @@ public class MockCountingFJP implements CountingFJP {
 	}
 
 	public synchronized final void shutdown() {
-		
+
 	}
-	
+
 	public synchronized final void fail(EvaluationException cause) {
 		failureCause = cause;
 	}
-	
+
 	public synchronized final boolean hasFailed() {
 		return failureCause != null;
 	}
-	
+
 	public synchronized final EvaluationException getFailureCause() {
 		return failureCause;
 	}
 
 	@Override
 	public synchronized void reportTaskCompletion() {
-		
+
 	}
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/Pair.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/Pair.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-
 public class Pair<U, V> {
 
 	private final U fst;

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/StackMap.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/StackMap.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
@@ -29,15 +28,15 @@ import java.util.Map;
 public class StackMap<K, V> {
 
 	private final Deque<Map<K, V>> stack = new ArrayDeque<>();
-	
+
 	public synchronized void push(Map<K, V> m) {
 		stack.addFirst(m);
 	}
-	
+
 	public synchronized Map<K, V> pop() {
 		return stack.remove();
 	}
-	
+
 	public synchronized V get(K k) {
 		for (Iterator<Map<K, V>> it = stack.iterator(); it.hasNext();) {
 			Map<K, V> m = it.next();
@@ -48,7 +47,7 @@ public class StackMap<K, V> {
 		}
 		return null;
 	}
-	
+
 	public synchronized V put(K k, V v) {
 		return stack.getFirst().put(k, v);
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/TodoException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/TodoException.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 public class TodoException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
 	public TodoException() {
-		
+
 	}
 
 	public TodoException(String message) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/Triple.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/Triple.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 public class Triple<S, T, U> {
 
 	public final S first;
 	public final T second;
 	public final U third;
-	
+
 	public Triple(S first, T second, U third) {
 		this.first = first;
 		this.second = second;
@@ -70,7 +69,7 @@ public class Triple<S, T, U> {
 			return false;
 		return true;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "< " + first + " , " + second + " , " + third + " >";

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/UnionFind.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/UnionFind.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.util;
  * #L%
  */
 
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -28,21 +27,21 @@ import java.util.Set;
 public class UnionFind<T> {
 
 	private final Map<T, T> m = new HashMap<>();
-	
+
 	public boolean contains(T t) {
 		return m.containsKey(t);
 	}
-	
+
 	public boolean add(T t) {
 		return m.putIfAbsent(t, t) == null;
 	}
-	
+
 	public void union(T t1, T t2) {
 		t1 = find(t1);
 		t2 = find(t2);
 		m.put(t1, t2);
 	}
-	
+
 	public T find(T t) {
 		assert contains(t);
 		T prev = null;
@@ -52,9 +51,9 @@ public class UnionFind<T> {
 		}
 		return t;
 	}
-	
+
 	public Set<T> members() {
 		return m.keySet();
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/Util.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/Util.java
@@ -44,175 +44,175 @@ import edu.harvard.seas.pl.formulog.ast.UserPredicate;
 
 public final class Util {
 
-    private Util() {
-        throw new AssertionError();
-    }
+	private Util() {
+		throw new AssertionError();
+	}
 
-    public static <K, V> V lookupOrCreate(Map<K, V> m, K k, Supplier<V> cnstr) {
-        V v = m.get(k);
-        if (v == null) {
-            v = cnstr.get();
-            V u = m.putIfAbsent(k, v);
-            if (u != null) {
-                v = u;
-            }
-        }
-        return v;
-    }
+	public static <K, V> V lookupOrCreate(Map<K, V> m, K k, Supplier<V> cnstr) {
+		V v = m.get(k);
+		if (v == null) {
+			v = cnstr.get();
+			V u = m.putIfAbsent(k, v);
+			if (u != null) {
+				v = u;
+			}
+		}
+		return v;
+	}
 
-    public static <T> Iterable<T> i2i(Iterator<T> it) {
-        return () -> it;
-    }
+	public static <T> Iterable<T> i2i(Iterator<T> it) {
+		return () -> it;
+	}
 
-    public static <K> Set<K> concurrentSet() {
-        return Collections.newSetFromMap(new ConcurrentHashMap<>());
-    }
+	public static <K> Set<K> concurrentSet() {
+		return Collections.newSetFromMap(new ConcurrentHashMap<>());
+	}
 
-    public static <T> List<T> iterableToList(Iterable<T> it) {
-        List<T> l = new ArrayList<>();
-        it.forEach(l::add);
-        return l;
-    }
+	public static <T> List<T> iterableToList(Iterable<T> it) {
+		List<T> l = new ArrayList<>();
+		it.forEach(l::add);
+		return l;
+	}
 
-    public static <A, B> List<B> map(List<A> xs, Function<A, B> f) {
-        return xs.stream().map(f).collect(Collectors.toList());
-    }
+	public static <A, B> List<B> map(List<A> xs, Function<A, B> f) {
+		return xs.stream().map(f).collect(Collectors.toList());
+	}
 
-    public static void printSortedFacts(Iterable<UserPredicate> facts, PrintStream out) {
-        Util.iterableToList(facts).stream().map(a -> {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream ps = new PrintStream(baos);
-            ps.print(a);
-            return baos.toString();
-        }).sorted().forEach(out::println);
-    }
+	public static void printSortedFacts(Iterable<UserPredicate> facts, PrintStream out) {
+		Util.iterableToList(facts).stream().map(a -> {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			PrintStream ps = new PrintStream(baos);
+			ps.print(a);
+			return baos.toString();
+		}).sorted().forEach(out::println);
+	}
 
-    public static <K, V> Map<K, V> fillMapWithFutures(Map<K, Future<V>> futures, Map<K, V> m)
-            throws InterruptedException, ExecutionException {
-        for (Map.Entry<K, Future<V>> e : futures.entrySet()) {
-            m.put(e.getKey(), e.getValue().get());
-        }
-        return m;
-    }
+	public static <K, V> Map<K, V> fillMapWithFutures(Map<K, Future<V>> futures, Map<K, V> m)
+			throws InterruptedException, ExecutionException {
+		for (Map.Entry<K, Future<V>> e : futures.entrySet()) {
+			m.put(e.getKey(), e.getValue().get());
+		}
+		return m;
+	}
 
-    public static class IterableOfIterables<T> implements Iterable<Iterable<T>> {
+	public static class IterableOfIterables<T> implements Iterable<Iterable<T>> {
 
-        private final Iterable<T> iterable;
-        private final int size;
+		private final Iterable<T> iterable;
+		private final int size;
 
-        public IterableOfIterables(Iterable<T> iterable, int size) {
-            this.iterable = iterable;
-            this.size = size;
-        }
+		public IterableOfIterables(Iterable<T> iterable, int size) {
+			this.iterable = iterable;
+			this.size = size;
+		}
 
-        @Override
-        public Iterator<Iterable<T>> iterator() {
-            Iterator<T> it = iterable.iterator();
-            return new Iterator<Iterable<T>>() {
+		@Override
+		public Iterator<Iterable<T>> iterator() {
+			Iterator<T> it = iterable.iterator();
+			return new Iterator<Iterable<T>>() {
 
-                @Override
-                public boolean hasNext() {
-                    return it.hasNext();
-                }
+				@Override
+				public boolean hasNext() {
+					return it.hasNext();
+				}
 
-                @Override
-                public Iterable<T> next() {
-                    assert hasNext();
-                    List<T> l = new ArrayList<>(size);
-                    for (int i = 0; i < size && it.hasNext(); ++i) {
-                        l.add(it.next());
-                    }
-                    return l;
-                }
+				@Override
+				public Iterable<T> next() {
+					assert hasNext();
+					List<T> l = new ArrayList<>(size);
+					for (int i = 0; i < size && it.hasNext(); ++i) {
+						l.add(it.next());
+					}
+					return l;
+				}
 
-            };
-        }
+			};
+		}
 
-        @Override
-        public String toString() {
-            String s = "{";
-            for (Iterator<Iterable<T>> it = iterator(); it.hasNext(); ) {
-                s += it.next();
-                if (it.hasNext()) {
-                    s += ",";
-                }
-            }
-            return s + "}";
-        }
+		@Override
+		public String toString() {
+			String s = "{";
+			for (Iterator<Iterable<T>> it = iterator(); it.hasNext();) {
+				s += it.next();
+				if (it.hasNext()) {
+					s += ",";
+				}
+			}
+			return s + "}";
+		}
 
-        public String toString(Function<T, String> printer) {
-            String s = "{";
-            for (Iterator<Iterable<T>> it = iterator(); it.hasNext(); ) {
-                s += " {";
-                for (Iterator<T> it2 = it.next().iterator(); it2.hasNext(); ) {
-                    s += printer.apply(it2.next());
-                    if (it2.hasNext()) {
-                        s += ", ";
-                    }
-                }
-                s += "} ";
-                if (it.hasNext()) {
-                    s += ", ";
-                }
-            }
-            return s + "}";
+		public String toString(Function<T, String> printer) {
+			String s = "{";
+			for (Iterator<Iterable<T>> it = iterator(); it.hasNext();) {
+				s += " {";
+				for (Iterator<T> it2 = it.next().iterator(); it2.hasNext();) {
+					s += printer.apply(it2.next());
+					if (it2.hasNext()) {
+						s += ", ";
+					}
+				}
+				s += "} ";
+				if (it.hasNext()) {
+					s += ", ";
+				}
+			}
+			return s + "}";
 
-        }
+		}
 
-    }
+	}
 
-    public static <T> Iterable<Iterable<T>> splitIterable(Iterable<T> iterable, int segmentSize) {
-        return new IterableOfIterables<>(iterable, segmentSize);
-    }
+	public static <T> Iterable<Iterable<T>> splitIterable(Iterable<T> iterable, int segmentSize) {
+		return new IterableOfIterables<>(iterable, segmentSize);
+	}
 
-    public static void clean(File f, boolean deleteTopLevel) {
-        if (!f.exists()) {
-            return;
-        }
-        if (f.isDirectory()) {
-            for (File ff : f.listFiles()) {
-                clean(ff, true);
-            }
-        }
-        if (deleteTopLevel) {
-            f.delete();
-        }
-    }
+	public static void clean(File f, boolean deleteTopLevel) {
+		if (!f.exists()) {
+			return;
+		}
+		if (f.isDirectory()) {
+			for (File ff : f.listFiles()) {
+				clean(ff, true);
+			}
+		}
+		if (deleteTopLevel) {
+			f.delete();
+		}
+	}
 
-    public static void assertBinaryOnPath(String exec) {
-        String os = System.getProperty("os.name");
-        String util = os.startsWith("Windows") ? "where" : "which";
-        String[] cmd = {util, exec};
-        String strCmd = util + " " + exec;
-        try {
-            Process p = Runtime.getRuntime().exec(cmd);
-            if (p.waitFor() != 0) {
-                throw new AssertionError("Cannot find " + exec + " executable on path (`" + strCmd
-                        + "` returned a non-zero exit code).");
-            }
-        } catch (IOException | InterruptedException e) {
-            throw new AssertionError("Command checking for presence of " + exec + " executable failed: " + strCmd + "\n"
-                    + e.getMessage());
-        }
-    }
+	public static void assertBinaryOnPath(String exec) {
+		String os = System.getProperty("os.name");
+		String util = os.startsWith("Windows") ? "where" : "which";
+		String[] cmd = { util, exec };
+		String strCmd = util + " " + exec;
+		try {
+			Process p = Runtime.getRuntime().exec(cmd);
+			if (p.waitFor() != 0) {
+				throw new AssertionError("Cannot find " + exec + " executable on path (`" + strCmd
+						+ "` returned a non-zero exit code).");
+			}
+		} catch (IOException | InterruptedException e) {
+			throw new AssertionError("Command checking for presence of " + exec + " executable failed: " + strCmd + "\n"
+					+ e.getMessage());
+		}
+	}
 
-    public static <V, E> void printGraph(PrintStream out, Graph<V, E> g) {
-        out.println("{");
-        for (Iterator<V> it = g.vertexSet().iterator(); it.hasNext(); ) {
-            V v = it.next();
-            out.println("\t" + v + ":");
-            if (g.outDegreeOf(v) == 0) {
-                out.println("\t\tNONE");
-            } else {
-                for (E e : g.outgoingEdgesOf(v)) {
-                    out.println("\t\t" + e);
-                }
-            }
-            if (it.hasNext()) {
-                out.println();
-            }
-        }
-        out.println("}");
-    }
+	public static <V, E> void printGraph(PrintStream out, Graph<V, E> g) {
+		out.println("{");
+		for (Iterator<V> it = g.vertexSet().iterator(); it.hasNext();) {
+			V v = it.next();
+			out.println("\t" + v + ":");
+			if (g.outDegreeOf(v) == 0) {
+				out.println("\t\tNONE");
+			} else {
+				for (E e : g.outgoingEdgesOf(v)) {
+					out.println("\t\t" + e);
+				}
+			}
+			if (it.hasNext()) {
+				out.println();
+			}
+		}
+		out.println("}");
+	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExp.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExp.java
@@ -25,13 +25,13 @@ import java.util.List;
 public interface SExp {
 
 	boolean isAtom();
-	
+
 	default boolean isList() {
 		return !isAtom();
 	}
-	
+
 	String asAtom();
-	
+
 	List<SExp> asList();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpAtom.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class SExpAtom implements SExp {
 
 	private final String value;
-	
+
 	public SExpAtom(String value) {
 		this.value = value;
 	}
@@ -44,10 +44,10 @@ public class SExpAtom implements SExp {
 	public List<SExp> asList() {
 		throw new UnsupportedOperationException();
 	}
-	
+
 	@Override
 	public String toString() {
-		return value; 
+		return value;
 	}
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpLexer.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpLexer.java
@@ -63,7 +63,7 @@ public class SExpLexer {
 		}
 		ready = false;
 	}
-	
+
 	public boolean hasToken() throws SExpException {
 		return ready || loadNextToken();
 	}
@@ -125,7 +125,7 @@ public class SExpLexer {
 		}
 		return bufSize > 0;
 	}
-	
+
 	public static void main(String[] args) throws SExpException {
 		Reader r = new StringReader("(hello 2(x ()) )");
 		SExpLexer lexer = new SExpLexer(r);

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpList.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpList.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class SExpList implements SExp {
 
 	private final List<SExp> l;
-	
+
 	public SExpList(List<SExp> l) {
 		this.l = Collections.unmodifiableList(new ArrayList<>(l));
 	}
@@ -47,7 +47,7 @@ public class SExpList implements SExp {
 	public List<SExp> asList() {
 		return l;
 	}
-	
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpParser.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/sexp/SExpParser.java
@@ -69,7 +69,7 @@ public class SExpParser {
 		lexer.consume(SExpToken.RPAREN);
 		return new SExpList(l);
 	}
-	
+
 	public static void main(String[] args) throws SExpException {
 		Reader r = new StringReader("(hello 2(x ()) )");
 		SExpParser parser = new SExpParser(r);

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/FunctionDefValidation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/FunctionDefValidation.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,7 +49,7 @@ public class FunctionDefValidation {
 			}
 		}
 	}
-	
+
 	public static void validate(UserFunctionDef def) throws InvalidProgramException {
 		Set<Var> params = checkParams(def.getParams());
 		Set<Var> vars = def.getBody().varSet();
@@ -66,7 +65,7 @@ public class FunctionDefValidation {
 			throw new InvalidProgramException(msg);
 		}
 	}
-	
+
 	private static Set<Var> checkParams(List<Var> params) throws InvalidProgramException {
 		Set<Var> vars = new HashSet<>();
 		for (Var param : params) {
@@ -76,5 +75,5 @@ public class FunctionDefValidation {
 		}
 		return vars;
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/InvalidProgramException.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/InvalidProgramException.java
@@ -20,13 +20,12 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 /**
- * An exception signifying that a Datalog program is not well-formed. 
+ * An exception signifying that a Datalog program is not well-formed.
  *
  */
 public class InvalidProgramException extends Exception {
-	
+
 	private static final long serialVersionUID = 1L;
 
 	/**
@@ -38,8 +37,7 @@ public class InvalidProgramException extends Exception {
 	/**
 	 * Constructs an exception signifying an ill-formedness error.
 	 * 
-	 * @param message
-	 *            the error message
+	 * @param message the error message
 	 */
 	public InvalidProgramException(String message) {
 		super(message);
@@ -48,8 +46,7 @@ public class InvalidProgramException extends Exception {
 	/**
 	 * Constructs an exception signifying an ill-formedness error.
 	 * 
-	 * @param cause
-	 *            the exception that caused this exception
+	 * @param cause the exception that caused this exception
 	 */
 	public InvalidProgramException(Throwable cause) {
 		super(cause);
@@ -58,10 +55,8 @@ public class InvalidProgramException extends Exception {
 	/**
 	 * Constructs an exception signifying an ill-formedness error.
 	 * 
-	 * @param message
-	 *            the error message
-	 * @param cause
-	 *            the exception that caused this exception
+	 * @param message the error message
+	 * @param cause   the exception that caused this exception
 	 */
 	public InvalidProgramException(String message, Throwable cause) {
 		super(message, cause);
@@ -70,16 +65,13 @@ public class InvalidProgramException extends Exception {
 	/**
 	 * Constructs an exception signifying an ill-formedness error.
 	 * 
-	 * @param message
-	 *            the error message
-	 * @param cause
-	 *            the exception that caused this exception
-	 * @param enableSuppression
-	 *            whether or not suppression is enabled or disabled
-	 * @param writableStackTrace
-	 *            whether or not the stack trace should be writable
+	 * @param message            the error message
+	 * @param cause              the exception that caused this exception
+	 * @param enableSuppression  whether or not suppression is enabled or disabled
+	 * @param writableStackTrace whether or not the stack trace should be writable
 	 */
-	public InvalidProgramException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+	public InvalidProgramException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/Stratum.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/Stratum.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
@@ -40,11 +39,11 @@ public class Stratum {
 	public int getRank() {
 		return rank;
 	}
-	
+
 	public Set<RelationSymbol> getPredicateSyms() {
 		return predicateSyms;
 	}
-	
+
 	public boolean hasRecursiveNegationOrAggregation() {
 		return hasRecursiveNegationOrAggregation;
 	}
@@ -53,6 +52,6 @@ public class Stratum {
 	public String toString() {
 		return "Stratum [rank=" + rank + ", predicateSyms=" + predicateSyms + ", hasRecursiveNegationOrAggregation="
 				+ hasRecursiveNegationOrAggregation + "]";
-	}	
-	
+	}
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ValidRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ValidRule.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Assignment.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Assignment.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
 import java.util.HashSet;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.ast.Var;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -33,20 +32,20 @@ public class Assignment implements SimpleLiteral {
 
 	private final Var var;
 	private final Term rhs;
-	
+
 	public static Assignment make(Var var, Term rhs) {
 		return new Assignment(var, rhs);
 	}
-	
+
 	public Assignment(Var var, Term rhs) {
 		this.var = var;
 		this.rhs = rhs;
 	}
-	
+
 	public void assign(Substitution subst) throws EvaluationException {
 		subst.put(var, rhs.normalize(subst));
 	}
-	
+
 	@Override
 	public <I, O> O accept(SimpleLiteralVisitor<I, O> visitor, I input) {
 		return visitor.visit(this, input);
@@ -79,11 +78,11 @@ public class Assignment implements SimpleLiteral {
 	public Term[] getArgs() {
 		return new Term[] { var, rhs };
 	}
-	
+
 	public Var getDef() {
 		return var;
 	}
-	
+
 	public Term getVal() {
 		return rhs;
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Check.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Check.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
 import java.util.HashSet;
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.Term;
 import edu.harvard.seas.pl.formulog.ast.Var;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -38,25 +37,25 @@ public class Check implements SimpleLiteral {
 	public static Check make(Term lhs, Term rhs, boolean negated) {
 		return new Check(lhs, rhs, negated);
 	}
-	
+
 	private Check(Term lhs, Term rhs, boolean negated) {
 		this.lhs = lhs;
 		this.rhs = rhs;
 		this.negated = negated;
 	}
-	
+
 	public boolean isNegated() {
 		return negated;
 	}
-	
+
 	public Term getLhs() {
 		return lhs;
 	}
-	
+
 	public Term getRhs() {
 		return rhs;
 	}
-	
+
 	public boolean check(Substitution subst) throws EvaluationException {
 		Term lhs = this.lhs.normalize(subst);
 		Term rhs = this.rhs.normalize(subst);
@@ -66,7 +65,7 @@ public class Check implements SimpleLiteral {
 		assert !rhs.containsUnevaluatedTerm();
 		return lhs.equals(rhs) ^ negated;
 	}
-	
+
 	@Override
 	public <I, O> O accept(SimpleLiteralVisitor<I, O> visitor, I input) {
 		return visitor.visit(this, input);

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Destructor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Destructor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,7 +40,8 @@ public class Destructor implements SimpleLiteral {
 	private final Var[] bindings;
 
 	public static Destructor make(Term x, ConstructorSymbol symbol, Var[] bindings) {
-		assert assertDisjoint(x.varSet(), Arrays.asList(bindings)) : "A variable cannot be on both sides of a destructor";
+		assert assertDisjoint(x.varSet(), Arrays.asList(bindings))
+				: "A variable cannot be on both sides of a destructor";
 		assert symbol.getArity() == bindings.length : "Symbol arity does not match number of variables";
 		assert bindings.length == new HashSet<>(Arrays.asList(bindings)).size() : "All variables must be distinct";
 		return new Destructor(x, symbol, bindings);
@@ -61,15 +61,15 @@ public class Destructor implements SimpleLiteral {
 		this.symbol = symbol;
 		this.bindings = vars;
 	}
-	
+
 	public Term getScrutinee() {
 		return x;
 	}
-	
+
 	public ConstructorSymbol getSymbol() {
 		return symbol;
 	}
-	
+
 	public Var[] getBindings() {
 		return bindings;
 	}
@@ -130,5 +130,5 @@ public class Destructor implements SimpleLiteral {
 		}
 		return new Term[] { x, Constructors.make(symbol, args) };
 	}
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteral.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteral.java
@@ -22,18 +22,17 @@ package edu.harvard.seas.pl.formulog.validating.ast;
 
 import java.util.Set;
 
-
 import edu.harvard.seas.pl.formulog.ast.Literal;
 import edu.harvard.seas.pl.formulog.ast.Var;
 
 public interface SimpleLiteral extends Literal {
 
 	<I, O> O accept(SimpleLiteralVisitor<I, O> visitor, I input);
-	
+
 	<I, O, E extends Throwable> O accept(SimpleLiteralExnVisitor<I, O, E> visitor, I input) throws E;
 
 	Set<Var> varSet();
-	
+
 	SimpleLiteralTag getTag();
-	
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralExnVisitor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralExnVisitor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-
 public interface SimpleLiteralExnVisitor<I, O, E extends Throwable> {
 
 	O visit(Assignment assignment, I input) throws E;

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralTag.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralTag.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-
 public enum SimpleLiteralTag {
 	ASSIGNMENT, CHECK, DESTRUCTOR, PREDICATE;
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralVisitor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteralVisitor.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-
 public interface SimpleLiteralVisitor<I, O> {
 
 	O visit(Assignment assignment, I input);

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimplePredicate.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimplePredicate.java
@@ -23,7 +23,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
 import java.util.Arrays;
 import java.util.HashSet;
 
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;
@@ -40,7 +39,8 @@ public class SimplePredicate implements SimpleLiteral {
 	private final BindingType[] bindingPattern;
 	private final boolean negated;
 
-	public static SimplePredicate make(RelationSymbol symbol, Term[] args, BindingType[] bindingPattern, boolean negated) {
+	public static SimplePredicate make(RelationSymbol symbol, Term[] args, BindingType[] bindingPattern,
+			boolean negated) {
 		assert symbol.getArity() == args.length : "Symbol does not match argument arity";
 		return new SimplePredicate(symbol, args, bindingPattern, negated);
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleRule.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleRule.java
@@ -32,185 +32,185 @@ import java.util.*;
 
 public class SimpleRule extends AbstractRule<SimplePredicate, SimpleLiteral> {
 
-    public static SimpleRule make(ValidRule rule, FunctionCallFactory funcFactory) throws InvalidProgramException {
-        Map<Var, Integer> varCounts = rule.countVariables();
-        Simplifier simplifier = new Simplifier(varCounts);
-        for (ComplexLiteral atom : rule) {
-            try {
-                simplifier.add(atom);
-            } catch (InvalidProgramException e) {
-                throw new InvalidProgramException("Problem simplifying this rule:\n" + rule
-                        + "\nCould not simplify this atom: " + atom + "\nReason:\n" + e.getMessage());
-            }
-        }
-        UserPredicate head = rule.getHead().applySubstitution(simplifier.getSubst());
-        Set<Var> boundVars = simplifier.getBoundVars();
-        if (!boundVars.containsAll(head.varSet())) {
-            throw new InvalidProgramException("Unbound variables in head of rule:\n" + rule);
-        }
-        Term[] headArgs = head.getArgs();
-        BindingType[] pat = computeBindingPattern(headArgs, boundVars, varCounts);
-        SimplePredicate newHead = SimplePredicate.make(head.getSymbol(), head.getArgs(), pat, head.isNegated());
-        return new SimpleRule(newHead, simplifier.getConjuncts());
-    }
+	public static SimpleRule make(ValidRule rule, FunctionCallFactory funcFactory) throws InvalidProgramException {
+		Map<Var, Integer> varCounts = rule.countVariables();
+		Simplifier simplifier = new Simplifier(varCounts);
+		for (ComplexLiteral atom : rule) {
+			try {
+				simplifier.add(atom);
+			} catch (InvalidProgramException e) {
+				throw new InvalidProgramException("Problem simplifying this rule:\n" + rule
+						+ "\nCould not simplify this atom: " + atom + "\nReason:\n" + e.getMessage());
+			}
+		}
+		UserPredicate head = rule.getHead().applySubstitution(simplifier.getSubst());
+		Set<Var> boundVars = simplifier.getBoundVars();
+		if (!boundVars.containsAll(head.varSet())) {
+			throw new InvalidProgramException("Unbound variables in head of rule:\n" + rule);
+		}
+		Term[] headArgs = head.getArgs();
+		BindingType[] pat = computeBindingPattern(headArgs, boundVars, varCounts);
+		SimplePredicate newHead = SimplePredicate.make(head.getSymbol(), head.getArgs(), pat, head.isNegated());
+		return new SimpleRule(newHead, simplifier.getConjuncts());
+	}
 
-    // XXX This isn't great because it doesn't check to make sure the invariants of
-    // a SimpleRule are actually maintained.
+	// XXX This isn't great because it doesn't check to make sure the invariants of
+	// a SimpleRule are actually maintained.
 //	public static SimpleRule make(SimplePredicate head, List<SimpleLiteral> body) {
 //		return new SimpleRule(head, body);
 //	}
 
-    private SimpleRule(SimplePredicate head, List<SimpleLiteral> body) {
-        super(head, body);
-    }
+	private SimpleRule(SimplePredicate head, List<SimpleLiteral> body) {
+		super(head, body);
+	}
 
-    private static BindingType[] computeBindingPattern(Term[] args, Set<Var> boundVars, Map<Var, Integer> counts) {
-        BindingType[] pat = new BindingType[args.length];
-        for (int i = 0; i < pat.length; ++i) {
-            Term arg = args[i];
-            if (arg instanceof Var && Integer.valueOf(1).equals(counts.get(arg))) {
-                pat[i] = BindingType.IGNORED;
-            } else if (boundVars.containsAll(arg.varSet())) {
-                pat[i] = BindingType.BOUND;
-            } else {
-                pat[i] = BindingType.FREE;
-            }
-        }
-        return pat;
-    }
+	private static BindingType[] computeBindingPattern(Term[] args, Set<Var> boundVars, Map<Var, Integer> counts) {
+		BindingType[] pat = new BindingType[args.length];
+		for (int i = 0; i < pat.length; ++i) {
+			Term arg = args[i];
+			if (arg instanceof Var && Integer.valueOf(1).equals(counts.get(arg))) {
+				pat[i] = BindingType.IGNORED;
+			} else if (boundVars.containsAll(arg.varSet())) {
+				pat[i] = BindingType.BOUND;
+			} else {
+				pat[i] = BindingType.FREE;
+			}
+		}
+		return pat;
+	}
 
-    private static class Simplifier {
+	private static class Simplifier {
 
-        private final List<SimpleLiteral> acc = new ArrayList<>();
-        private final Set<Var> boundVars = new HashSet<>();
-        private final Map<Var, Integer> varCounts;
-        private final Substitution subst = new SimpleSubstitution();
+		private final List<SimpleLiteral> acc = new ArrayList<>();
+		private final Set<Var> boundVars = new HashSet<>();
+		private final Map<Var, Integer> varCounts;
+		private final Substitution subst = new SimpleSubstitution();
 
-        public Simplifier(Map<Var, Integer> varCounts) {
-            this.varCounts = varCounts;
-        }
+		public Simplifier(Map<Var, Integer> varCounts) {
+			this.varCounts = varCounts;
+		}
 
-        public Substitution getSubst() {
-            return subst;
-        }
+		public Substitution getSubst() {
+			return subst;
+		}
 
-        public void add(ComplexLiteral atom) throws InvalidProgramException {
-            List<ComplexLiteral> todo = new ArrayList<>();
-            atom = atom.applySubstitution(subst);
-            SimpleLiteral c = atom.accept(new ComplexLiteralExnVisitor<Void, SimpleLiteral, InvalidProgramException>() {
+		public void add(ComplexLiteral atom) throws InvalidProgramException {
+			List<ComplexLiteral> todo = new ArrayList<>();
+			atom = atom.applySubstitution(subst);
+			SimpleLiteral c = atom.accept(new ComplexLiteralExnVisitor<Void, SimpleLiteral, InvalidProgramException>() {
 
-                @Override
-                public SimpleLiteral visit(UnificationPredicate unificationPredicate, Void input)
-                        throws InvalidProgramException {
-                    Term lhs = unificationPredicate.getLhs();
-                    Term rhs = unificationPredicate.getRhs();
-                    boolean leftBound = boundVars.containsAll(lhs.varSet());
-                    boolean rightBound = boundVars.containsAll(rhs.varSet());
-                    if (unificationPredicate.isNegated() && !(leftBound && rightBound)) {
-                        throw new InvalidProgramException();
-                    }
-                    if (leftBound && rightBound) {
-                        return Check.make(lhs, rhs, unificationPredicate.isNegated());
-                    } else if (rightBound) {
-                        if (lhs instanceof Var) {
-                            if (Configuration.inlineInRules || rhs instanceof Var) {
-                                subst.put((Var) lhs, rhs);
-                                return null;
-                            }
-                            return Assignment.make((Var) lhs, rhs);
-                        }
-                        if (!(lhs instanceof Constructor)) {
-                            throw new InvalidProgramException();
-                        }
-                        return makeDestructor(rhs, (Constructor) lhs, todo);
-                    } else if (leftBound) {
-                        if (rhs instanceof Var) {
-                            if (Configuration.inlineInRules || lhs instanceof Var) {
-                                subst.put((Var) rhs, lhs);
-                                return null;
-                            }
-                            return Assignment.make((Var) rhs, lhs);
-                        }
-                        if (!(rhs instanceof Constructor)) {
-                            throw new InvalidProgramException();
-                        }
-                        return makeDestructor(lhs, (Constructor) rhs, todo);
-                    } else {
-                        if (!(lhs instanceof Constructor) || !(rhs instanceof Constructor)) {
-                            throw new InvalidProgramException();
-                        }
-                        Constructor c1 = (Constructor) lhs;
-                        Constructor c2 = (Constructor) rhs;
-                        if (!c1.getSymbol().equals(c2.getSymbol())) {
-                            throw new InvalidProgramException("Unsatisfiable unification conjunct");
-                        }
-                        List<ComplexLiteral> cs = new ArrayList<>();
-                        Term[] args1 = c1.getArgs();
-                        Term[] args2 = c2.getArgs();
-                        for (int i = 0; i < args1.length; ++i) {
-                            cs.add(UnificationPredicate.make(args1[i], args2[i], false));
-                        }
-                        // XXX Not reordering because of type soundness issues.
-                        // ValidRule.order(cs, (p, xs) -> 1, new HashSet<>(boundVars), varCounts);
-                        for (ComplexLiteral c : cs) {
-                            todo.add(c);
-                        }
-                        return null;
-                    }
-                }
+				@Override
+				public SimpleLiteral visit(UnificationPredicate unificationPredicate, Void input)
+						throws InvalidProgramException {
+					Term lhs = unificationPredicate.getLhs();
+					Term rhs = unificationPredicate.getRhs();
+					boolean leftBound = boundVars.containsAll(lhs.varSet());
+					boolean rightBound = boundVars.containsAll(rhs.varSet());
+					if (unificationPredicate.isNegated() && !(leftBound && rightBound)) {
+						throw new InvalidProgramException();
+					}
+					if (leftBound && rightBound) {
+						return Check.make(lhs, rhs, unificationPredicate.isNegated());
+					} else if (rightBound) {
+						if (lhs instanceof Var) {
+							if (Configuration.inlineInRules || rhs instanceof Var) {
+								subst.put((Var) lhs, rhs);
+								return null;
+							}
+							return Assignment.make((Var) lhs, rhs);
+						}
+						if (!(lhs instanceof Constructor)) {
+							throw new InvalidProgramException();
+						}
+						return makeDestructor(rhs, (Constructor) lhs, todo);
+					} else if (leftBound) {
+						if (rhs instanceof Var) {
+							if (Configuration.inlineInRules || lhs instanceof Var) {
+								subst.put((Var) rhs, lhs);
+								return null;
+							}
+							return Assignment.make((Var) rhs, lhs);
+						}
+						if (!(rhs instanceof Constructor)) {
+							throw new InvalidProgramException();
+						}
+						return makeDestructor(lhs, (Constructor) rhs, todo);
+					} else {
+						if (!(lhs instanceof Constructor) || !(rhs instanceof Constructor)) {
+							throw new InvalidProgramException();
+						}
+						Constructor c1 = (Constructor) lhs;
+						Constructor c2 = (Constructor) rhs;
+						if (!c1.getSymbol().equals(c2.getSymbol())) {
+							throw new InvalidProgramException("Unsatisfiable unification conjunct");
+						}
+						List<ComplexLiteral> cs = new ArrayList<>();
+						Term[] args1 = c1.getArgs();
+						Term[] args2 = c2.getArgs();
+						for (int i = 0; i < args1.length; ++i) {
+							cs.add(UnificationPredicate.make(args1[i], args2[i], false));
+						}
+						// XXX Not reordering because of type soundness issues.
+						// ValidRule.order(cs, (p, xs) -> 1, new HashSet<>(boundVars), varCounts);
+						for (ComplexLiteral c : cs) {
+							todo.add(c);
+						}
+						return null;
+					}
+				}
 
-                private Destructor makeDestructor(Term boundTerm, Constructor unboundCtor, List<ComplexLiteral> todo) {
-                    Term[] args = unboundCtor.getArgs();
-                    Var[] vars = new Var[args.length];
-                    for (int i = 0; i < args.length; ++i) {
-                        Var y = Var.fresh();
-                        vars[i] = y;
-                        todo.add(UnificationPredicate.make(y, args[i], false));
-                    }
-                    return Destructor.make(boundTerm, unboundCtor.getSymbol(), vars);
-                }
+				private Destructor makeDestructor(Term boundTerm, Constructor unboundCtor, List<ComplexLiteral> todo) {
+					Term[] args = unboundCtor.getArgs();
+					Var[] vars = new Var[args.length];
+					for (int i = 0; i < args.length; ++i) {
+						Var y = Var.fresh();
+						vars[i] = y;
+						todo.add(UnificationPredicate.make(y, args[i], false));
+					}
+					return Destructor.make(boundTerm, unboundCtor.getSymbol(), vars);
+				}
 
-                @Override
-                public SimpleLiteral visit(UserPredicate userPredicate, Void input) {
-                    Term[] args = userPredicate.getArgs();
-                    Term[] newArgs = new Term[args.length];
-                    Set<Var> seen = new HashSet<>();
-                    for (int i = 0; i < args.length; ++i) {
-                        Term arg = args[i];
-                        if (boundVars.containsAll(arg.varSet())) {
-                            newArgs[i] = arg;
-                        } else if (arg instanceof Var && seen.add((Var) arg)) {
-                            newArgs[i] = arg;
-                        } else {
-                            Var y = Var.fresh();
-                            newArgs[i] = y;
-                            todo.add(UnificationPredicate.make(y, arg, false));
-                        }
-                    }
-                    BindingType[] pat = computeBindingPattern(newArgs, boundVars, varCounts);
-                    SimpleLiteral c = SimplePredicate.make(userPredicate.getSymbol(), newArgs, pat,
-                            userPredicate.isNegated());
-                    return c;
-                }
+				@Override
+				public SimpleLiteral visit(UserPredicate userPredicate, Void input) {
+					Term[] args = userPredicate.getArgs();
+					Term[] newArgs = new Term[args.length];
+					Set<Var> seen = new HashSet<>();
+					for (int i = 0; i < args.length; ++i) {
+						Term arg = args[i];
+						if (boundVars.containsAll(arg.varSet())) {
+							newArgs[i] = arg;
+						} else if (arg instanceof Var && seen.add((Var) arg)) {
+							newArgs[i] = arg;
+						} else {
+							Var y = Var.fresh();
+							newArgs[i] = y;
+							todo.add(UnificationPredicate.make(y, arg, false));
+						}
+					}
+					BindingType[] pat = computeBindingPattern(newArgs, boundVars, varCounts);
+					SimpleLiteral c = SimplePredicate.make(userPredicate.getSymbol(), newArgs, pat,
+							userPredicate.isNegated());
+					return c;
+				}
 
-            }, null);
-            if (c != null) {
-                acc.add(c);
-                boundVars.addAll(c.varSet());
-            }
-            for (ComplexLiteral x : todo) {
-                add(x);
-            }
-        }
+			}, null);
+			if (c != null) {
+				acc.add(c);
+				boundVars.addAll(c.varSet());
+			}
+			for (ComplexLiteral x : todo) {
+				add(x);
+			}
+		}
 
-        public List<SimpleLiteral> getConjuncts() {
-            return acc;
-        }
+		public List<SimpleLiteral> getConjuncts() {
+			return acc;
+		}
 
-        public Set<Var> getBoundVars() {
-            return boundVars;
-        }
+		public Set<Var> getBoundVars() {
+			return boundVars;
+		}
 
-    }
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveEvaluationTest.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.codegen;
 
 import edu.harvard.seas.pl.formulog.Configuration;
 
-
 import edu.harvard.seas.pl.formulog.eval.CommonEvaluationTest;
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveEvaluation;
 
@@ -30,10 +29,11 @@ public class CompiledSemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNa
 
 	static {
 		if (!Configuration.testCodegen) {
-			System.err.println("WARNING: skipping CompiledSemiNaiveEvaluationTest; enable with system property `-DtestCodegen`");
+			System.err.println(
+					"WARNING: skipping CompiledSemiNaiveEvaluationTest; enable with system property `-DtestCodegen`");
 		}
 	}
-	
+
 	public CompiledSemiNaiveEvaluationTest() {
 		super(Configuration.testCodegen ? new CompiledSemiNaiveTester() : new NopTester<>());
 	}

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveMagicSetTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveMagicSetTest.java
@@ -22,7 +22,6 @@ package edu.harvard.seas.pl.formulog.codegen;
 
 import edu.harvard.seas.pl.formulog.Configuration;
 
-
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveEvaluation;
 import edu.harvard.seas.pl.formulog.magic.CommonMagicSetTest;
 
@@ -30,10 +29,11 @@ public class CompiledSemiNaiveMagicSetTest extends CommonMagicSetTest<SemiNaiveE
 
 	static {
 		if (!Configuration.testCodegen) {
-			System.err.println("WARNING: skipping CompiledSemiNaiveMagicSetTest; enable with system property `-DtestCodegen`");
+			System.err.println(
+					"WARNING: skipping CompiledSemiNaiveMagicSetTest; enable with system property `-DtestCodegen`");
 		}
 	}
-	
+
 	public CompiledSemiNaiveMagicSetTest() {
 		super(Configuration.testCodegen ? new CompiledSemiNaiveTester() : new NopTester<>());
 	}

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveTester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/CompiledSemiNaiveTester.java
@@ -44,106 +44,106 @@ import static org.junit.Assert.fail;
 
 public class CompiledSemiNaiveTester implements Tester {
 
-    private List<String> inputDirs = Collections.emptyList();
+	private List<String> inputDirs = Collections.emptyList();
 
-    @Override
-    public void test(String file, List<String> inputDirs) {
-        boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
-        Path topPath = null;
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(file);
-            if (is == null) {
-                throw new FileNotFoundException(file + " not found");
-            }
-            List<Path> dirs = new ArrayList<>();
-            for (String inputDir : inputDirs) {
-                URL dir = getClass().getClassLoader().getResource(inputDir);
-                dirs.add(Paths.get(dir.toURI()));
-            }
-            BasicProgram prog = new Parser().parse(new InputStreamReader(is), dirs);
-            WellTypedProgram wtp = new TypeChecker(prog).typeCheck();
-            MagicSetTransformer mst = new MagicSetTransformer(wtp);
-            BasicProgram magicProg = mst.transform(true, true);
-            String name = file.substring(0, file.indexOf('.'));
-            topPath = Path.of("codegen", "tests", name);
-            boolean ok = evaluate(name, topPath, magicProg);
-            if (!ok && !isBad) {
-                String msg = "Test failed for a good program";
-                fail(msg);
-            }
-            if (ok && isBad) {
-                fail("Test succeeded for a bad program");
-            }
-        } catch (Exception e) {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream out = new PrintStream(baos);
-            out.println("Unexpected exception:");
-            e.printStackTrace(out);
-            fail(baos.toString());
-        } finally {
-            if (!Configuration.keepCodegenTestDirs && topPath != null) {
-                Util.clean(topPath.toFile(), true);
-            }
-        }
-    }
+	@Override
+	public void test(String file, List<String> inputDirs) {
+		boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
+		Path topPath = null;
+		try {
+			InputStream is = getClass().getClassLoader().getResourceAsStream(file);
+			if (is == null) {
+				throw new FileNotFoundException(file + " not found");
+			}
+			List<Path> dirs = new ArrayList<>();
+			for (String inputDir : inputDirs) {
+				URL dir = getClass().getClassLoader().getResource(inputDir);
+				dirs.add(Paths.get(dir.toURI()));
+			}
+			BasicProgram prog = new Parser().parse(new InputStreamReader(is), dirs);
+			WellTypedProgram wtp = new TypeChecker(prog).typeCheck();
+			MagicSetTransformer mst = new MagicSetTransformer(wtp);
+			BasicProgram magicProg = mst.transform(true, true);
+			String name = file.substring(0, file.indexOf('.'));
+			topPath = Path.of("codegen", "tests", name);
+			boolean ok = evaluate(name, topPath, magicProg);
+			if (!ok && !isBad) {
+				String msg = "Test failed for a good program";
+				fail(msg);
+			}
+			if (ok && isBad) {
+				fail("Test succeeded for a bad program");
+			}
+		} catch (Exception e) {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			PrintStream out = new PrintStream(baos);
+			out.println("Unexpected exception:");
+			e.printStackTrace(out);
+			fail(baos.toString());
+		} finally {
+			if (!Configuration.keepCodegenTestDirs && topPath != null) {
+				Util.clean(topPath.toFile(), true);
+			}
+		}
+	}
 
-    private boolean evaluate(String name, Path topPath, BasicProgram prog) throws Exception {
-        File srcDir = topPath.resolve("src").toFile();
-        srcDir.mkdirs();
-        Util.clean(srcDir, false);
-        Path buildPath = topPath.resolve("build");
-        CodeGen cg = new CodeGen(prog, topPath.toFile());
-        cg.go();
-        var cmakeCmds = new ArrayList<>(Arrays.asList("cmake", "-B", buildPath.toString(), "-S", topPath.toString(),
-                "-DCMAKE_BUILD_TYPE=Debug"));
-        if (Configuration.cxxCompiler != null) {
-            cmakeCmds.add("-DCMAKE_CXX_COMPILER=" + Configuration.cxxCompiler);
-        }
-        Process cmake = Runtime.getRuntime().exec(cmakeCmds.toArray(new String[0]));
-        if (cmake.waitFor() != 0) {
-            System.err.println("Could not cmake test");
-            printToStdErr(cmake.getErrorStream());
-            return false;
-        }
+	private boolean evaluate(String name, Path topPath, BasicProgram prog) throws Exception {
+		File srcDir = topPath.resolve("src").toFile();
+		srcDir.mkdirs();
+		Util.clean(srcDir, false);
+		Path buildPath = topPath.resolve("build");
+		CodeGen cg = new CodeGen(prog, topPath.toFile());
+		cg.go();
+		var cmakeCmds = new ArrayList<>(Arrays.asList("cmake", "-B", buildPath.toString(), "-S", topPath.toString(),
+				"-DCMAKE_BUILD_TYPE=Debug"));
+		if (Configuration.cxxCompiler != null) {
+			cmakeCmds.add("-DCMAKE_CXX_COMPILER=" + Configuration.cxxCompiler);
+		}
+		Process cmake = Runtime.getRuntime().exec(cmakeCmds.toArray(new String[0]));
+		if (cmake.waitFor() != 0) {
+			System.err.println("Could not cmake test");
+			printToStdErr(cmake.getErrorStream());
+			return false;
+		}
 
-        Process make = Runtime.getRuntime().exec(new String[]{"cmake", "--build", buildPath.toString(),
-                "-j", String.valueOf(Main.parallelism)});
-        if (make.waitFor() != 0) {
-            System.err.println("Could not make test");
-            printToStdErr(make.getErrorStream());
-            return false;
-        }
+		Process make = Runtime.getRuntime().exec(
+				new String[] { "cmake", "--build", buildPath.toString(), "-j", String.valueOf(Main.parallelism) });
+		if (make.waitFor() != 0) {
+			System.err.println("Could not make test");
+			printToStdErr(make.getErrorStream());
+			return false;
+		}
 
-        String cmd = topPath.resolve("build").resolve("flg").toString();
-        for (String inputDir : inputDirs) {
-            Path p = Paths.get(getClass().getClassLoader().getResource(inputDir).toURI());
-            cmd += " --fact-dir " + p;
-        }
-        cmd += " --dump-sizes";
+		String cmd = topPath.resolve("build").resolve("flg").toString();
+		for (String inputDir : inputDirs) {
+			Path p = Paths.get(getClass().getClassLoader().getResource(inputDir).toURI());
+			cmd += " --fact-dir " + p;
+		}
+		cmd += " --dump-sizes";
 
-        Process flg = Runtime.getRuntime().exec(cmd);
-        if (flg.waitFor() != 0) {
-            System.err.println("Evaluation error");
-            printToStdErr(flg.getErrorStream());
-            return false;
-        }
+		Process flg = Runtime.getRuntime().exec(cmd);
+		if (flg.waitFor() != 0) {
+			System.err.println("Evaluation error");
+			printToStdErr(flg.getErrorStream());
+			return false;
+		}
 
-        BufferedReader br = new BufferedReader(new InputStreamReader(flg.getInputStream()));
-        String line;
-        while ((line = br.readLine()) != null) {
-            if (line.equals("ok: 1") || line.equals("query__ok: 1")) {
-                return true;
-            }
-        }
-        return false;
-    }
+		BufferedReader br = new BufferedReader(new InputStreamReader(flg.getInputStream()));
+		String line;
+		while ((line = br.readLine()) != null) {
+			if (line.equals("ok: 1") || line.equals("query__ok: 1")) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    private static void printToStdErr(InputStream is) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(is));
-        String line;
-        while ((line = br.readLine()) != null) {
-            System.err.println(line);
-        }
-    }
+	private static void printToStdErr(InputStream is) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(is));
+		String line;
+		while ((line = br.readLine()) != null) {
+			System.err.println(line);
+		}
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/codegen/NopTester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/codegen/NopTester.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.codegen;
  * #L%
  */
 
-
 import java.util.List;
 
 import edu.harvard.seas.pl.formulog.eval.Evaluation;
@@ -28,9 +27,9 @@ import edu.harvard.seas.pl.formulog.eval.Tester;
 
 public class NopTester<T extends Evaluation> implements Tester {
 
-    @Override
-    public void test(String file, List<String> inputDirs) {
-        // do nothing
-    }
+	@Override
+	public void test(String file, List<String> inputDirs) {
+		// do nothing
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/AbstractEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/AbstractEvaluationTest.java
@@ -20,24 +20,23 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.Collections;
 import java.util.List;
 
 public abstract class AbstractEvaluationTest<T extends Evaluation> {
 
-    private final Tester tester;
+	private final Tester tester;
 
-    public AbstractEvaluationTest(Tester tester) {
-        this.tester = tester;
-    }
+	public AbstractEvaluationTest(Tester tester) {
+		this.tester = tester;
+	}
 
-    protected void test(String file, List<String> inputDirs) {
-        tester.test(file, inputDirs);
-    }
+	protected void test(String file, List<String> inputDirs) {
+		tester.test(file, inputDirs);
+	}
 
-    protected void test(String file) {
-        test(file, Collections.singletonList(""));
-    }
+	protected void test(String file) {
+		test(file, Collections.singletonList(""));
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/AbstractTester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/AbstractTester.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -42,41 +41,41 @@ import edu.harvard.seas.pl.formulog.validating.InvalidProgramException;
 
 public abstract class AbstractTester<T extends Evaluation> implements Tester {
 
-    @Override
-    public void test(String file, List<String> inputDirs) {
-        boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(file);
-            if (is == null) {
-                throw new FileNotFoundException(file + " not found");
-            }
-            List<Path> dirs = new ArrayList<>();
-            for (String inputDir : inputDirs) {
-                URL dir = getClass().getClassLoader().getResource(inputDir);
-                dirs.add(Paths.get(dir.toURI()));
-            }
-            BasicProgram prog = new Parser().parse(new InputStreamReader(is), dirs);
-            WellTypedProgram wellTypedProg = (new TypeChecker(prog)).typeCheck();
-            T eval = setup(wellTypedProg);
-            boolean ok = evaluate(eval);
-            if (!ok && !isBad) {
-                String msg = "Test failed for a good program";
-                fail(msg);
-            }
-            if (ok && isBad) {
-                fail("Test succeeded for a bad program");
-            }
-        } catch (Exception e) {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream out = new PrintStream(baos);
-            out.println("Unexpected exception:");
-            e.printStackTrace(out);
-            fail(baos.toString());
-        }
-    }
+	@Override
+	public void test(String file, List<String> inputDirs) {
+		boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
+		try {
+			InputStream is = getClass().getClassLoader().getResourceAsStream(file);
+			if (is == null) {
+				throw new FileNotFoundException(file + " not found");
+			}
+			List<Path> dirs = new ArrayList<>();
+			for (String inputDir : inputDirs) {
+				URL dir = getClass().getClassLoader().getResource(inputDir);
+				dirs.add(Paths.get(dir.toURI()));
+			}
+			BasicProgram prog = new Parser().parse(new InputStreamReader(is), dirs);
+			WellTypedProgram wellTypedProg = (new TypeChecker(prog)).typeCheck();
+			T eval = setup(wellTypedProg);
+			boolean ok = evaluate(eval);
+			if (!ok && !isBad) {
+				String msg = "Test failed for a good program";
+				fail(msg);
+			}
+			if (ok && isBad) {
+				fail("Test succeeded for a bad program");
+			}
+		} catch (Exception e) {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			PrintStream out = new PrintStream(baos);
+			out.println("Unexpected exception:");
+			e.printStackTrace(out);
+			fail(baos.toString());
+		}
+	}
 
-    protected abstract T setup(WellTypedProgram prog) throws InvalidProgramException, EvaluationException;
+	protected abstract T setup(WellTypedProgram prog) throws InvalidProgramException, EvaluationException;
 
-    protected abstract boolean evaluate(T eval) throws EvaluationException;
+	protected abstract boolean evaluate(T eval) throws EvaluationException;
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/CommonEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/CommonEvaluationTest.java
@@ -22,893 +22,880 @@ package edu.harvard.seas.pl.formulog.eval;
 
 import java.util.Arrays;
 
-
 import org.junit.Test;
 
 public abstract class CommonEvaluationTest<T extends Evaluation> extends AbstractEvaluationTest<T> {
 
-    public CommonEvaluationTest(Tester tester) {
-        super(tester);
-    }
-
-    @Test
-    public void test018() {
-        test("test018_ok.flg");
-    }
-
-    @Test
-    public void test019() {
-        test("test019_ok.flg");
-    }
-
-    @Test
-    public void test020() {
-        test("test020_ok.flg");
-    }
-
-    @Test
-    public void test021() {
-        test("test021_ok.flg");
-    }
-
-    @Test
-    public void test022() {
-        test("test022_ok.flg");
-    }
-
-    @Test
-    public void test023() {
-        test("test023_ok.flg");
-    }
-
-    @Test
-    public void test024() {
-        test("test024_ok.flg");
-    }
-
-    @Test
-    public void test027() {
-        test("test027_ok.flg");
-    }
-
-    @Test
-    public void test029() {
-        test("test029_ok.flg");
-    }
-
-    @Test
-    public void test030() {
-        test("test030_ok.flg");
-    }
-
-    @Test
-    public void test032() {
-        test("test032_ok.flg");
-    }
-
-    @Test
-    public void test033() {
-        test("test033_ok.flg");
-    }
-
-    @Test
-    public void test034() {
-        test("test034_ok.flg");
-    }
-
-    @Test
-    public void test035() {
-        test("test035_ok.flg");
-    }
-
-    @Test
-    public void test037() {
-        test("test037_ok.flg");
-    }
-
-    @Test
-    public void test038() {
-        test("test038_ok.flg");
-    }
-
-    @Test
-    public void test039() {
-        test("test039_ok.flg");
-    }
-
-    @Test
-    public void test040() {
-        test("test040_ok.flg");
-    }
-
-    @Test
-    public void test041() {
-        test("test041_ok.flg");
-    }
-
-    @Test
-    public void test043() {
-        test("test043_ok.flg");
-    }
-
-    @Test
-    public void test044() {
-        test("test044_ok.flg");
-    }
-
-    @Test
-    public void test045() {
-        test("test045_ok.flg");
-    }
-
-    @Test
-    public void test046() {
-        test("test046_ok.flg");
-    }
-
-    @Test
-    public void test047() {
-        test("test047_ok.flg");
-    }
-
-    @Test
-    public void test048() {
-        test("test048_ok.flg");
-    }
-
-    @Test
-    public void test056() {
-        test("test056_ok.flg");
-    }
-
-    @Test
-    public void test057() {
-        test("test057_ok.flg");
-    }
-
-    @Test
-    public void test058() {
-        test("test058_ok.flg");
-    }
-
-    @Test
-    public void test061() {
-        test("test061_ok.flg");
-    }
-
-    @Test
-    public void test062() {
-        test("test062_ok.flg");
-    }
-
-    @Test
-    public void test063() {
-        test("test063_ok.flg");
-    }
-
-    @Test
-    public void test064() {
-        test("test064_ok.flg");
-    }
-
-    @Test
-    public void test065() {
-        test("test065_ok.flg");
-    }
-
-    @Test
-    public void test066() {
-        test("test066_ok.flg");
-    }
-
-    @Test
-    public void test067() {
-        test("test067_ok.flg");
-    }
-
-    @Test
-    public void test068() {
-        test("test068_ok.flg");
-    }
-
-    @Test
-    public void test069() {
-        test("test069_ok.flg");
-    }
-
-    @Test
-    public void test070() {
-        test("test070_ok.flg");
-    }
-
-    @Test
-    public void test071() {
-        test("test071_ok.flg");
-    }
-
-    @Test
-    public void test072() {
-        test("test072_ok.flg");
-    }
-
-    @Test
-    public void test073() {
-        test("test073_ok.flg");
-    }
-
-    @Test
-    public void test077() {
-        test("test077_ok.flg");
-    }
-
-    @Test
-    public void test078() {
-        test("test078_ok.flg");
-    }
-
-    @Test
-    public void test079() {
-        test("test079_ok.flg");
-    }
-
-    @Test
-    public void test081() {
-        test("test081_ok.flg");
-    }
-
-    @Test
-    public void test082() {
-        test("test082_ok.flg");
-    }
-
-    @Test
-    public void test083() {
-        test("test083_ok.flg");
-    }
-
-    @Test
-    public void test084() {
-        test("test084_ok.flg");
-    }
-
-    @Test
-    public void test085() {
-        test("test085_ok.flg");
-    }
-
-    @Test
-    public void test086() {
-        test("test086_ok.flg");
-    }
-
-    @Test
-    public void test087() {
-        test("test087_ok.flg");
-    }
-
-    @Test
-    public void test088() {
-        test("test088_ok.flg");
-    }
-
-    @Test
-    public void test089() {
-        test("test089_ok.flg");
-    }
-
-    @Test
-    public void test090() {
-        test("test090_ok.flg");
-    }
-
-    @Test
-    public void test092() {
-        test("test092_ok.flg");
-    }
-
-    @Test
-    public void test093() {
-        test("test093_ok.flg");
-    }
-
-    @Test
-    public void test094() {
-        test("test094_ok.flg");
-    }
-
-    @Test
-    public void test095() {
-        test("test095_ok.flg");
-    }
-
-    @Test
-    public void test096() {
-        test("test096_ok.flg");
-    }
-
-    @Test
-    public void test097() {
-        test("test097_ok.flg");
-    }
-
-    @Test
-    public void test099() {
-        test("test099_ok.flg");
-    }
-
-    @Test
-    public void test100() {
-        test("test100_ok.flg");
-    }
-
-    @Test
-    public void test102() {
-        test("test102_ok.flg");
-    }
-
-    @Test
-    public void test103() {
-        test("test103_ok.flg");
-    }
-
-    @Test
-    public void test104() {
-        test("test104_ok.flg");
-    }
-
-    @Test
-    public void test105() {
-        test("test105_ok.flg");
-    }
-
-    @Test
-    public void test106() {
-        test("test106_ok.flg");
-    }
-
-    @Test
-    public void test107() {
-        test("test107_ok.flg");
-    }
-
-    @Test
-    public void test108() {
-        test("test108_ok.flg");
-    }
-
-    @Test
-    public void test109() {
-        test("test109_ok.flg");
-    }
-
-    @Test
-    public void test110() {
-        test("test110_ok.flg");
-    }
-
-    @Test
-    public void test111() {
-        test("test111_ok.flg");
-    }
-
-    @Test
-    public void test112() {
-        test("test112_ok.flg");
-    }
-
-    @Test
-    public void test113() {
-        test("test113_ok.flg");
-    }
-
-    @Test
-    public void test114() {
-        test("test114_ok.flg");
-    }
-
-    @Test
-    public void test115() {
-        test("test115_ok.flg");
-    }
-
-    @Test
-    public void test116() {
-        test("test116_ok.flg");
-    }
-
-    @Test
-    public void test117() {
-        test("test117_ok.flg");
-    }
-
-    @Test
-    public void test119() {
-        test("test119_ok.flg");
-    }
-
-    @Test
-    public void test120() {
-        test("test120_ok.flg");
-    }
-
-    @Test
-    public void test121() {
-        test("test121_ok.flg");
-    }
-
-    @Test
-    public void test122() {
-        test("test122_ok.flg");
-    }
-
-    @Test
-    public void test123() {
-        test("test123_ok.flg");
-    }
-
-    @Test
-    public void test124() {
-        test("test124_ok.flg");
-    }
-
-    @Test
-    public void test125() {
-        test("test125_ok.flg");
-    }
-
-    @Test
-    public void test126() {
-        test("test126_ok.flg");
-    }
-
-    @Test
-    public void test127() {
-        test("test127_ok.flg");
-    }
-
-    @Test
-    public void test128() {
-        test("test128_ok.flg");
-    }
-
-    @Test
-    public void test129() {
-        test("test129_ok.flg");
-    }
-
-    @Test
-    public void test134() {
-        test("test134_ok.flg");
-    }
-
-    @Test
-    public void test135() {
-        test("test135_ok.flg");
-    }
-
-    @Test
-    public void test136() {
-        test("test136_ok.flg");
-    }
-
-    @Test
-    public void test137() {
-        test("test137_ok.flg");
-    }
-
-    /*
-    No longer supporting this semantics
-    @Test
-    public void test138() {
-        test("test138_ok.flg");
-    }
-     */
-
-    @Test
-    public void test139() {
-        test("test139_ok.flg");
-    }
-
-    @Test
-    public void test180() {
-        test("test180_ok.flg");
-    }
-
-    @Test
-    public void test181() {
-        test("test181_ok.flg");
-    }
-
-    @Test
-    public void test182() {
-        test("test182_ok.flg");
-    }
-
-    @Test
-    public void test183() {
-        test("test183_ok.flg");
-    }
-
-    @Test
-    public void test184() {
-        test("test184_ok.flg");
-    }
-
-    @Test
-    public void test186() {
-        test("test186_ok.flg");
-    }
-
-    @Test
-    public void test187() {
-        test("test187_ok.flg");
-    }
-
-    @Test
-    public void test189() {
-        test("test189_ok.flg");
-    }
-
-    @Test
-    public void test190() {
-        test("test190_ok.flg");
-    }
-
-    @Test
-    public void test191() {
-        test("test191_ok.flg", Arrays.asList("test191_input"));
-    }
-
-    @Test
-    public void test192() {
-        test("test192_ok.flg");
-    }
-
-    @Test
-    public void test193() {
-        test("test193_ok.flg");
-    }
-
-    @Test
-    public void test238() {
-        test("test238_ok.flg");
-    }
-
-    @Test
-    public void test240() {
-        test("test240_ok.flg");
-    }
-
-    @Test
-    public void test241() {
-        test("test241_ok.flg");
-    }
-
-    @Test
-    public void test242() {
-        test("test242_ok.flg");
-    }
-
-    @Test
-    public void test243() {
-        test("test243_ok.flg");
-    }
-
-    @Test
-    public void test244() {
-        test("test244_ok.flg");
-    }
-
-    @Test
-    public void test245() {
-        test("test245_ok.flg");
-    }
-
-    @Test
-    public void test254() {
-        test("test254_ok.flg");
-    }
-
-    @Test
-    public void test256() {
-        test("test256_ok.flg");
-    }
-
-    @Test
-    public void test258() {
-        test("test258_ok.flg");
-    }
-
-    @Test
-    public void test259() {
-        test("test259_ok.flg");
-    }
-
-    @Test
-    public void test260() {
-        test("test260_ok.flg");
-    }
-
-    @Test
-    public void test261() {
-        test("test261_ok.flg");
-    }
-
-    @Test
-    public void test262() {
-        test("test262_ok.flg");
-    }
-
-    @Test
-    public void test263() {
-        test("test263_ok.flg");
-    }
-
-    @Test
-    public void test264() {
-        test("test264_ok.flg");
-    }
-
-    @Test
-    public void test265() {
-        test("test265_ok.flg");
-    }
-
-    @Test
-    public void test267() {
-        test("test267_ok.flg");
-    }
-
-    @Test
-    public void test273() {
-        test("test273_ok.flg");
-    }
-
-    @Test
-    public void test274() {
-        test("test274_ok.flg");
-    }
-
-    @Test
-    public void test275() {
-        test("test275_ok.flg");
-    }
-
-    @Test
-    public void test276() {
-        test("test276_ok.flg", Arrays.asList("test276_inputA", "test276_inputB"));
-    }
-
-    @Test
-    public void test277() {
-        test("test277_ok.flg");
-    }
-
-    @Test
-    public void test278() {
-        test("test278_ok.flg");
-    }
-
-    @Test
-    public void test279() {
-        test("test279_ok.flg");
-    }
-
-    @Test
-    public void test280() {
-        test("test280_ok.flg");
-    }
-
-    @Test
-    public void test281() {
-        test("test281_ok.flg");
-    }
-
-    @Test
-    public void test282() {
-        test("test282_ok.flg");
-    }
-
-    @Test
-    public void test283() {
-        test("test283_ok.flg");
-    }
-
-    @Test
-    public void test284() {
-        test("test284_ok.flg");
-    }
-
-    @Test
-    public void test285() {
-        test("test285_ok.flg");
-    }
-
-    @Test
-    public void test286() {
-        test("test286_ok.flg");
-    }
-
-    @Test
-    public void test287() {
-        test("test287_ok.flg");
-    }
-
-    @Test
-    public void test288() {
-        test("test288_ok.flg");
-    }
-
-    @Test
-    public void test289() {
-        test("test289_ok.flg");
-    }
-
-    @Test
-    public void test290() {
-        test("test290_ok.flg");
-    }
-
-    @Test
-    public void test291() {
-        test("test291_ok.flg");
-    }
-
-    @Test
-    public void test292() {
-        test("test292_ok.flg");
-    }
-
-    @Test
-    public void test297() {
-        test("test297_ok.flg");
-    }
-
-    @Test
-    public void test298() {
-        test("test298_ok.flg");
-    }
-
-    @Test
-    public void test299() {
-        test("test299_ok.flg");
-    }
-
-    @Test
-    public void test300() {
-        test("test300_ok.flg");
-    }
-
-    @Test
-    public void test301() {
-        test("test301_ok.flg");
-    }
-
-    @Test
-    public void test304() {
-        test("test304_ok.flg");
-    }
-
-    @Test
-    public void test305() {
-        test("test305_ok.flg");
-    }
-
-    @Test
-    public void test306() {
-        test("test306_ok.flg");
-    }
-
-    @Test
-    public void test308() {
-        test("test308_ok.flg");
-    }
-
-    @Test
-    public void test309() {
-        test("test309_ok.flg");
-    }
-
-    @Test
-    public void test310() {
-        test("test310_ok.flg");
-    }
-
-    @Test
-    public void test311() {
-        test("test311_ok.flg");
-    }
-
-    /* No longer supporting these semantics
-    @Test
-    public void test316() {
-        test("test316_ok.flg");
-    }
-
-    @Test
-    public void test317() {
-        test("test317_ok.flg");
-    }
-
-    @Test
-    public void test318() {
-        test("test318_ok.flg");
-    }
-
-    @Test
-    public void test319() {
-        test("test319_ok.flg");
-    }
-     */
-
-    @Test
-    public void test320() {
-        test("test320_ok.flg");
-    }
-
-    @Test
-    public void test321() {
-        test("test321_ok.flg");
-    }
-
-    @Test
-    public void test323() {
-        test("test323_ok.flg");
-    }
-
-    @Test
-    public void test324() {
-        test("test324_ok.flg");
-    }
-
-    @Test
-    public void test325() {
-        test("test325_ok.flg");
-    }
-
-    @Test
-    public void test326() {
-        test("test326_ok.flg");
-    }
-
-    @Test
-    public void test328() {
-        test("test328_ok.flg");
-    }
-
-    @Test
-    public void test329() {
-        test("test329_ok.flg");
-    }
-
-    @Test
-    public void test330() {
-        test("test330_ok.flg");
-    }
-
-    @Test
-    public void test331() {
-        test("test331_ok.flg");
-    }
-
-    @Test
-    public void test332() {
-        test("test332_ok.flg");
-    }
-
-    @Test
-    public void test334() {
-        test("test334_ok.flg");
-    }
-
-    @Test
-    public void test336() {
-        test("test336_ok.flg");
-    }
-
-    @Test
-    public void test337() {
-        test("test337_ok.flg");
-    }
+	public CommonEvaluationTest(Tester tester) {
+		super(tester);
+	}
+
+	@Test
+	public void test018() {
+		test("test018_ok.flg");
+	}
+
+	@Test
+	public void test019() {
+		test("test019_ok.flg");
+	}
+
+	@Test
+	public void test020() {
+		test("test020_ok.flg");
+	}
+
+	@Test
+	public void test021() {
+		test("test021_ok.flg");
+	}
+
+	@Test
+	public void test022() {
+		test("test022_ok.flg");
+	}
+
+	@Test
+	public void test023() {
+		test("test023_ok.flg");
+	}
+
+	@Test
+	public void test024() {
+		test("test024_ok.flg");
+	}
+
+	@Test
+	public void test027() {
+		test("test027_ok.flg");
+	}
+
+	@Test
+	public void test029() {
+		test("test029_ok.flg");
+	}
+
+	@Test
+	public void test030() {
+		test("test030_ok.flg");
+	}
+
+	@Test
+	public void test032() {
+		test("test032_ok.flg");
+	}
+
+	@Test
+	public void test033() {
+		test("test033_ok.flg");
+	}
+
+	@Test
+	public void test034() {
+		test("test034_ok.flg");
+	}
+
+	@Test
+	public void test035() {
+		test("test035_ok.flg");
+	}
+
+	@Test
+	public void test037() {
+		test("test037_ok.flg");
+	}
+
+	@Test
+	public void test038() {
+		test("test038_ok.flg");
+	}
+
+	@Test
+	public void test039() {
+		test("test039_ok.flg");
+	}
+
+	@Test
+	public void test040() {
+		test("test040_ok.flg");
+	}
+
+	@Test
+	public void test041() {
+		test("test041_ok.flg");
+	}
+
+	@Test
+	public void test043() {
+		test("test043_ok.flg");
+	}
+
+	@Test
+	public void test044() {
+		test("test044_ok.flg");
+	}
+
+	@Test
+	public void test045() {
+		test("test045_ok.flg");
+	}
+
+	@Test
+	public void test046() {
+		test("test046_ok.flg");
+	}
+
+	@Test
+	public void test047() {
+		test("test047_ok.flg");
+	}
+
+	@Test
+	public void test048() {
+		test("test048_ok.flg");
+	}
+
+	@Test
+	public void test056() {
+		test("test056_ok.flg");
+	}
+
+	@Test
+	public void test057() {
+		test("test057_ok.flg");
+	}
+
+	@Test
+	public void test058() {
+		test("test058_ok.flg");
+	}
+
+	@Test
+	public void test061() {
+		test("test061_ok.flg");
+	}
+
+	@Test
+	public void test062() {
+		test("test062_ok.flg");
+	}
+
+	@Test
+	public void test063() {
+		test("test063_ok.flg");
+	}
+
+	@Test
+	public void test064() {
+		test("test064_ok.flg");
+	}
+
+	@Test
+	public void test065() {
+		test("test065_ok.flg");
+	}
+
+	@Test
+	public void test066() {
+		test("test066_ok.flg");
+	}
+
+	@Test
+	public void test067() {
+		test("test067_ok.flg");
+	}
+
+	@Test
+	public void test068() {
+		test("test068_ok.flg");
+	}
+
+	@Test
+	public void test069() {
+		test("test069_ok.flg");
+	}
+
+	@Test
+	public void test070() {
+		test("test070_ok.flg");
+	}
+
+	@Test
+	public void test071() {
+		test("test071_ok.flg");
+	}
+
+	@Test
+	public void test072() {
+		test("test072_ok.flg");
+	}
+
+	@Test
+	public void test073() {
+		test("test073_ok.flg");
+	}
+
+	@Test
+	public void test077() {
+		test("test077_ok.flg");
+	}
+
+	@Test
+	public void test078() {
+		test("test078_ok.flg");
+	}
+
+	@Test
+	public void test079() {
+		test("test079_ok.flg");
+	}
+
+	@Test
+	public void test081() {
+		test("test081_ok.flg");
+	}
+
+	@Test
+	public void test082() {
+		test("test082_ok.flg");
+	}
+
+	@Test
+	public void test083() {
+		test("test083_ok.flg");
+	}
+
+	@Test
+	public void test084() {
+		test("test084_ok.flg");
+	}
+
+	@Test
+	public void test085() {
+		test("test085_ok.flg");
+	}
+
+	@Test
+	public void test086() {
+		test("test086_ok.flg");
+	}
+
+	@Test
+	public void test087() {
+		test("test087_ok.flg");
+	}
+
+	@Test
+	public void test088() {
+		test("test088_ok.flg");
+	}
+
+	@Test
+	public void test089() {
+		test("test089_ok.flg");
+	}
+
+	@Test
+	public void test090() {
+		test("test090_ok.flg");
+	}
+
+	@Test
+	public void test092() {
+		test("test092_ok.flg");
+	}
+
+	@Test
+	public void test093() {
+		test("test093_ok.flg");
+	}
+
+	@Test
+	public void test094() {
+		test("test094_ok.flg");
+	}
+
+	@Test
+	public void test095() {
+		test("test095_ok.flg");
+	}
+
+	@Test
+	public void test096() {
+		test("test096_ok.flg");
+	}
+
+	@Test
+	public void test097() {
+		test("test097_ok.flg");
+	}
+
+	@Test
+	public void test099() {
+		test("test099_ok.flg");
+	}
+
+	@Test
+	public void test100() {
+		test("test100_ok.flg");
+	}
+
+	@Test
+	public void test102() {
+		test("test102_ok.flg");
+	}
+
+	@Test
+	public void test103() {
+		test("test103_ok.flg");
+	}
+
+	@Test
+	public void test104() {
+		test("test104_ok.flg");
+	}
+
+	@Test
+	public void test105() {
+		test("test105_ok.flg");
+	}
+
+	@Test
+	public void test106() {
+		test("test106_ok.flg");
+	}
+
+	@Test
+	public void test107() {
+		test("test107_ok.flg");
+	}
+
+	@Test
+	public void test108() {
+		test("test108_ok.flg");
+	}
+
+	@Test
+	public void test109() {
+		test("test109_ok.flg");
+	}
+
+	@Test
+	public void test110() {
+		test("test110_ok.flg");
+	}
+
+	@Test
+	public void test111() {
+		test("test111_ok.flg");
+	}
+
+	@Test
+	public void test112() {
+		test("test112_ok.flg");
+	}
+
+	@Test
+	public void test113() {
+		test("test113_ok.flg");
+	}
+
+	@Test
+	public void test114() {
+		test("test114_ok.flg");
+	}
+
+	@Test
+	public void test115() {
+		test("test115_ok.flg");
+	}
+
+	@Test
+	public void test116() {
+		test("test116_ok.flg");
+	}
+
+	@Test
+	public void test117() {
+		test("test117_ok.flg");
+	}
+
+	@Test
+	public void test119() {
+		test("test119_ok.flg");
+	}
+
+	@Test
+	public void test120() {
+		test("test120_ok.flg");
+	}
+
+	@Test
+	public void test121() {
+		test("test121_ok.flg");
+	}
+
+	@Test
+	public void test122() {
+		test("test122_ok.flg");
+	}
+
+	@Test
+	public void test123() {
+		test("test123_ok.flg");
+	}
+
+	@Test
+	public void test124() {
+		test("test124_ok.flg");
+	}
+
+	@Test
+	public void test125() {
+		test("test125_ok.flg");
+	}
+
+	@Test
+	public void test126() {
+		test("test126_ok.flg");
+	}
+
+	@Test
+	public void test127() {
+		test("test127_ok.flg");
+	}
+
+	@Test
+	public void test128() {
+		test("test128_ok.flg");
+	}
+
+	@Test
+	public void test129() {
+		test("test129_ok.flg");
+	}
+
+	@Test
+	public void test134() {
+		test("test134_ok.flg");
+	}
+
+	@Test
+	public void test135() {
+		test("test135_ok.flg");
+	}
+
+	@Test
+	public void test136() {
+		test("test136_ok.flg");
+	}
+
+	@Test
+	public void test137() {
+		test("test137_ok.flg");
+	}
+
+	/*
+	 * No longer supporting this semantics
+	 * 
+	 * @Test public void test138() { test("test138_ok.flg"); }
+	 */
+
+	@Test
+	public void test139() {
+		test("test139_ok.flg");
+	}
+
+	@Test
+	public void test180() {
+		test("test180_ok.flg");
+	}
+
+	@Test
+	public void test181() {
+		test("test181_ok.flg");
+	}
+
+	@Test
+	public void test182() {
+		test("test182_ok.flg");
+	}
+
+	@Test
+	public void test183() {
+		test("test183_ok.flg");
+	}
+
+	@Test
+	public void test184() {
+		test("test184_ok.flg");
+	}
+
+	@Test
+	public void test186() {
+		test("test186_ok.flg");
+	}
+
+	@Test
+	public void test187() {
+		test("test187_ok.flg");
+	}
+
+	@Test
+	public void test189() {
+		test("test189_ok.flg");
+	}
+
+	@Test
+	public void test190() {
+		test("test190_ok.flg");
+	}
+
+	@Test
+	public void test191() {
+		test("test191_ok.flg", Arrays.asList("test191_input"));
+	}
+
+	@Test
+	public void test192() {
+		test("test192_ok.flg");
+	}
+
+	@Test
+	public void test193() {
+		test("test193_ok.flg");
+	}
+
+	@Test
+	public void test238() {
+		test("test238_ok.flg");
+	}
+
+	@Test
+	public void test240() {
+		test("test240_ok.flg");
+	}
+
+	@Test
+	public void test241() {
+		test("test241_ok.flg");
+	}
+
+	@Test
+	public void test242() {
+		test("test242_ok.flg");
+	}
+
+	@Test
+	public void test243() {
+		test("test243_ok.flg");
+	}
+
+	@Test
+	public void test244() {
+		test("test244_ok.flg");
+	}
+
+	@Test
+	public void test245() {
+		test("test245_ok.flg");
+	}
+
+	@Test
+	public void test254() {
+		test("test254_ok.flg");
+	}
+
+	@Test
+	public void test256() {
+		test("test256_ok.flg");
+	}
+
+	@Test
+	public void test258() {
+		test("test258_ok.flg");
+	}
+
+	@Test
+	public void test259() {
+		test("test259_ok.flg");
+	}
+
+	@Test
+	public void test260() {
+		test("test260_ok.flg");
+	}
+
+	@Test
+	public void test261() {
+		test("test261_ok.flg");
+	}
+
+	@Test
+	public void test262() {
+		test("test262_ok.flg");
+	}
+
+	@Test
+	public void test263() {
+		test("test263_ok.flg");
+	}
+
+	@Test
+	public void test264() {
+		test("test264_ok.flg");
+	}
+
+	@Test
+	public void test265() {
+		test("test265_ok.flg");
+	}
+
+	@Test
+	public void test267() {
+		test("test267_ok.flg");
+	}
+
+	@Test
+	public void test273() {
+		test("test273_ok.flg");
+	}
+
+	@Test
+	public void test274() {
+		test("test274_ok.flg");
+	}
+
+	@Test
+	public void test275() {
+		test("test275_ok.flg");
+	}
+
+	@Test
+	public void test276() {
+		test("test276_ok.flg", Arrays.asList("test276_inputA", "test276_inputB"));
+	}
+
+	@Test
+	public void test277() {
+		test("test277_ok.flg");
+	}
+
+	@Test
+	public void test278() {
+		test("test278_ok.flg");
+	}
+
+	@Test
+	public void test279() {
+		test("test279_ok.flg");
+	}
+
+	@Test
+	public void test280() {
+		test("test280_ok.flg");
+	}
+
+	@Test
+	public void test281() {
+		test("test281_ok.flg");
+	}
+
+	@Test
+	public void test282() {
+		test("test282_ok.flg");
+	}
+
+	@Test
+	public void test283() {
+		test("test283_ok.flg");
+	}
+
+	@Test
+	public void test284() {
+		test("test284_ok.flg");
+	}
+
+	@Test
+	public void test285() {
+		test("test285_ok.flg");
+	}
+
+	@Test
+	public void test286() {
+		test("test286_ok.flg");
+	}
+
+	@Test
+	public void test287() {
+		test("test287_ok.flg");
+	}
+
+	@Test
+	public void test288() {
+		test("test288_ok.flg");
+	}
+
+	@Test
+	public void test289() {
+		test("test289_ok.flg");
+	}
+
+	@Test
+	public void test290() {
+		test("test290_ok.flg");
+	}
+
+	@Test
+	public void test291() {
+		test("test291_ok.flg");
+	}
+
+	@Test
+	public void test292() {
+		test("test292_ok.flg");
+	}
+
+	@Test
+	public void test297() {
+		test("test297_ok.flg");
+	}
+
+	@Test
+	public void test298() {
+		test("test298_ok.flg");
+	}
+
+	@Test
+	public void test299() {
+		test("test299_ok.flg");
+	}
+
+	@Test
+	public void test300() {
+		test("test300_ok.flg");
+	}
+
+	@Test
+	public void test301() {
+		test("test301_ok.flg");
+	}
+
+	@Test
+	public void test304() {
+		test("test304_ok.flg");
+	}
+
+	@Test
+	public void test305() {
+		test("test305_ok.flg");
+	}
+
+	@Test
+	public void test306() {
+		test("test306_ok.flg");
+	}
+
+	@Test
+	public void test308() {
+		test("test308_ok.flg");
+	}
+
+	@Test
+	public void test309() {
+		test("test309_ok.flg");
+	}
+
+	@Test
+	public void test310() {
+		test("test310_ok.flg");
+	}
+
+	@Test
+	public void test311() {
+		test("test311_ok.flg");
+	}
+
+	/*
+	 * No longer supporting these semantics
+	 * 
+	 * @Test public void test316() { test("test316_ok.flg"); }
+	 * 
+	 * @Test public void test317() { test("test317_ok.flg"); }
+	 * 
+	 * @Test public void test318() { test("test318_ok.flg"); }
+	 * 
+	 * @Test public void test319() { test("test319_ok.flg"); }
+	 */
+
+	@Test
+	public void test320() {
+		test("test320_ok.flg");
+	}
+
+	@Test
+	public void test321() {
+		test("test321_ok.flg");
+	}
+
+	@Test
+	public void test323() {
+		test("test323_ok.flg");
+	}
+
+	@Test
+	public void test324() {
+		test("test324_ok.flg");
+	}
+
+	@Test
+	public void test325() {
+		test("test325_ok.flg");
+	}
+
+	@Test
+	public void test326() {
+		test("test326_ok.flg");
+	}
+
+	@Test
+	public void test328() {
+		test("test328_ok.flg");
+	}
+
+	@Test
+	public void test329() {
+		test("test329_ok.flg");
+	}
+
+	@Test
+	public void test330() {
+		test("test330_ok.flg");
+	}
+
+	@Test
+	public void test331() {
+		test("test331_ok.flg");
+	}
+
+	@Test
+	public void test332() {
+		test("test332_ok.flg");
+	}
+
+	@Test
+	public void test334() {
+		test("test334_ok.flg");
+	}
+
+	@Test
+	public void test336() {
+		test("test336_ok.flg");
+	}
+
+	@Test
+	public void test337() {
+		test("test337_ok.flg");
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/EagerSemiNaiveEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/EagerSemiNaiveEvaluationTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 public class EagerSemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNaiveEvaluation> {
 
 	public EagerSemiNaiveEvaluationTest() {

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/InterpretedSemiNaiveTester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/InterpretedSemiNaiveTester.java
@@ -20,15 +20,14 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 import edu.harvard.seas.pl.formulog.types.WellTypedProgram;
 import edu.harvard.seas.pl.formulog.validating.InvalidProgramException;
 
 public class InterpretedSemiNaiveTester extends AbstractTester<SemiNaiveEvaluation> {
-	
+
 	private final boolean eagerEval;
-	
+
 	public InterpretedSemiNaiveTester(boolean eagerEval) {
 		this.eagerEval = eagerEval;
 	}

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluationTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluationTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 public class SemiNaiveEvaluationTest extends CommonEvaluationTest<SemiNaiveEvaluation> {
 
 	public SemiNaiveEvaluationTest() {

--- a/src/test/java/edu/harvard/seas/pl/formulog/eval/Tester.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/eval/Tester.java
@@ -20,11 +20,10 @@ package edu.harvard.seas.pl.formulog.eval;
  * #L%
  */
 
-
 import java.util.List;
 
 public interface Tester {
 
-    void test(String file, List<String> inputDirs);
+	void test(String file, List<String> inputDirs);
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/magic/CommonMagicSetTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/magic/CommonMagicSetTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import org.junit.Test;
 
 import edu.harvard.seas.pl.formulog.eval.AbstractEvaluationTest;
@@ -29,228 +28,228 @@ import edu.harvard.seas.pl.formulog.eval.Tester;
 
 public abstract class CommonMagicSetTest<T extends Evaluation> extends AbstractEvaluationTest<T> {
 
-    public CommonMagicSetTest(Tester tester) {
-        super(tester);
-    }
+	public CommonMagicSetTest(Tester tester) {
+		super(tester);
+	}
 
-    @Test
-    public void test140() {
-        test("test140_ok.flg");
-    }
+	@Test
+	public void test140() {
+		test("test140_ok.flg");
+	}
 
-    @Test
-    public void test141() {
-        test("test141_ok.flg");
-    }
+	@Test
+	public void test141() {
+		test("test141_ok.flg");
+	}
 
-    @Test
-    public void test142() {
-        test("test142_ok.flg");
-    }
+	@Test
+	public void test142() {
+		test("test142_ok.flg");
+	}
 
-    @Test
-    public void test143() {
-        test("test143_ok.flg");
-    }
+	@Test
+	public void test143() {
+		test("test143_ok.flg");
+	}
 
-    @Test
-    public void test144() {
-        test("test144_ok.flg");
-    }
+	@Test
+	public void test144() {
+		test("test144_ok.flg");
+	}
 
-    @Test
-    public void test145() {
-        test("test145_ok.flg");
-    }
+	@Test
+	public void test145() {
+		test("test145_ok.flg");
+	}
 
-    @Test
-    public void test146() {
-        test("test146_ok.flg");
-    }
+	@Test
+	public void test146() {
+		test("test146_ok.flg");
+	}
 
-    @Test
-    public void test147() {
-        test("test147_ok.flg");
-    }
+	@Test
+	public void test147() {
+		test("test147_ok.flg");
+	}
 
-    @Test
-    public void test148() {
-        test("test148_ok.flg");
-    }
+	@Test
+	public void test148() {
+		test("test148_ok.flg");
+	}
 
-    @Test
-    public void test149() {
-        test("test149_ok.flg");
-    }
+	@Test
+	public void test149() {
+		test("test149_ok.flg");
+	}
 
-    @Test
-    public void test150() {
-        test("test150_ok.flg");
-    }
+	@Test
+	public void test150() {
+		test("test150_ok.flg");
+	}
 
-    @Test
-    public void test151() {
-        test("test151_ok.flg");
-    }
+	@Test
+	public void test151() {
+		test("test151_ok.flg");
+	}
 
-    @Test
-    public void test152() {
-        test("test152_ok.flg");
-    }
+	@Test
+	public void test152() {
+		test("test152_ok.flg");
+	}
 
-    @Test
-    public void test153() {
-        test("test153_ok.flg");
-    }
+	@Test
+	public void test153() {
+		test("test153_ok.flg");
+	}
 
-    @Test
-    public void test154() {
-        test("test154_ok.flg");
-    }
+	@Test
+	public void test154() {
+		test("test154_ok.flg");
+	}
 
-    @Test
-    public void test155() {
-        test("test155_ok.flg");
-    }
+	@Test
+	public void test155() {
+		test("test155_ok.flg");
+	}
 
-    @Test
-    public void test156() {
-        test("test156_ok.flg");
-    }
+	@Test
+	public void test156() {
+		test("test156_ok.flg");
+	}
 
-    @Test
-    public void test157() {
-        test("test157_ok.flg");
-    }
+	@Test
+	public void test157() {
+		test("test157_ok.flg");
+	}
 
-    @Test
-    public void test158() {
-        test("test158_ok.flg");
-    }
+	@Test
+	public void test158() {
+		test("test158_ok.flg");
+	}
 
-    @Test
-    public void test159() {
-        test("test159_ok.flg");
-    }
+	@Test
+	public void test159() {
+		test("test159_ok.flg");
+	}
 
-    @Test
-    public void test160() {
-        test("test160_ok.flg");
-    }
+	@Test
+	public void test160() {
+		test("test160_ok.flg");
+	}
 
-    @Test
-    public void test161() {
-        test("test161_ok.flg");
-    }
+	@Test
+	public void test161() {
+		test("test161_ok.flg");
+	}
 
-    @Test
-    public void test162() {
-        test("test162_ok.flg");
-    }
+	@Test
+	public void test162() {
+		test("test162_ok.flg");
+	}
 
-    @Test
-    public void test163() {
-        test("test163_ok.flg");
-    }
+	@Test
+	public void test163() {
+		test("test163_ok.flg");
+	}
 
-    @Test
-    public void test164() {
-        test("test164_ok.flg");
-    }
+	@Test
+	public void test164() {
+		test("test164_ok.flg");
+	}
 
-    @Test
-    public void test165() {
-        test("test165_ok.flg");
-    }
+	@Test
+	public void test165() {
+		test("test165_ok.flg");
+	}
 
-    @Test
-    public void test166() {
-        test("test166_ok.flg");
-    }
+	@Test
+	public void test166() {
+		test("test166_ok.flg");
+	}
 
-    @Test
-    public void test167() {
-        test("test167_ok.flg");
-    }
+	@Test
+	public void test167() {
+		test("test167_ok.flg");
+	}
 
-    @Test
-    public void test168() {
-        test("test168_ok.flg");
-    }
+	@Test
+	public void test168() {
+		test("test168_ok.flg");
+	}
 
-    @Test
-    public void test169() {
-        test("test169_ok.flg");
-    }
+	@Test
+	public void test169() {
+		test("test169_ok.flg");
+	}
 
-    @Test
-    public void test170() {
-        test("test170_ok.flg");
-    }
+	@Test
+	public void test170() {
+		test("test170_ok.flg");
+	}
 
-    @Test
-    public void test171() {
-        test("test171_ok.flg");
-    }
+	@Test
+	public void test171() {
+		test("test171_ok.flg");
+	}
 
-    @Test
-    public void test172() {
-        test("test172_ok.flg");
-    }
+	@Test
+	public void test172() {
+		test("test172_ok.flg");
+	}
 
-    @Test
-    public void test173() {
-        test("test173_ok.flg");
-    }
+	@Test
+	public void test173() {
+		test("test173_ok.flg");
+	}
 
-    @Test
-    public void test174() {
-        test("test174_ok.flg");
-    }
+	@Test
+	public void test174() {
+		test("test174_ok.flg");
+	}
 
-    @Test
-    public void test175() {
-        test("test175_ok.flg");
-    }
+	@Test
+	public void test175() {
+		test("test175_ok.flg");
+	}
 
-    @Test
-    public void test176() {
-        test("test176_ok.flg");
-    }
+	@Test
+	public void test176() {
+		test("test176_ok.flg");
+	}
 
-    @Test
-    public void test177() {
-        test("test177_ok.flg");
-    }
+	@Test
+	public void test177() {
+		test("test177_ok.flg");
+	}
 
-    @Test
-    public void test178() {
-        test("test178_ok.flg");
-    }
+	@Test
+	public void test178() {
+		test("test178_ok.flg");
+	}
 
-    @Test
-    public void test179() {
-        test("test179_ok.flg");
-    }
+	@Test
+	public void test179() {
+		test("test179_ok.flg");
+	}
 
-    @Test
-    public void test249() {
-        test("test249_ok.flg");
-    }
+	@Test
+	public void test249() {
+		test("test249_ok.flg");
+	}
 
-    @Test
-    public void test250() {
-        test("test250_ok.flg");
-    }
+	@Test
+	public void test250() {
+		test("test250_ok.flg");
+	}
 
-    @Test
-    public void test252() {
-        test("test252_ok.flg");
-    }
+	@Test
+	public void test252() {
+		test("test252_ok.flg");
+	}
 
-    @Test
-    public void test253() {
-        test("test253_ok.flg");
-    }
+	@Test
+	public void test253() {
+		test("test253_ok.flg");
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/magic/EagerSemiNaiveMagicSetTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/magic/EagerSemiNaiveMagicSetTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.eval.InterpretedSemiNaiveTester;
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveEvaluation;
 

--- a/src/test/java/edu/harvard/seas/pl/formulog/magic/SemiNaiveMagicSetTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/magic/SemiNaiveMagicSetTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.magic;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.eval.InterpretedSemiNaiveTester;
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveEvaluation;
 

--- a/src/test/java/edu/harvard/seas/pl/formulog/parsing/ParsingTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/parsing/ParsingTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.parsing;
  * #L%
  */
 
-
 import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
@@ -31,145 +30,145 @@ import org.junit.Test;
 
 public class ParsingTest {
 
-    void test(String file) {
-        boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(file);
-            if (is == null) {
-                throw new FileNotFoundException(file + " not found");
-            }
-            (new Parser()).parse(new InputStreamReader(is));
-        } catch (ParseException e) {
-            if (!isBad) {
-                fail("Test failed for a good program: " + e.getMessage());
-            }
-            return;
-        } catch (Exception e) {
-            fail("Unexpected exception: " + e.getMessage() + " " + e.getClass());
-        }
-        if (isBad) {
-            fail("Test succeeded for a bad program");
-        }
-    }
+	void test(String file) {
+		boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
+		try {
+			InputStream is = getClass().getClassLoader().getResourceAsStream(file);
+			if (is == null) {
+				throw new FileNotFoundException(file + " not found");
+			}
+			(new Parser()).parse(new InputStreamReader(is));
+		} catch (ParseException e) {
+			if (!isBad) {
+				fail("Test failed for a good program: " + e.getMessage());
+			}
+			return;
+		} catch (Exception e) {
+			fail("Unexpected exception: " + e.getMessage() + " " + e.getClass());
+		}
+		if (isBad) {
+			fail("Test succeeded for a bad program");
+		}
+	}
 
-    @Test
-    public void test001() {
-        test("test001_ok.flg");
-    }
+	@Test
+	public void test001() {
+		test("test001_ok.flg");
+	}
 
-    @Test
-    public void test002() {
-        test("test002_ok.flg");
-    }
+	@Test
+	public void test002() {
+		test("test002_ok.flg");
+	}
 
-    @Test
-    public void test003() {
-        test("test003_ok.flg");
-    }
+	@Test
+	public void test003() {
+		test("test003_ok.flg");
+	}
 
-    @Test
-    public void test004() {
-        test("test004_ok.flg");
-    }
+	@Test
+	public void test004() {
+		test("test004_ok.flg");
+	}
 
-    @Test
-    public void test005() {
-        test("test005_ok.flg");
-    }
+	@Test
+	public void test005() {
+		test("test005_ok.flg");
+	}
 
-    @Test
-    public void test006() {
-        test("test006_ok.flg");
-    }
+	@Test
+	public void test006() {
+		test("test006_ok.flg");
+	}
 
-    @Test
-    public void test007() {
-        test("test007_ok.flg");
-    }
+	@Test
+	public void test007() {
+		test("test007_ok.flg");
+	}
 
-    @Test
-    public void test028() {
-        test("test028_ok.flg");
-    }
+	@Test
+	public void test028() {
+		test("test028_ok.flg");
+	}
 
-    @Test
-    public void test031() {
-        test("test031_ok.flg");
-    }
+	@Test
+	public void test031() {
+		test("test031_ok.flg");
+	}
 
-    @Test
-    public void test036() {
-        test("test036_ok.flg");
-    }
+	@Test
+	public void test036() {
+		test("test036_ok.flg");
+	}
 
-    @Test
-    public void test042() {
-        test("test042_ok.flg");
-    }
+	@Test
+	public void test042() {
+		test("test042_ok.flg");
+	}
 
-    @Test
-    public void test055() {
-        test("test055_bd.flg");
-    }
+	@Test
+	public void test055() {
+		test("test055_bd.flg");
+	}
 
-    @Test
-    public void test059() {
-        test("test059_ok.flg");
-    }
+	@Test
+	public void test059() {
+		test("test059_ok.flg");
+	}
 
-    @Test
-    public void test074() {
-        test("test074_ok.flg");
-    }
+	@Test
+	public void test074() {
+		test("test074_ok.flg");
+	}
 
-    @Test
-    public void test075() {
-        test("test075_ok.flg");
-    }
+	@Test
+	public void test075() {
+		test("test075_ok.flg");
+	}
 
-    @Test
-    public void test076() {
-        test("test076_ok.flg");
-    }
+	@Test
+	public void test076() {
+		test("test076_ok.flg");
+	}
 
-    @Test
-    public void test255() {
-        test("test255_bd.flg");
-    }
+	@Test
+	public void test255() {
+		test("test255_bd.flg");
+	}
 
-    @Test
-    public void test257() {
-        test("test257_ok.flg");
-    }
+	@Test
+	public void test257() {
+		test("test257_ok.flg");
+	}
 
-    @Test
-    public void test266() {
-        test("test266_bd.flg");
-    }
+	@Test
+	public void test266() {
+		test("test266_bd.flg");
+	}
 
-    @Test
-    public void test271() {
-        test("test271_bd.flg");
-    }
+	@Test
+	public void test271() {
+		test("test271_bd.flg");
+	}
 
-    @Test
-    public void test272() {
-        test("test272_bd.flg");
-    }
+	@Test
+	public void test272() {
+		test("test272_bd.flg");
+	}
 
-    @Test
-    public void test302() {
-        test("test302_bd.flg");
-    }
+	@Test
+	public void test302() {
+		test("test302_bd.flg");
+	}
 
-    @Test
-    public void test322() {
-        test("test322_bd.flg");
-    }
+	@Test
+	public void test322() {
+		test("test322_bd.flg");
+	}
 
-    @Test
-    public void test335() {
-        test("test335_bd.flg");
-    }
+	@Test
+	public void test335() {
+		test("test335_bd.flg");
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/types/TypeCheckingTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/types/TypeCheckingTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.types;
  * #L%
  */
 
-
 import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
@@ -34,221 +33,221 @@ import edu.harvard.seas.pl.formulog.parsing.Parser;
 
 public class TypeCheckingTest {
 
-    void test(String file) {
-        boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(file);
-            if (is == null) {
-                throw new FileNotFoundException(file + " not found");
-            }
-            BasicProgram prog = (new Parser()).parse(new InputStreamReader(is));
-            (new TypeChecker(prog)).typeCheck();
-        } catch (TypeException e) {
-            if (!isBad) {
-                fail("Test failed for a good program: " + e.getMessage());
-            }
-            return;
-        } catch (Exception e) {
-            fail("Unexpected exception: " + e.getMessage());
-        }
-        if (isBad) {
-            fail("Test succeeded for a bad program");
-        }
-    }
+	void test(String file) {
+		boolean isBad = file.matches("test\\d\\d\\d_bd.flg");
+		try {
+			InputStream is = getClass().getClassLoader().getResourceAsStream(file);
+			if (is == null) {
+				throw new FileNotFoundException(file + " not found");
+			}
+			BasicProgram prog = (new Parser()).parse(new InputStreamReader(is));
+			(new TypeChecker(prog)).typeCheck();
+		} catch (TypeException e) {
+			if (!isBad) {
+				fail("Test failed for a good program: " + e.getMessage());
+			}
+			return;
+		} catch (Exception e) {
+			fail("Unexpected exception: " + e.getMessage());
+		}
+		if (isBad) {
+			fail("Test succeeded for a bad program");
+		}
+	}
 
-    @Test
-    public void test006() {
-        test("test006_ok.flg");
-    }
+	@Test
+	public void test006() {
+		test("test006_ok.flg");
+	}
 
-    @Test
-    public void test008() {
-        test("test008_ok.flg");
-    }
+	@Test
+	public void test008() {
+		test("test008_ok.flg");
+	}
 
-    @Test
-    public void test009() {
-        test("test009_ok.flg");
-    }
+	@Test
+	public void test009() {
+		test("test009_ok.flg");
+	}
 
-    @Test
-    public void test010() {
-        test("test010_ok.flg");
-    }
+	@Test
+	public void test010() {
+		test("test010_ok.flg");
+	}
 
-    @Test
-    public void test011() {
-        test("test011_ok.flg");
-    }
+	@Test
+	public void test011() {
+		test("test011_ok.flg");
+	}
 
-    @Test
-    public void test012() {
-        test("test012_bd.flg");
-    }
+	@Test
+	public void test012() {
+		test("test012_bd.flg");
+	}
 
-    @Test
-    public void test013() {
-        test("test013_ok.flg");
-    }
+	@Test
+	public void test013() {
+		test("test013_ok.flg");
+	}
 
-    @Test
-    public void test014() {
-        test("test014_ok.flg");
-    }
+	@Test
+	public void test014() {
+		test("test014_ok.flg");
+	}
 
-    @Test
-    public void test015() {
-        test("test015_ok.flg");
-    }
+	@Test
+	public void test015() {
+		test("test015_ok.flg");
+	}
 
-    @Test
-    public void test016() {
-        test("test016_ok.flg");
-    }
+	@Test
+	public void test016() {
+		test("test016_ok.flg");
+	}
 
-    @Test
-    public void test017() {
-        test("test017_ok.flg");
-    }
+	@Test
+	public void test017() {
+		test("test017_ok.flg");
+	}
 
-    @Test
-    public void test049() {
-        test("test049_ok.flg");
-    }
+	@Test
+	public void test049() {
+		test("test049_ok.flg");
+	}
 
-    @Test
-    public void test052() {
-        test("test052_bd.flg");
-    }
+	@Test
+	public void test052() {
+		test("test052_bd.flg");
+	}
 
-    @Test
-    public void test053() {
-        test("test053_ok.flg");
-    }
+	@Test
+	public void test053() {
+		test("test053_ok.flg");
+	}
 
-    @Test
-    public void test054() {
-        test("test054_ok.flg");
-    }
+	@Test
+	public void test054() {
+		test("test054_ok.flg");
+	}
 
-    @Test
-    public void test060() {
-        test("test060_ok.flg");
-    }
+	@Test
+	public void test060() {
+		test("test060_ok.flg");
+	}
 
-    @Test
-    public void test080() {
-        test("test080_bd.flg");
-    }
+	@Test
+	public void test080() {
+		test("test080_bd.flg");
+	}
 
-    @Test
-    public void test091() {
-        test("test091_bd.flg");
-    }
+	@Test
+	public void test091() {
+		test("test091_bd.flg");
+	}
 
-    @Test
-    public void test098() {
-        test("test098_bd.flg");
-    }
+	@Test
+	public void test098() {
+		test("test098_bd.flg");
+	}
 
-    @Test
-    public void test118() {
-        test("test118_bd.flg");
-    }
+	@Test
+	public void test118() {
+		test("test118_bd.flg");
+	}
 
-    @Test
-    public void test130() {
-        test("test130_bd.flg");
-    }
+	@Test
+	public void test130() {
+		test("test130_bd.flg");
+	}
 
-    @Test
-    public void test131() {
-        test("test131_bd.flg");
-    }
+	@Test
+	public void test131() {
+		test("test131_bd.flg");
+	}
 
-    @Test
-    public void test132() {
-        test("test132_bd.flg");
-    }
+	@Test
+	public void test132() {
+		test("test132_bd.flg");
+	}
 
-    @Test
-    public void test185() {
-        test("test185_bd.flg");
-    }
+	@Test
+	public void test185() {
+		test("test185_bd.flg");
+	}
 
-    @Test
-    public void test188() {
-        test("test188_bd.flg");
-    }
+	@Test
+	public void test188() {
+		test("test188_bd.flg");
+	}
 
-    @Test
-    public void test268() {
-        test("test268_bd.flg");
-    }
+	@Test
+	public void test268() {
+		test("test268_bd.flg");
+	}
 
-    @Test
-    public void test269() {
-        test("test269_bd.flg");
-    }
+	@Test
+	public void test269() {
+		test("test269_bd.flg");
+	}
 
-    @Test
-    public void test270() {
-        test("test270_bd.flg");
-    }
+	@Test
+	public void test270() {
+		test("test270_bd.flg");
+	}
 
-    @Test
-    public void test293() {
-        test("test293_ok.flg");
-    }
+	@Test
+	public void test293() {
+		test("test293_ok.flg");
+	}
 
-    @Test
-    public void test294() {
-        test("test294_ok.flg");
-    }
+	@Test
+	public void test294() {
+		test("test294_ok.flg");
+	}
 
-    @Test
-    public void test295() {
-        test("test295_bd.flg");
-    }
+	@Test
+	public void test295() {
+		test("test295_bd.flg");
+	}
 
-    @Test
-    public void test296() {
-        test("test296_bd.flg");
-    }
+	@Test
+	public void test296() {
+		test("test296_bd.flg");
+	}
 
-    @Test
-    public void test307() {
-        test("test307_ok.flg");
-    }
+	@Test
+	public void test307() {
+		test("test307_ok.flg");
+	}
 
-    @Test
-    public void test312() {
-        test("test312_bd.flg");
-    }
+	@Test
+	public void test312() {
+		test("test312_bd.flg");
+	}
 
-    @Test
-    public void test313() {
-        test("test313_bd.flg");
-    }
+	@Test
+	public void test313() {
+		test("test313_bd.flg");
+	}
 
-    @Test
-    public void test314() {
-        test("test314_bd.flg");
-    }
+	@Test
+	public void test314() {
+		test("test314_bd.flg");
+	}
 
-    @Test
-    public void test315() {
-        test("test315_bd.flg");
-    }
+	@Test
+	public void test315() {
+		test("test315_bd.flg");
+	}
 
-    @Test
-    public void test327() {
-        test("test327_bd.flg");
-    }
+	@Test
+	public void test327() {
+		test("test327_bd.flg");
+	}
 
-    @Test
-    public void test333() {
-        test("test333_bd.flg");
-    }
+	@Test
+	public void test333() {
+		test("test333_bd.flg");
+	}
 
 }

--- a/src/test/java/edu/harvard/seas/pl/formulog/validating/SemiNaiveValidatingTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/validating/SemiNaiveValidatingTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 import edu.harvard.seas.pl.formulog.eval.Evaluation;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveEvaluation;

--- a/src/test/java/edu/harvard/seas/pl/formulog/validating/ValidatingTest.java
+++ b/src/test/java/edu/harvard/seas/pl/formulog/validating/ValidatingTest.java
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating;
  * #L%
  */
 
-
 import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
@@ -100,12 +99,12 @@ public abstract class ValidatingTest {
 	public void test219() {
 		test("test219_ok.flg");
 	}
-	
+
 	@Test
 	public void test248() {
 		test("test248_bd.flg");
 	}
-	
+
 	@Test
 	public void test251() {
 		test("test251_bd.flg");


### PR DESCRIPTION
Previously, the codebase used a combination of tabs and spaces, which made it a pain to edit. Now everything uses tabs (the default Eclipse style).