### PR TITLE
Codegen: split rules before SMT calls.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -169,6 +169,7 @@ public final class Configuration {
 	public static final boolean inlineInRules = propIsSet("inlineInRules", true);
 
 	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
+	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt");
 
 	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter", true);
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -169,7 +169,7 @@ public final class Configuration {
 	public static final boolean inlineInRules = propIsSet("inlineInRules", true);
 
 	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
-	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt");
+	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt", true);
 
 	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter", true);
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SAtom.java
@@ -21,6 +21,7 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 import java.util.List;
+import java.util.Set;
 
 public class SAtom implements SLit {
 
@@ -54,6 +55,13 @@ public class SAtom implements SLit {
 		}
 		sb.append(")");
 		return sb.toString();
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		for (var t : args) {
+			t.varSet(vars);
+		}
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorCall.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SFunctorCall.java
@@ -22,6 +22,7 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class SFunctorCall implements STerm {
 
@@ -51,6 +52,13 @@ public class SFunctorCall implements STerm {
 		}
 		sb.append(")");
 		return sb.toString();
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		for (var t : args) {
+			t.varSet(vars);
+		}
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInfixBinaryOpAtom.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInfixBinaryOpAtom.java
@@ -1,5 +1,7 @@
 package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
+import java.util.Set;
+
 /*-
  * #%L
  * Formulog
@@ -35,6 +37,12 @@ public class SInfixBinaryOpAtom implements SLit {
 	@Override
 	public String toString() {
 		return lhs + " " + op + " " + rhs;
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		lhs.varSet(vars);
+		rhs.varSet(vars);
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInt.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SInt.java
@@ -1,5 +1,7 @@
 package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
+import java.util.Set;
+
 /*-
  * #%L
  * Formulog
@@ -31,6 +33,11 @@ public class SInt implements STerm {
 	@Override
 	public String toString() {
 		return Integer.toString(val);
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		// do nothing
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntList.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SIntList.java
@@ -21,6 +21,7 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 import java.util.List;
+import java.util.Set;
 
 public class SIntList implements STerm {
 
@@ -42,6 +43,13 @@ public class SIntList implements STerm {
 		}
 		sb.append("]");
 		return sb.toString();
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		for (var t : ts) {
+			t.varSet(vars);
+		}
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SLit.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SLit.java
@@ -1,5 +1,8 @@
 package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /*-
  * #%L
  * Formulog
@@ -21,4 +24,13 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 public interface SLit {
+	
+	default Set<SVar> varSet() {
+		Set<SVar> vars = new HashSet<>();
+		varSet(vars);
+		return vars;
+	}
+	
+	void varSet(Set<SVar> vars);
+	
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/STerm.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/STerm.java
@@ -1,5 +1,8 @@
 package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /*-
  * #%L
  * Formulog
@@ -21,4 +24,13 @@ package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
  */
 
 public interface STerm {
+
+	default Set<SVar> varSet() {
+		Set<SVar> vars = new HashSet<>();
+		varSet(vars);
+		return vars;
+	}
+
+	void varSet(Set<SVar> vars);
+
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SVar.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/ast/souffle/SVar.java
@@ -1,5 +1,7 @@
 package edu.harvard.seas.pl.formulog.codegen.ast.souffle;
 
+import java.util.Set;
+
 /*-
  * #%L
  * Formulog
@@ -37,6 +39,36 @@ public class SVar implements STerm {
 	@Override
 	public String toString() {
 		return name;
+	}
+
+	@Override
+	public void varSet(Set<SVar> vars) {
+		vars.add(this);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SVar other = (SVar) obj;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
 	}
 
 }

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SmtCallFinder.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SmtCallFinder.java
@@ -51,6 +51,7 @@ public class SmtCallFinder {
 		smtCallSymbols.add(BuiltInFunctionSymbol.IS_SAT_OPT);
 		smtCallSymbols.add(BuiltInFunctionSymbol.IS_VALID);
 		smtCallSymbols.add(BuiltInFunctionSymbol.GET_MODEL);
+		smtCallSymbols.add(BuiltInFunctionSymbol.IS_SET_SAT);
 	}
 
 	public boolean containsSmtCall(Literal l) {


### PR DESCRIPTION
When translating from Formulog to Souffle, introduce intermediate relations (a la supplemental relations in the magic set transformation) in rules involving SMT calls. Since Souffle parallelizes only the outermost loop of rule evaluation, this helps distribute SMT calls more fairly across threads.