### PR TITLE
Fix work stats

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -299,9 +299,6 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 		}
 
 		private boolean handleDelta(SimplePredicate pred, Substitution s) throws EvaluationException {
-			if (Configuration.recordWork) {
-				Configuration.work.increment();
-			}
 			BindingType[] bindings = pred.getBindingPattern();
 			Term[] args = pred.getArgs();
 			int i = 0;
@@ -316,6 +313,9 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					}
 				}
 				++i;
+			}
+			if (Configuration.recordWork) {
+				Configuration.work.increment();
 			}
 			return true;
 		}


### PR DESCRIPTION
Fix how we record work during eager evaluation: do not increment the work counter if matching against the delta atom fails. This is consistent with how we calculate the amount of work done during semi-naive evaluation.