### PR TITLE
Better error reporting for type arity mismatch.

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/formulog/parsing/TypeExtractor.java
+++ b/src/main/java/edu/harvard/seas/pl/formulog/parsing/TypeExtractor.java
@@ -143,6 +143,17 @@ class TypeExtractor {
                 typeArgs.clear();
                 typeArgs.addAll(expanded);
               }
+              if (sym.getArity() != typeArgs.size()) {
+                var msg =
+                    "Type "
+                        + sym
+                        + " expects "
+                        + sym.getArity()
+                        + " parameter(s), but "
+                        + typeArgs.size()
+                        + " provided";
+                throw new UncheckedParseException(ctx.start.getLine(), msg);
+              }
               return pc.typeManager().lookup((TypeSymbol) sym, typeArgs);
           }
         }


### PR DESCRIPTION
Fixes #85 

We now give error messages like this:

```
Parsing...
Error while parsing line 3:
Type foo expects 0 parameter(s), but 1 provided
```