### PR TITLE
Use hash filter in DB

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -169,6 +169,8 @@ public final class Configuration {
 
 	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
 
+	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter", true);
+
 	public static final boolean recordWork = propIsSet("recordWork");
 	public static final AtomicLong work = new AtomicLong();
 	public static final AtomicLong workItems = new AtomicLong();

--- a/src/main/java/edu/harvard/seas/pl/formulog/db/SortedIndexedFactDb.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/db/SortedIndexedFactDb.java
@@ -127,7 +127,9 @@ public class SortedIndexedFactDb implements IndexedFactDb {
 	private boolean hashFilterContains(RelationSymbol sym, Term[] tup) {
 		var key = hashKey.get();
 		key.tup = tup;
-		return hashFilter.get(sym).contains(key);
+		var r = hashFilter.get(sym).contains(key);
+		key.tup = null;
+		return r;
 	}
 
 	@Override


### PR DESCRIPTION
Profiling showed that a major hotspot was checking whether a tuple was already in our DB and adding a tuple to the DB, because both operations involved working with Java's `ConcurrentSkipListSet` (used to represent indices). This PR adds a hash set that acts as a filter before any skip list is accessed. It leads to substantial speedups, especially in cases where many duplicate tuples are derived and tested against the DB.