### PR TITLE
Add property for parallelizing inner loops.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/Configuration.java
@@ -139,6 +139,7 @@ public final class Configuration {
 	private static final Dataset otherSolverEvalStats = new Dataset();
 
 	public static final boolean oneRuleAtATime = propIsSet("oneRuleAtATime");
+	public static final boolean parallelizeInnerLoops = propIsSet("parallelizeInnerLoops", true);
 
 	public static final boolean useDemandTransformation = propIsSet("useDemandTransformation", true);
 	public static final boolean restoreStratification = propIsSet("restoreStratification", true);

--- a/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/eval/AbstractStratumEvaluator.java
@@ -105,7 +105,7 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 	abstract protected boolean checkFact(RelationSymbol sym, Term[] args, Substitution s, Term[] scratch)
 			throws EvaluationException;
 
-	abstract protected Iterable<Iterable<Term[]>> lookup(IndexedRule r, int pos, OverwriteSubstitution s)
+	abstract protected Iterable<Iterable<Term[]>> lookup(IndexedRule r, int pos, OverwriteSubstitution s, boolean split)
 			throws EvaluationException;
 
 	protected static final boolean recordRuleDiagnostics = Configuration.recordRuleDiagnostics;
@@ -227,7 +227,8 @@ public abstract class AbstractStratumEvaluator implements StratumEvaluator {
 							}
 							break;
 						case PREDICATE:
-							Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s).iterator();
+							Iterator<Iterable<Term[]>> tups = lookup(rule, pos, s, Configuration.parallelizeInnerLoops)
+									.iterator();
 							if (((SimplePredicate) l).isNegated()) {
 								if (!tups.hasNext()) {
 									pos++;


### PR DESCRIPTION
If property `-DparallelizeInnerLoops` is true (which it is by default), parallelize the scan of every relation encountered in a rule body (not just the first one).