### PR TITLE
Report SMT cache clears.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -181,6 +181,7 @@ public final class Configuration {
 
 	public static final SharedLong smtCalls = new SharedLong();
 	public static final SharedLong smtTime = new SharedLong();
+	public static final SharedLong smtCacheClears = new SharedLong();
 
 	static {
 		if (recordFuncDiagnostics) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/Main.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Main.java
@@ -256,6 +256,7 @@ public final class Main implements Callable<Integer> {
 			out.println(getBanner("SMT STATS"));
 			out.println("SMT calls: " + Configuration.smtCalls.unsafeGet());
 			out.println("SMT time (ms): " + Configuration.smtTime.unsafeGet());
+			out.println("SMT cache clears: " + Configuration.smtCacheClears.unsafeGet());
 		}
 		List<RelationSymbol> allSymbols = res.getSymbols().stream().sorted(Comparator.comparing(Object::toString))
 				.collect(Collectors.toList());

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/CheckSatAssumingSolver.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/CheckSatAssumingSolver.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import edu.harvard.seas.pl.formulog.Configuration;
+import edu.harvard.seas.pl.formulog.Main;
 import edu.harvard.seas.pl.formulog.ast.Constructors;
 import edu.harvard.seas.pl.formulog.ast.Constructors.SolverVariable;
 import edu.harvard.seas.pl.formulog.ast.SmtLibTerm;
@@ -52,6 +53,9 @@ public class CheckSatAssumingSolver extends AbstractSmtLibSolver {
 	private void clearCache() throws EvaluationException {
 		if (Configuration.timeSmt) {
 			Configuration.recordCsaCacheClear(solverId);
+		}
+		if (Main.smtStats) {
+			Configuration.smtCacheClears.increment();
 		}
 		indicatorVars.clear();
 		nextVarId = 0;


### PR DESCRIPTION
Interpreter should report SMT cache clears when `--smt-stats` is set (same as generated executable when compiling the program).