### PR TITLE
Update CMake command in docs

### DIFF
--- a/docs/eval_modes/compile.md
+++ b/docs/eval_modes/compile.md
@@ -16,7 +16,7 @@ For example, to compile and execute the `greeting.flg` program from above, you c
 ```
 java -jar formulog.jar -c examples/greeting.flg && \
   cd codegen && \
-  cmake -B build -S . && \
+  cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && \
   cmake --build build -j && \
   ./build/flg --dump-idb
 ```

--- a/docs/eval_modes/eager.md
+++ b/docs/eval_modes/eager.md
@@ -18,7 +18,7 @@ For example, to build a version of the greeting program that uses eager evaluati
 ```
 java -jar formulog.jar -c examples/greeting.flg && \
   cd codegen && \
-  cmake -B build -S . -DFLG_EAGER_EVAL=On && \
+  cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DFLG_EAGER_EVAL=On && \
   cmake --build build -j && \
   ./build/flg --dump-idb
 ```


### PR DESCRIPTION
Include `-DCMAKE_BUILD_TYPE=Release` in CMake command in documentation to encourage folks to use optimizations when compiling Formulog programs.