### PR TITLE
Various performance-related improvements

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -22,6 +22,7 @@ package edu.harvard.seas.pl.formulog;
 
 import edu.harvard.seas.pl.formulog.ast.Rule;
 import edu.harvard.seas.pl.formulog.db.IndexedFactDb;
+import edu.harvard.seas.pl.formulog.eval.IndexedRule;
 import edu.harvard.seas.pl.formulog.smt.*;
 import edu.harvard.seas.pl.formulog.symbols.FunctionSymbol;
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
@@ -180,6 +181,7 @@ public final class Configuration {
 	public static final SharedLong workItems = new SharedLong();
 	public static final SharedLong newDerivs = new SharedLong();
 	public static final SharedLong dupDerivs = new SharedLong();
+	public static final Map<IndexedRule, SharedLong> workPerRule = new ConcurrentHashMap<>();
 
 	public static class SmtStats {
 		public long time;

--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -171,7 +171,7 @@ public final class Configuration {
 	public static final boolean inlineInRules = propIsSet("inlineInRules", true);
 
 	public static final boolean eagerSemiNaive = propIsSet("eagerSemiNaive");
-	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt", true);
+	public static final boolean codegenSplitOnSmt = propIsSet("codegenSplitOnSmt");
 
 	public static final boolean useHashDbFilter = propIsSet("useHashDbFilter");
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -135,8 +135,8 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 			}
 		}
 
-		protected RuleSuffixEvaluator(IndexedRule rule, int pos, OverwriteSubstitution s,
-				Iterator<Iterable<Term[]>> it, Term[] scratch) {
+		protected RuleSuffixEvaluator(IndexedRule rule, int pos, OverwriteSubstitution s, Iterator<Iterable<Term[]>> it,
+				Term[] scratch) {
 			super(exec);
 			this.rule = rule;
 			this.head = rule.getHead();
@@ -188,7 +188,7 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 			var checkPos = checkPosition.get(rule);
 			while (pos > startPos) {
 				try {
-					if (checkPos == pos && !checkFact(head.getSymbol(), head.getArgs(), s, scratch)) {
+					if (movingRight && checkPos == pos && !checkFact(head.getSymbol(), head.getArgs(), s, scratch)) {
 						pos--;
 						movingRight = false;
 					}
@@ -237,8 +237,8 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 								if (tups.hasNext()) {
 									stack[pos] = tups.next().iterator();
 									if (tups.hasNext()) {
-										exec.recursivelyAddTask(
-												new RuleSuffixEvaluator(rule, head, body, pos, s.copy(), tups, scratch));
+										exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, head, body, pos, s.copy(),
+												tups, scratch));
 									}
 									// No need to do anything else: we'll hit the right case on the next iteration.
 								} else {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -35,6 +35,7 @@ import edu.harvard.seas.pl.formulog.unification.OverwriteSubstitution;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
 import edu.harvard.seas.pl.formulog.util.AbstractFJPTask;
 import edu.harvard.seas.pl.formulog.util.CountingFJP;
+import edu.harvard.seas.pl.formulog.util.SharedLong;
 import edu.harvard.seas.pl.formulog.util.Util;
 import edu.harvard.seas.pl.formulog.validating.ast.Assignment;
 import edu.harvard.seas.pl.formulog.validating.ast.Check;
@@ -271,6 +272,9 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 		private void updateBinding(SimplePredicate p, Term[] ans) {
 			if (Configuration.recordWork) {
 				Configuration.work.increment();
+			}
+			if (Configuration.recordDetailedWork) {
+				Util.lookupOrCreate(Configuration.workPerRule, rule, SharedLong::new).increment();
 			}
 			Term[] args = p.getArgs();
 			BindingType[] pat = p.getBindingPattern();

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -162,7 +162,8 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 			}
 			Iterable<Term[]> tups = it.next();
 			if (it.hasNext()) {
-				exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, head, body, startPos, s.copy(), it, scratch));
+				exec.recursivelyAddTask(
+						new RuleSuffixEvaluator(rule, head, body, startPos, s.copy(), it, scratch.clone()));
 			}
 			try {
 				for (Term[] tup : tups) {
@@ -238,7 +239,7 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 									stack[pos] = tups.next().iterator();
 									if (tups.hasNext()) {
 										exec.recursivelyAddTask(new RuleSuffixEvaluator(rule, head, body, pos, s.copy(),
-												tups, scratch));
+												tups, scratch.clone()));
 									}
 									// No need to do anything else: we'll hit the right case on the next iteration.
 								} else {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -49,7 +49,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 	private final Set<RelationSymbol> trackedRelations;
 
 	static final int taskSize = Configuration.taskSize;
-	static final int smtTaskSize = 1;
+	static final int smtTaskSize = Configuration.smtTaskSize;
 
 	public EagerStratumEvaluator(SortedIndexedFactDb db, Iterable<IndexedRule> rules, CountingFJP exec,
 			Set<RelationSymbol> trackedRelations) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -35,6 +35,7 @@ import edu.harvard.seas.pl.formulog.unification.OverwriteSubstitution;
 import edu.harvard.seas.pl.formulog.unification.Substitution;
 import edu.harvard.seas.pl.formulog.util.AbstractFJPTask;
 import edu.harvard.seas.pl.formulog.util.CountingFJP;
+import edu.harvard.seas.pl.formulog.util.SharedLong;
 import edu.harvard.seas.pl.formulog.util.Util;
 import edu.harvard.seas.pl.formulog.validating.ast.Assignment;
 import edu.harvard.seas.pl.formulog.validating.ast.Check;
@@ -154,6 +155,9 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 			}
 			if (Configuration.recordWork) {
 				Configuration.work.increment();
+			}
+			if (Configuration.recordDetailedWork) {
+				Util.lookupOrCreate(Configuration.workPerRule, rule, SharedLong::new).increment();
 			}
 			return true;
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -189,8 +189,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					return;
 				}
 				if (pos == len) {
-					reportFact(head.getSymbol(), scratch);
-					return;
+					break;
 				}
 				l = rule.getBody(pos);
 				try {
@@ -229,6 +228,10 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					throw new EvaluationException(
 							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
 				}
+			}
+			if (pos == len) {
+				reportFact(head.getSymbol(), scratch);
+				return;
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -189,7 +189,8 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					return;
 				}
 				if (pos == len) {
-					break;
+					reportFact(head.getSymbol(), scratch);
+					return;
 				}
 				l = rule.getBody(pos);
 				try {
@@ -228,10 +229,6 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					throw new EvaluationException(
 							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
 				}
-			}
-			if (pos == len) {
-				reportFact(head.getSymbol(), scratch);
-				return;
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -232,7 +232,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {
-				new RuleSuffixEvaluator(rule, pos, s, tups, scratch).doTask();
+				new RuleSuffixEvaluator(rule, pos, s, tups, scratch.clone()).doTask();
 			}
 		}
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/EagerStratumEvaluator.java
@@ -184,6 +184,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 			var scratch = new Term[head.getSymbol().getArity()];
 			var checkPos = checkPosition.get(rule);
 			loop: for (; pos <= len; ++pos) {
+				SimpleLiteral l = head;
 				if (checkPos == pos && !checkFact(head.getSymbol(), head.getArgs(), s, scratch)) {
 					return;
 				}
@@ -191,7 +192,7 @@ public final class EagerStratumEvaluator extends AbstractStratumEvaluator {
 					reportFact(head.getSymbol(), scratch);
 					return;
 				}
-				SimpleLiteral l = rule.getBody(pos);
+				l = rule.getBody(pos);
 				try {
 					switch (l.getTag()) {
 					case ASSIGNMENT:

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -277,7 +277,7 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {
-				new RuleSuffixEvaluator(rule, pos, s, tups, scratch).doTask();
+				new RuleSuffixEvaluator(rule, pos, s, tups, scratch.clone()).doTask();
 			}
 		}
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -239,7 +239,8 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 					return;
 				}
 				if (pos == len) {
-					break;
+					reportFact(head.getSymbol(), scratch);
+					return;
 				}
 				l = rule.getBody(pos);
 				try {
@@ -273,10 +274,6 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 					throw new EvaluationException(
 							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
 				}
-			}
-			if (pos == len) {
-				reportFact(head.getSymbol(), scratch);
-				return;
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -239,8 +239,7 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 					return;
 				}
 				if (pos == len) {
-					reportFact(head.getSymbol(), scratch);
-					return;
+					break;
 				}
 				l = rule.getBody(pos);
 				try {
@@ -274,6 +273,10 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 					throw new EvaluationException(
 							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
 				}
+			}
+			if (pos == len) {
+				reportFact(head.getSymbol(), scratch);
+				return;
 			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -234,6 +234,7 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 			Term[] scratch = new Term[head.getSymbol().getArity()];
 			int checkPos = checkPosition.get(rule);
 			loop: for (; pos <= len; ++pos) {
+				SimpleLiteral l = head;
 				if (checkPos == pos && !checkFact(head.getSymbol(), head.getArgs(), s, scratch)) {
 					return;
 				}
@@ -241,7 +242,7 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 					reportFact(head.getSymbol(), scratch);
 					return;
 				}
-				SimpleLiteral l = rule.getBody(pos);
+				l = rule.getBody(pos);
 				try {
 					switch (l.getTag()) {
 					case ASSIGNMENT:

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/RoundBasedStratumEvaluator.java
@@ -104,15 +104,12 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 	}
 
 	@Override
-	protected final void reportFact(RelationSymbol sym, Term[] args, Substitution s) throws EvaluationException {
-		Term[] newArgs = new Term[args.length];
-		for (int i = 0; i < args.length; ++i) {
-			newArgs[i] = args[i].normalize(s);
-		}
-		if (!db.hasFact(sym, newArgs) && nextDeltaDb.add(sym, newArgs)) {
+	protected final void reportFact(RelationSymbol sym, Term[] args) {
+		var copy = args.clone();
+		if (nextDeltaDb.add(sym, copy)) {
 			changed = true;
 			if (trackedRelations.contains(sym)) {
-				System.err.println("[TRACKED] " + UserPredicate.make(sym, newArgs, false));
+				System.err.println("[TRACKED] " + UserPredicate.make(sym, copy, false));
 			}
 			if (Configuration.recordDetailedWork) {
 				Configuration.newDerivs.increment();
@@ -120,6 +117,15 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 		} else if (Configuration.recordDetailedWork) {
 			Configuration.dupDerivs.increment();
 		}
+	}
+
+	@Override
+	protected final boolean checkFact(RelationSymbol sym, Term[] args, Substitution s, Term[] scratch)
+			throws EvaluationException {
+		for (int i = 0; i < args.length; ++i) {
+			scratch[i] = args[i].normalize(s);
+		}
+		return !db.hasFact(sym, scratch) && !nextDeltaDb.hasFact(sym, scratch);
 	}
 
 	private void updateDbs() {
@@ -224,7 +230,17 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 			int len = rule.getBodySize();
 			int pos = 0;
 			OverwriteSubstitution s = new OverwriteSubstitution();
-			loop: for (; pos < len; ++pos) {
+			SimplePredicate head = rule.getHead();
+			Term[] scratch = new Term[head.getSymbol().getArity()];
+			int checkPos = checkPosition.get(rule);
+			loop: for (; pos <= len; ++pos) {
+				if (checkPos == pos && !checkFact(head.getSymbol(), head.getArgs(), s, scratch)) {
+					return;
+				}
+				if (pos == len) {
+					reportFact(head.getSymbol(), scratch);
+					return;
+				}
 				SimpleLiteral l = rule.getBody(pos);
 				try {
 					switch (l.getTag()) {
@@ -258,19 +274,9 @@ public final class RoundBasedStratumEvaluator extends AbstractStratumEvaluator {
 							"Exception raised while evaluating the literal: " + l + "\n\n" + e.getMessage());
 				}
 			}
-			if (pos == len) {
-				try {
-					SimplePredicate head = rule.getHead();
-					reportFact(head.getSymbol(), head.getArgs(), s);
-					return;
-				} catch (EvaluationException e) {
-					throw new EvaluationException("Exception raised while evaluationg the literal: " + rule.getHead()
-							+ e.getLocalizedMessage());
-				}
-			}
 			Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
 			if (tups.hasNext()) {
-				new RuleSuffixEvaluator(rule, pos, s, tups).doTask();
+				new RuleSuffixEvaluator(rule, pos, s, tups, scratch).doTask();
 			}
 		}
 	}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
@@ -121,7 +121,7 @@ public class SemiNaiveEvaluation implements Evaluation {
 				for (BasicRule br : magicProg.getRules(sym)) {
 					for (SemiNaiveRule snr : SemiNaiveRule.make(br, stratumSymbols)) {
 						BiFunction<ComplexLiteral, Set<Var>, Integer> score = chooseScoringFunction(eagerEval);
-						ValidRule vr = ValidRule.make(tweakRule(snr, true), score);
+						ValidRule vr = ValidRule.make(tweakDeltaAtom(snr), score);
 						checkRule(vr, eagerEval);
 						predFuncs.preprocess(vr);
 						SimpleRule sr = SimpleRule.make(vr, magicProg.getFunctionCallFactory());
@@ -190,11 +190,7 @@ public class SemiNaiveEvaluation implements Evaluation {
 				getTrackedRelations(magicProg.getSymbolManager()), eagerEval);
 	}
 
-	private static Rule<UserPredicate, ComplexLiteral> tweakRule(Rule<UserPredicate, ComplexLiteral> r,
-			boolean eagerEval) {
-		if (!eagerEval) {
-			return r;
-		}
+	private static Rule<UserPredicate, ComplexLiteral> tweakDeltaAtom(Rule<UserPredicate, ComplexLiteral> r) {
 		List<ComplexLiteral> newBody = new ArrayList<>();
 		for (ComplexLiteral l : r) {
 			l.accept(new ComplexLiteralVisitor<Void, Void>() {
@@ -540,7 +536,7 @@ public class SemiNaiveEvaluation implements Evaluation {
 							.sorted((p1, p2) -> Long.compare(p2.snd(), p1.snd())).forEach(p -> {
 								System.err.println("[PER RULE WORK] " + p.snd() + " " + p.fst());
 							});
-					
+
 				}
 			});
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
@@ -1,5 +1,15 @@
 package edu.harvard.seas.pl.formulog.eval;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
 /*-
  * #%L
  * Formulog
@@ -22,26 +32,51 @@ package edu.harvard.seas.pl.formulog.eval;
 
 import edu.harvard.seas.pl.formulog.Configuration;
 import edu.harvard.seas.pl.formulog.Main;
-import edu.harvard.seas.pl.formulog.ast.*;
+import edu.harvard.seas.pl.formulog.ast.BasicProgram;
+import edu.harvard.seas.pl.formulog.ast.BasicRule;
+import edu.harvard.seas.pl.formulog.ast.ComplexLiteral;
 import edu.harvard.seas.pl.formulog.ast.ComplexLiterals.ComplexLiteralVisitor;
+import edu.harvard.seas.pl.formulog.ast.Rule;
+import edu.harvard.seas.pl.formulog.ast.Term;
+import edu.harvard.seas.pl.formulog.ast.Terms;
+import edu.harvard.seas.pl.formulog.ast.UnificationPredicate;
+import edu.harvard.seas.pl.formulog.ast.UserPredicate;
+import edu.harvard.seas.pl.formulog.ast.Var;
 import edu.harvard.seas.pl.formulog.db.IndexedFactDbBuilder;
 import edu.harvard.seas.pl.formulog.db.SortedIndexedFactDb;
 import edu.harvard.seas.pl.formulog.db.SortedIndexedFactDb.SortedIndexedFactDbBuilder;
 import edu.harvard.seas.pl.formulog.eval.SemiNaiveRule.DeltaSymbol;
 import edu.harvard.seas.pl.formulog.functions.FunctionDefManager;
 import edu.harvard.seas.pl.formulog.magic.MagicSetTransformer;
-import edu.harvard.seas.pl.formulog.smt.*;
+import edu.harvard.seas.pl.formulog.smt.BestMatchSmtManager;
+import edu.harvard.seas.pl.formulog.smt.CallAndResetSolver;
+import edu.harvard.seas.pl.formulog.smt.CheckSatAssumingSolver;
+import edu.harvard.seas.pl.formulog.smt.DoubleCheckingSolver;
+import edu.harvard.seas.pl.formulog.smt.NotThreadSafeQueueSmtManager;
+import edu.harvard.seas.pl.formulog.smt.PerThreadSmtManager;
+import edu.harvard.seas.pl.formulog.smt.PushPopNaiveSolver;
+import edu.harvard.seas.pl.formulog.smt.PushPopSolver;
+import edu.harvard.seas.pl.formulog.smt.QueueSmtManager;
+import edu.harvard.seas.pl.formulog.smt.SingleShotSolver;
+import edu.harvard.seas.pl.formulog.smt.SmtLibSolver;
+import edu.harvard.seas.pl.formulog.smt.SmtStrategy;
 import edu.harvard.seas.pl.formulog.symbols.RelationSymbol;
 import edu.harvard.seas.pl.formulog.symbols.Symbol;
 import edu.harvard.seas.pl.formulog.symbols.SymbolManager;
 import edu.harvard.seas.pl.formulog.types.WellTypedProgram;
 import edu.harvard.seas.pl.formulog.unification.SimpleSubstitution;
-import edu.harvard.seas.pl.formulog.util.*;
-import edu.harvard.seas.pl.formulog.validating.*;
+import edu.harvard.seas.pl.formulog.util.AbstractFJPTask;
+import edu.harvard.seas.pl.formulog.util.CountingFJP;
+import edu.harvard.seas.pl.formulog.util.CountingFJPImpl;
+import edu.harvard.seas.pl.formulog.util.MockCountingFJP;
+import edu.harvard.seas.pl.formulog.util.Pair;
+import edu.harvard.seas.pl.formulog.util.Util;
+import edu.harvard.seas.pl.formulog.validating.FunctionDefValidation;
+import edu.harvard.seas.pl.formulog.validating.InvalidProgramException;
+import edu.harvard.seas.pl.formulog.validating.Stratifier;
+import edu.harvard.seas.pl.formulog.validating.Stratum;
+import edu.harvard.seas.pl.formulog.validating.ValidRule;
 import edu.harvard.seas.pl.formulog.validating.ast.SimpleRule;
-
-import java.util.*;
-import java.util.function.BiFunction;
 
 public class SemiNaiveEvaluation implements Evaluation {
 
@@ -500,6 +535,12 @@ public class SemiNaiveEvaluation implements Evaluation {
 					System.err.println("[WORK ITEMS] " + Configuration.workItems.unsafeGet());
 					System.err.println("[NEW DERIVS] " + Configuration.newDerivs.unsafeGet());
 					System.err.println("[DUP DERIVS] " + Configuration.dupDerivs.unsafeGet());
+					Configuration.workPerRule.entrySet().stream()
+							.map(e -> new Pair<>(e.getKey(), e.getValue().unsafeGet()))
+							.sorted((p1, p2) -> Long.compare(p2.snd(), p1.snd())).forEach(p -> {
+								System.err.println("[PER RULE WORK] " + p.snd() + " " + p.fst());
+							});
+					
 				}
 			});
 		}

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/SemiNaiveEvaluation.java
@@ -121,7 +121,7 @@ public class SemiNaiveEvaluation implements Evaluation {
 				for (BasicRule br : magicProg.getRules(sym)) {
 					for (SemiNaiveRule snr : SemiNaiveRule.make(br, stratumSymbols)) {
 						BiFunction<ComplexLiteral, Set<Var>, Integer> score = chooseScoringFunction(eagerEval);
-						ValidRule vr = ValidRule.make(tweakRule(snr, eagerEval), score);
+						ValidRule vr = ValidRule.make(tweakRule(snr, true), score);
 						checkRule(vr, eagerEval);
 						predFuncs.preprocess(vr);
 						SimpleRule sr = SimpleRule.make(vr, magicProg.getFunctionCallFactory());

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Assignment.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Assignment.java
@@ -4,7 +4,7 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #%L
  * Formulog
  * %%
- * Copyright (C) 2018 - 2020 President and Fellows of Harvard College
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-import java.util.HashSet;
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.Term;
@@ -62,11 +61,9 @@ public class Assignment implements SimpleLiteral {
 	}
 
 	@Override
-	public Set<Var> varSet() {
-		Set<Var> vars = new HashSet<>();
+	public void varSet(Set<Var> vars) {
 		vars.add(var);
 		rhs.varSet(vars);
-		return vars;
 	}
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Check.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Check.java
@@ -4,7 +4,7 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #%L
  * Formulog
  * %%
- * Copyright (C) 2018 - 2020 President and Fellows of Harvard College
+ * Copyright (C) 2018 - 2023 President and Fellows of Harvard College
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  * #L%
  */
 
-import java.util.HashSet;
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.Term;
@@ -82,11 +81,9 @@ public class Check implements SimpleLiteral {
 	}
 
 	@Override
-	public Set<Var> varSet() {
-		Set<Var> vars = new HashSet<>();
+	public void varSet(Set<Var> vars) {
 		lhs.varSet(vars);
 		rhs.varSet(vars);
-		return vars;
 	}
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Destructor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/Destructor.java
@@ -110,11 +110,9 @@ public class Destructor implements SimpleLiteral {
 	}
 
 	@Override
-	public Set<Var> varSet() {
-		Set<Var> vars = new HashSet<>();
+	public void varSet(Set<Var> vars) {
 		x.varSet(vars);
 		vars.addAll(Arrays.asList(bindings));
-		return vars;
 	}
 
 	@Override

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteral.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimpleLiteral.java
@@ -1,5 +1,7 @@
 package edu.harvard.seas.pl.formulog.validating.ast;
 
+import java.util.HashSet;
+
 /*-
  * #%L
  * Formulog
@@ -31,7 +33,13 @@ public interface SimpleLiteral extends Literal {
 
 	<I, O, E extends Throwable> O accept(SimpleLiteralExnVisitor<I, O, E> visitor, I input) throws E;
 
-	Set<Var> varSet();
+	default Set<Var> varSet() {
+		Set<Var> vars = new HashSet<>();
+		varSet(vars);
+		return vars;
+	}
+	
+	void varSet(Set<Var> vars);
 
 	SimpleLiteralTag getTag();
 

--- a/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimplePredicate.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/validating/ast/SimplePredicate.java
@@ -21,8 +21,6 @@ package edu.harvard.seas.pl.formulog.validating.ast;
  */
 
 import java.util.Arrays;
-import java.util.HashSet;
-
 import java.util.Set;
 
 import edu.harvard.seas.pl.formulog.ast.BindingType;
@@ -153,12 +151,10 @@ public class SimplePredicate implements SimpleLiteral {
 	}
 
 	@Override
-	public Set<Var> varSet() {
-		Set<Var> vars = new HashSet<>();
+	public void varSet(Set<Var> vars) {
 		for (Term arg : args) {
 			arg.varSet(vars);
 		}
-		return vars;
 	}
 
 	@Override


### PR DESCRIPTION
- Short-circuit rule evaluation: eagerly check if the head of a rule has been derived already and, if so, move on to the next tuple combination.
- Fix reordering of rules, so that delta atoms can always be placed first (if desired).
- Change default settings:
    - `codegenSplitOnSmt` is now false by default
    - Eager evaluation uses the user-provided `smtTaskSize` parameter (used to always be 1)
- Add ability to collect statistics on the amount of work done per rule. 