### PR TITLE
Report more stats

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Main.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Main.java
@@ -249,14 +249,32 @@ public final class Main implements Callable<Integer> {
 		}
 	}
 
+	private void printSmtStats(PrintStream out) {
+		List<String> times = new ArrayList<>();
+		List<String> calls = new ArrayList<>();
+		long[] total_time = {0};
+		long[] total_calls = {0};
+		Configuration.smtTime.forEach((stats) -> {
+			times.add(Long.toString(stats.time));
+			total_time[0] += stats.time;
+			calls.add(Long.toString(stats.ncalls));
+			total_calls[0] += stats.ncalls;
+		});
+		
+		out.println();
+		out.println(getBanner("SMT STATS"));
+		out.println("SMT calls: " + total_calls[0]);
+		out.println("SMT time (ms): " + total_time[0]);
+		out.println("SMT wait time (ms): " + Configuration.smtWaitTime.unsafeGet() / 1e6);
+		out.println("SMT cache clears: " + Configuration.smtCacheClears.unsafeGet());
+		out.println("SMT calls per solver: " + String.join(",", calls));
+		out.println("SMT time per solver (ms): " + String.join(",", times));
+	}
+
 	private void dumpResults(EvaluationResult res) {
 		PrintStream out = System.out;
 		if (smtStats) {
-			out.println();
-			out.println(getBanner("SMT STATS"));
-			out.println("SMT calls: " + Configuration.smtCalls.unsafeGet());
-			out.println("SMT time (ms): " + Configuration.smtTime.unsafeGet());
-			out.println("SMT cache clears: " + Configuration.smtCacheClears.unsafeGet());
+			printSmtStats(out);
 		}
 		List<RelationSymbol> allSymbols = res.getSymbols().stream().sorted(Comparator.comparing(Object::toString))
 				.collect(Collectors.toList());

--- a/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGen.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/codegen/CodeGen.java
@@ -68,6 +68,7 @@ public class CodeGen {
 		assert repr.equals("Symbol::smt_var__bool__bool") : repr;
 
 		copy("CMakeLists.txt");
+		copySrc("time.hpp");
 		copySrc("ConcurrentHashMap.hpp");
 		new RelsHpp(ctx).gen(outDir);
 		new FuncsHpp(ctx).gen(outDir);

--- a/src/main/java/edu/harvard/seas/pl/formulog/functions/BuiltInFunctionDefFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/functions/BuiltInFunctionDefFactory.java
@@ -21,6 +21,7 @@ package edu.harvard.seas.pl.formulog.functions;
  */
 
 import edu.harvard.seas.pl.formulog.Configuration;
+import edu.harvard.seas.pl.formulog.Main;
 import edu.harvard.seas.pl.formulog.ast.*;
 import edu.harvard.seas.pl.formulog.ast.Constructors.SolverVariable;
 import edu.harvard.seas.pl.formulog.eval.EvaluationException;
@@ -1741,7 +1742,7 @@ public final class BuiltInFunctionDefFactory {
 			fut = completableFut;
 		}
 		long waitStart = 0;
-		if (Configuration.timeSmt) {
+		if (Configuration.timeSmt || Main.smtStats) {
 			waitStart = System.nanoTime();
 		}
 		try {
@@ -1749,7 +1750,7 @@ public final class BuiltInFunctionDefFactory {
 		} catch (InterruptedException | ExecutionException e) {
 			throw new EvaluationException(e);
 		} finally {
-			if (Configuration.timeSmt) {
+			if (Configuration.timeSmt || Main.smtStats) {
 				Configuration.recordSmtWaitTime(System.nanoTime() - waitStart);
 			}
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/smt/SmtLibShim.java
@@ -246,8 +246,7 @@ public class SmtLibShim {
 			}
 			result = in.readLine();
 			if (Main.smtStats) {
-				Configuration.smtTime.add(clock.getTime());
-				Configuration.smtCalls.increment();
+				Configuration.smtTime.get().add(clock.getTime());
 			}
 			if (result == null) {
 				throw new EvaluationException("Problem with evaluating solver! Unexpected end of stream");

--- a/src/main/java/edu/harvard/seas/pl/formulog/util/EnumerableThreadLocal.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/util/EnumerableThreadLocal.java
@@ -1,0 +1,48 @@
+package edu.harvard.seas.pl.formulog.util;
+
+/*-
+ * #%L
+ * Formulog
+ * %%
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class EnumerableThreadLocal<T> {
+
+	private final Set<T> items = Util.concurrentSet();
+	private final ThreadLocal<T> tl;
+
+	public EnumerableThreadLocal(Supplier<T> f) {
+		tl = ThreadLocal.withInitial(() -> {
+			var item = f.get();
+			items.add(item);
+			return item;
+		});
+	}
+	
+	public T get() {
+		return tl.get();
+	}
+
+	public void forEach(Consumer<T> f) {
+		items.forEach(f);
+	}
+
+}

--- a/src/main/resources/codegen/CMakeLists.txt
+++ b/src/main/resources/codegen/CMakeLists.txt
@@ -21,6 +21,7 @@ add_custom_command(OUTPUT formulog.cpp
         DEPENDS src/formulog.dl)
 
 target_sources(flg PRIVATE
+        src/time.hpp
         src/ConcurrentHashMap.hpp
         src/funcs.hpp
         src/functors.cpp

--- a/src/main/resources/codegen/CMakeLists.txt
+++ b/src/main/resources/codegen/CMakeLists.txt
@@ -16,6 +16,12 @@ if (FLG_EAGER_EVAL)
     set(SOUFFLE_FLAGS ${SOUFFLE_FLAGS} --eager-eval)
 endif ()
 
+option(FLG_RECORD_WORK "Report amount of work performed during evaluation (requires custom Soufflé)" OFF)
+if (FLG_RECORD_WORK)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFLG_RECORD_WORK")
+    set(SOUFFLE_FLAGS ${SOUFFLE_FLAGS} --record-work)
+endif ()
+
 add_custom_command(OUTPUT formulog.cpp
         COMMAND souffle ${CMAKE_CURRENT_SOURCE_DIR}/src/formulog.dl ${SOUFFLE_FLAGS} -g formulog.cpp
         DEPENDS src/formulog.dl)

--- a/src/main/resources/codegen/src/globals.h
+++ b/src/main/resources/codegen/src/globals.h
@@ -3,6 +3,7 @@
 #include <souffle/SouffleInterface.h>
 #include <tbb/combinable.h>
 #include "smt_solver.h"
+#include "time.hpp"
 
 namespace flg::globals {
 
@@ -18,7 +19,20 @@ inline bool smt_stats{false};
 
 inline tbb::combinable<unsigned long long> smt_calls;
 
-inline tbb::combinable<unsigned long long> smt_time;
+struct smt_stats_t {
+    time_t time;
+    unsigned long long ncalls;
+
+    friend smt_stats_t &operator+=(smt_stats_t &stats, time_t time) {
+        stats.time += time;
+        stats.ncalls++;
+        return stats;
+    }
+};
+
+inline tbb::combinable<smt_stats_t> smt_time;
+
+inline tbb::combinable<time_t> smt_wait_time;
 
 inline tbb::combinable<unsigned> smt_cache_clears;
 

--- a/src/main/resources/codegen/src/main.cpp
+++ b/src/main/resources/codegen/src/main.cpp
@@ -177,6 +177,11 @@ void printSmtStats() {
     std::cout << "SMT calls: " << globals::sum(globals::smt_calls) << "\n";
     std::cout << "SMT time (ms): " << globals::sum(globals::smt_time) << std::endl;
     std::cout << "SMT cache clears: " << globals::sum(globals::smt_cache_clears) << std::endl;
+    std::cout << "SMT calls per solver: ";
+    globals::smt_calls.combine_each([&](auto ncalls) {
+        std::cout << ncalls << ",";
+    });
+    std::cout << std::endl;
 }
 
 int main(int argc, char **argv) {

--- a/src/main/resources/codegen/src/main.cpp
+++ b/src/main/resources/codegen/src/main.cpp
@@ -291,5 +291,8 @@ int main(int argc, char **argv) {
     if (dump_idb) {
         printResults();
     }
+#ifdef FLG_RECORD_WORK
+    cout << "[WORK] " << globals::sum(souffle::work) << std::endl;
+#endif
     std::_Exit(EXIT_SUCCESS);
 }

--- a/src/main/resources/codegen/src/main.cpp
+++ b/src/main/resources/codegen/src/main.cpp
@@ -171,17 +171,43 @@ std::ostream &operator<<(std::ostream &os, const std::vector<std::string> &vec) 
 }
 }
 
+template <typename T>
+std::string join(const std::vector<T> &v) {
+    if (v.empty()) {
+        return "";
+    }
+    std::stringstream ss;
+    auto it = v.begin();
+    while (true) {
+        ss << *it++;
+        if (it == v.end()) {
+            break;
+        }
+        ss << ",";
+    }
+    return ss.str();
+}
+
 void printSmtStats() {
+    std::vector<double> times;
+    std::vector<unsigned long long> calls;
+    flg::time_t total_time;
+    double total_calls;
+    globals::smt_time.combine_each([&](auto stats) {
+        times.push_back(stats.time.count());
+        total_time += stats.time;
+        calls.push_back(stats.ncalls);
+        total_calls += stats.ncalls;
+    });
+
     std::cout << "\n";
     printBanner("SMT STATS");
-    std::cout << "SMT calls: " << globals::sum(globals::smt_calls) << "\n";
-    std::cout << "SMT time (ms): " << globals::sum(globals::smt_time) << std::endl;
+    std::cout << "SMT calls: " << total_calls << "\n";
+    std::cout << "SMT time (ms): " << total_time.count() << std::endl;
+    std::cout << "SMT wait time (ms): " << globals::sum(globals::smt_wait_time).count() << std::endl;
     std::cout << "SMT cache clears: " << globals::sum(globals::smt_cache_clears) << std::endl;
-    std::cout << "SMT calls per solver: ";
-    globals::smt_calls.combine_each([&](auto ncalls) {
-        std::cout << ncalls << ",";
-    });
-    std::cout << std::endl;
+    std::cout << "SMT calls per solver: " << join(calls) << std::endl;
+    std::cout << "SMT time per solver (ms): " << join(times) << std::endl;
 }
 
 int main(int argc, char **argv) {

--- a/src/main/resources/codegen/src/smt_shim.cpp
+++ b/src/main/resources/codegen/src/smt_shim.cpp
@@ -199,16 +199,12 @@ SmtStatus SmtLibShim::check_sat_assuming(const std::vector<term_ptr> &onVars, co
     }
     m_in.flush();
 
-    std::chrono::time_point<std::chrono::steady_clock> start;
-    if (globals::smt_stats) {
-        start = std::chrono::steady_clock::now();
-    }
     string line;
-    getline(m_out, line);
+    auto op = [&] { getline(m_out, line); };
     if (globals::smt_stats) {
-        auto end = std::chrono::steady_clock::now();
-        globals::smt_time.local() += std::chrono::duration_cast<chrono::milliseconds>(end - start).count();
-        globals::smt_calls.local()++;
+        globals::smt_time.local() += time(op);
+    } else {
+        op();
     }
     SmtStatus status;
     if (line == "sat") {

--- a/src/main/resources/codegen/src/smt_solver.cpp
+++ b/src/main/resources/codegen/src/smt_solver.cpp
@@ -86,11 +86,21 @@ SmtResult MemoizingSmtSolver::check(const std::vector<term_ptr> &assertions, boo
             p.set_value(res);
         } else {
             fut = it2.first->second;
-            res = fut.get();
+            auto op = [&] { res = fut.get(); };
+            if (globals::smt_stats) {
+                globals::smt_wait_time.local() += time(op);
+            } else {
+                op();
+            }
         }
     } else {
         fut = it->second;
-        res = fut.get();
+        auto op = [&] { res = fut.get(); };
+        if (globals::smt_stats) {
+            globals::smt_wait_time.local() += time(op);
+        } else {
+            op();
+        }
     }
     return res;
 }

--- a/src/main/resources/codegen/src/time.hpp
+++ b/src/main/resources/codegen/src/time.hpp
@@ -1,0 +1,21 @@
+//
+// Created by Aaron Bembenek on 5/20/23.
+//
+
+#pragma once
+
+#include <chrono>
+
+namespace flg {
+
+typedef std::chrono::duration<double, std::milli> time_t;
+
+template<typename F>
+time_t time(const F &f) {
+    auto start = std::chrono::steady_clock::now();
+    f();
+    auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<time_t>(end - start);
+}
+
+}


### PR DESCRIPTION
- Interpreter and codegen: report number of SMT calls and evaluation time per solver, as well as total SMT wait times
- Codegen: report work