### PR TITLE
Disable hash DB filter by default.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -171,7 +171,7 @@ public final class Configuration {
 	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
 	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt", true);
 
-	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter", true);
+	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter");
 
 	public static final boolean recordWork = propIsSet("recordWork");
 	public static final SharedLong work = new SharedLong();


### PR DESCRIPTION
The hash-based DB filter leads to excessive memory usage in some cases, so disable it by default.