### PR TITLE
Split work statistics

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -174,6 +174,7 @@ public final class Configuration {
 	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter");
 
 	public static final boolean recordWork = propIsSet("recordWork");
+	public static final boolean recordDetailedWork = propIsSet("recordDetailedWork");
 	public static final SharedLong work = new SharedLong();
 	public static final SharedLong workItems = new SharedLong();
 	public static final SharedLong newDerivs = new SharedLong();

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -110,7 +110,7 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 			this.startPos = pos;
 			this.s = s;
 			this.it = it;
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.workItems.increment();
 			}
 		}
@@ -128,7 +128,7 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 			this.startPos = pos;
 			this.s = s;
 			this.it = it;
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.workItems.increment();
 			}
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -84,10 +84,10 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 			if (trackedRelations.contains(sym)) {
 				System.err.println("[TRACKED] " + UserPredicate.make(sym, newArgs, false));
 			}
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.newDerivs.increment();
 			}
-		} else if (Configuration.recordWork) {
+		} else if (Configuration.recordDetailedWork) {
 			Configuration.dupDerivs.increment();
 		}
 	}
@@ -124,7 +124,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 			super(exec);
 			this.rule = rule;
 			this.deltaArgs = deltaArgs;
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.workItems.increment();
 			}
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -114,10 +114,10 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 			if (trackedRelations.contains(sym)) {
 				System.err.println("[TRACKED] " + UserPredicate.make(sym, newArgs, false));
 			}
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.newDerivs.increment();
 			}
-		} else if (Configuration.recordWork) {
+		} else if (Configuration.recordDetailedWork) {
 			Configuration.dupDerivs.increment();
 		}
 	}
@@ -197,7 +197,7 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 		protected RulePrefixEvaluator(IndexedRule rule) {
 			super(exec);
 			this.rule = rule;
-			if (Configuration.recordWork) {
+			if (Configuration.recordDetailedWork) {
 				Configuration.workItems.increment();
 			}
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
@@ -490,6 +490,13 @@ public class SemiNaiveEvaluation implements Evaluation {
 				@Override
 				public void run() {
 					System.err.println("[WORK] " + Configuration.work.unsafeGet());
+				}
+			});
+		}
+		if (Configuration.recordDetailedWork) {
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+				@Override
+				public void run() {
 					System.err.println("[WORK ITEMS] " + Configuration.workItems.unsafeGet());
 					System.err.println("[NEW DERIVS] " + Configuration.newDerivs.unsafeGet());
 					System.err.println("[DUP DERIVS] " + Configuration.dupDerivs.unsafeGet());


### PR DESCRIPTION
Differentiate between `-DrecordWork` and `-DrecordDetailedWork`, to cut down on unnecessary performance costs when you just want basic statistics.