### PR TITLE
Codegen: exit without cleaning up resources.

### DIFF
--- a/src/main/resources/codegen/src/main.cpp
+++ b/src/main/resources/codegen/src/main.cpp
@@ -260,5 +260,5 @@ int main(int argc, char **argv) {
     if (dump_idb) {
         printResults();
     }
-    return 0;
+    std::_Exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
It takes a bunch of time to free all the memory that has been allocated during the Datalog computation; instead, exit immediately.